### PR TITLE
Conditionalize code to enable P4OVS_CHANGES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,10 @@ message(NOTICE "Building ${TARGETFLAG}")
 ###########################
 
 add_compile_options(-D${TARGETFLAG})
-add_compile_options(-DP4OVS_CHANGES)
+
+if(IPDK_TARGET)
+    add_compile_options(-DP4OVS_CHANGES)
+endif()
 
 if(DEPEND_INSTALL_PREFIX)
   include_directories(${DEPEND_INSTALL_PREFIX}/include)


### PR DESCRIPTION
- Only enable the P4OVS_CHANGES conditional when IPDK_TARGET is in effect.

Signed-off-by: Derek G Foster <derek.foster@intel.com>