### PR TITLE
Refine CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,6 @@ project(networking-recipe VERSION 0.1 LANGUAGES C CXX)
 
 include(CMakePrintHelpers)
 
-set(LT_CURRENT "0" CACHE STRING "Current version number for linker symbols")
-
 #############################
 # Symbolic path definitions #
 #############################
@@ -67,14 +65,30 @@ if(IPDK_TARGET)
 endif()
 
 if(DEPEND_INSTALL_PREFIX)
-  include_directories(${DEPEND_INSTALL_PREFIX}/include)
-  link_directories(${DEPEND_INSTALL_PREFIX}/lib)
+    include_directories(${DEPEND_INSTALL_PREFIX}/include)
+    link_directories(${DEPEND_INSTALL_PREFIX}/lib)
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+#####################
+# External packages #
+#####################
+
+if(DEPEND_INSTALL_PREFIX)
+    list(APPEND CMAKE_PREFIX_PATH ${DEPEND_INSTALL_PREFIX})
+endif()
+
 if(WITH_STRATUM)
-  add_subdirectory(stratum)
+    find_package(absl REQUIRED)
+endif()
+
+##################
+# Subdirectories #
+##################
+
+if(WITH_STRATUM)
+    add_subdirectory(stratum)
 endif()
 add_subdirectory(infrap4d)
 add_subdirectory(modules)

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -17,10 +17,7 @@ endif()
 
 # Update pkg-config search path.
 set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH TRUE)
-list(APPEND CMAKE_PREFIX_PATH
-    ${OVS_INSTALL_PREFIX}
-    ${SDE_INSTALL_PREFIX}
-)
+list(APPEND CMAKE_PREFIX_PATH ${SDE_INSTALL_PREFIX})
 
 #if(DPDK_TARGET)
 #    pkg_check_modules(DPDK REQUIRED libdpdk)

--- a/modules/clients/CMakeLists.txt
+++ b/modules/clients/CMakeLists.txt
@@ -66,16 +66,13 @@ if(DPDK_TARGET)
 endif()
 
 target_link_libraries(tdi_pipeline_builder PUBLIC stratum_proto p4v1_proto)
-target_link_libraries(tdi_pipeline_builder PUBLIC stratum)
 
 target_link_libraries(tdi_pipeline_builder PUBLIC
     protobuf gflags glog grpc grpc++
 )
 
-add_dependencies(tdi_pipeline_builder
-    stratum
-    p4v1_proto
-    stratum_proto
-)
+target_link_libraries(tdi_pipeline_builder PRIVATE stratum)
+
+add_dependencies(tdi_pipeline_builder stratum p4v1_proto stratum_proto)
 
 install(TARGETS tdi_pipeline_builder RUNTIME)

--- a/setup/.gitignore
+++ b/setup/.gitignore
@@ -1,0 +1,10 @@
+/build
+/abseil-cpp
+/protobuf
+/grpc
+/cctz
+/gflags
+/glog
+/gmock-gbl
+/gtest
+/json

--- a/stratum/proto/CMakeLists.txt
+++ b/stratum/proto/CMakeLists.txt
@@ -218,15 +218,6 @@ target_include_directories(rpc_proto PRIVATE ${PROTO_OUT_DIR})
 
 target_link_libraries(rpc_proto PUBLIC protobuf)
 
-configure_file(rpc_proto.sym.in
-    ${CMAKE_CURRENT_BINARY_DIR}/rpc_proto.sym @ONLY
-)
-
-set_target_properties(rpc_proto PROPERTIES
-    LINK_OPTIONS -Wl,--version-script=rpc_proto.sym
-    LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/rpc_proto.sym
-)
-
 install(TARGETS rpc_proto LIBRARY)
 
 #######################
@@ -251,14 +242,6 @@ target_include_directories(p4v1_proto PRIVATE ${PROTO_OUT_DIR})
 
 target_link_libraries(p4v1_proto PUBLIC rpc_proto absl_synchronization)
 add_dependencies(p4v1_proto rpc_proto)
-
-configure_file(p4v1_proto.sym.in
-    ${CMAKE_CURRENT_BINARY_DIR}/p4v1_proto.sym @ONLY)
-
-set_target_properties(p4v1_proto PROPERTIES
-    LINK_OPTIONS -Wl,--version-script=p4v1_proto.sym
-    LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/p4v1_proto.sym
-)
 
 install(TARGETS p4v1_proto LIBRARY)
 
@@ -286,15 +269,6 @@ target_link_libraries(gnmi_proto
         absl_strings
         absl_synchronization
         absl_time
-)
-
-configure_file(gnmi_proto.sym.in
-    ${CMAKE_CURRENT_BINARY_DIR}/gnmi_proto.sym @ONLY
-)
-
-set_target_properties(gnmi_proto PROPERTIES
-    LINK_OPTIONS -Wl,--version-script=gnmi_proto.sym
-    LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gnmi_proto.sym
 )
 
 install(TARGETS gnmi_proto LIBRARY)
@@ -407,15 +381,6 @@ target_include_directories(stratum_proto2_o PRIVATE ${PROTO_OUT_DIR})
 add_library(stratum_proto SHARED
     $<TARGET_OBJECTS:stratum_proto1_o>
     $<TARGET_OBJECTS:stratum_proto2_o>
-)
-
-configure_file(stratum_proto.sym.in
-    ${CMAKE_CURRENT_BINARY_DIR}/stratum_proto.sym @ONLY
-)
-
-set_target_properties(stratum_proto PROPERTIES
-    LINK_OPTIONS -Wl,--version-script=stratum_proto.sym
-    LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/stratum_proto.sym
 )
 
 install(TARGETS stratum_proto LIBRARY)

--- a/stratum/proto/gnmi_proto.sym.in
+++ b/stratum/proto/gnmi_proto.sym.in
@@ -1,4 +1,0 @@
-libgnmi_proto_@LT_CURRENT@ {
-global:
-        *;
-};

--- a/stratum/proto/p4v1_proto.sym.in
+++ b/stratum/proto/p4v1_proto.sym.in
@@ -1,4 +1,0 @@
-p4v1_proto_@LT_CURRENT@ {
-global:
-        *;
-};

--- a/stratum/proto/rpc_proto.sym.in
+++ b/stratum/proto/rpc_proto.sym.in
@@ -1,4 +1,0 @@
-rpc_proto_@LT_CURRENT@ {
-global:
-        *;
-};

--- a/stratum/proto/stratum_proto.sym.in
+++ b/stratum/proto/stratum_proto.sym.in
@@ -1,4 +1,0 @@
-stratum_proto_@LT_CURRENT@ {
-global:
-        *;
-};


### PR DESCRIPTION
- Don't create version scripts for protobuf libraries.

- Use find_package() to locate Abseil libraries.

- Change link order for client utilities to include stratum static library last.

- Remove reference to OVS_INSTALL_PREFIX.

- Fix inconsistent indentation.

- Supply .gitignore file for setup directory.

Signed-off-by: Derek G Foster <derek.foster@intel.com>