### PR TITLE
Add support for DPDK-specific Stratum TDI classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,10 @@ option(WITH_OPENCONFIG  "Build with OpenConfig" ${WITH_STRATUM})
 # Target selection options #
 ############################
 
-option(TOFINO_TARGET    "Build for Tofino target" OFF)
 option(DPDK_TARGET      "Build for DPDK target" OFF)
-option(IPDK_TARGET      "Build Stratum for IPDK" OFF)
+option(TOFINO_TARGET    "Build for Tofino target" OFF)
 
-# Translate selected option to TARGETFLAG string.
+# Translate target option to TARGETFLAG string.
 # - Use precedence to deal with multiple selections.
 # - Ensure that individual target options are consistent
 #   so we can use them to control the build.
@@ -61,7 +60,7 @@ message(NOTICE "Building ${TARGETFLAG}")
 ###########################
 
 add_compile_options(-D${TARGETFLAG})
-if(IPDK_TARGET)
+if(DPDK_TARGET)
     add_compile_options(-DP4OVS_CHANGES)
 endif()
 

--- a/infrap4d/CMakeLists.txt
+++ b/infrap4d/CMakeLists.txt
@@ -2,8 +2,16 @@ cmake_minimum_required(VERSION 3.12)
 
 project(infrap4d VERSION 0.1.0 LANGUAGES C CXX)
 
+set(STRATUM_TDI_BIN_DIR ${STRATUM_SOURCE_DIR}/stratum/hal/bin/tdi)
+
+if(DPDK_TARGET)
+    set(INFRAP4D_MAIN ${STRATUM_TDI_BIN_DIR}/dpdk/main.cc)
+elseif(TOFINO_TARGET)
+    set(INFRAP4D_MAIN ${STRATUM_TDI_BIN_DIR}/main.cc)
+endif()
+
 add_executable(infrap4d
-    ${STRATUM_SOURCE_DIR}/stratum/hal/bin/tdi/main.cc
+    ${INFRAP4D_MAIN}
 )
 
 target_include_directories(infrap4d PRIVATE ${STRATUM_SOURCE_DIR})

--- a/make-all.sh
+++ b/make-all.sh
@@ -64,6 +64,9 @@ else
     OVS_INSTALL=${PREFIX}
 fi
 
+# Abort on error.
+set -e
+
 # Build OVS first.
 cmake -S ovs -B ${OVS_BUILD} -DCMAKE_INSTALL_PREFIX=${OVS_INSTALL}
 cmake --build ${OVS_BUILD} -j6 -- V=0

--- a/make-all.sh
+++ b/make-all.sh
@@ -9,7 +9,7 @@ eval set -- "${GETOPTS}"
 
 # Set defaults.
 PREFIX="install"
-TARGET="TOFINO"
+TARGET_TYPE="TOFINO"
 DEVELOP=0
 
 # Process command-line options.
@@ -19,20 +19,24 @@ while true ; do
         rm -fr build install
         shift 1;;
     -p|--prefix)
+        # --prefix=<path>
         PREFIX=$2
         shift 2 ;;
     --dep-install)
+        # --dep-install=<path>
         DEPEND_INSTALL=$2
         shift 2 ;;
     --develop)
         DEVELOP=1
         shift ;;
     --sde-install)
+        # --sde-install=<path>
         SDE_INSTALL=$2
         shift 2 ;;
     --target)
+        # --target={dpdk|tofino}
         # convert to uppercase
-        TARGET=${2^^}
+        TARGET_TYPE=${2^^}
         shift 2 ;;
     --)
         shift
@@ -70,7 +74,7 @@ cmake -S . -B build \
     -DOVS_INSTALL_PREFIX=${OVS_INSTALL} \
     -DSDE_INSTALL_PREFIX=${SDE_INSTALL} \
     ${DEPEND_INSTALL_OPTION} \
-    -D${TARGET}_TARGET=ON
+    -D${TARGET_TYPE}_TARGET=ON
 
 cmake --build build -j6
 cmake --install build

--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -163,29 +163,27 @@ add_dependencies(stratum_hal_lib_p4_o
 # stratum_target_o #
 ####################
 
-if(IPDK_TARGET)
-    # IPDK files
+set(STRATUM_TDI_LIB_DIR ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi)
+
+if(TOFINO_TARGET)
+    # Tofino files
     set(STRATUM_TARGET_FILES
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/ipdk/ipdk_chassis_manager.cc
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/ipdk/ipdk_chassis_manager.h
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/ipdk/ipdk_hal.cc
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/ipdk/ipdk_hal.h
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/ipdk/ipdk_node.cc
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/ipdk/ipdk_node.h
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/ipdk/ipdk_switch.cc
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/ipdk/ipdk_switch.h
+        ${STRATUM_TDI_LIB_DIR}/tdi_chassis_manager.cc
+        ${STRATUM_TDI_LIB_DIR}/tdi_chassis_manager.h
+        ${STRATUM_TDI_LIB_DIR}/tdi_hal.cc
+        ${STRATUM_TDI_LIB_DIR}/tdi_hal.h
+        ${STRATUM_TDI_LIB_DIR}/tdi_switch.cc
+        ${STRATUM_TDI_LIB_DIR}/tdi_switch.h
     )
-else()
-    # TDI files
+elseif(DPDK_TARGET)
+    # DPDK files
     set(STRATUM_TARGET_FILES
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_chassis_manager.cc
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_chassis_manager.h
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_hal.cc
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_hal.h
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_node.cc
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_node.h
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_switch.cc
-        ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_switch.h
+        ${STRATUM_TDI_LIB_DIR}/dpdk/dpdk_chassis_manager.cc
+        ${STRATUM_TDI_LIB_DIR}/dpdk/dpdk_chassis_manager.h
+        ${STRATUM_TDI_LIB_DIR}/dpdk/dpdk_hal.cc
+        ${STRATUM_TDI_LIB_DIR}/dpdk/dpdk_hal.h
+        ${STRATUM_TDI_LIB_DIR}/dpdk/dpdk_switch.cc
+        ${STRATUM_TDI_LIB_DIR}/dpdk/dpdk_switch.h
     )
 endif()
 
@@ -199,6 +197,8 @@ add_library(stratum_target_o OBJECT
     ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_counter_manager.h
     ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_id_mapper.cc
     ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_id_mapper.h
+    ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_node.cc
+    ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_node.h
     ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_packetio_manager.cc
     ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_packetio_manager.h
     ${STRATUM_SOURCE_DIR}/stratum/hal/lib/tdi/tdi_pipeline_utils.cc
@@ -227,16 +227,19 @@ add_dependencies(stratum_target_o stratum_proto)
 # stratum_main_o #
 ##################
 
-if(IPDK_TARGET)
-    # IPDK files
+set(STRATUM_TDI_BIN_DIR ${STRATUM_SOURCE_DIR}/stratum/hal/bin/tdi)
+
+if(TOFINO_TARGET)
+    # Tofino files
     set(STRATUM_MAIN_FILES
-      ${STRATUM_SOURCE_DIR}/stratum/hal/bin/ipdk/ipdk_main.cc
-      ${STRATUM_SOURCE_DIR}/stratum/hal/bin/ipdk/ipdk_main.h
+        ${STRATUM_TDI_BIN_DIR}/tdi_main.cc
+        ${STRATUM_TDI_BIN_DIR}/tdi_main.h
     )
-else()
-    # TDI files
+elseif(DPDK_TARGET)
+    # DPDK files
     set(STRATUM_MAIN_FILES
-        ${STRATUM_SOURCE_DIR}/stratum/hal/bin/tdi/tdi_main.cc
+        ${STRATUM_TDI_BIN_DIR}/dpdk/dpdk_main.cc
+        ${STRATUM_TDI_BIN_DIR}/dpdk/dpdk_main.h
     )
 endif()
 


### PR DESCRIPTION
- In DPDK_TARGET mode, compile Stratum using DPDK-specific files.

- Eliminated IPDK_TARGET conditional.

Signed-off-by: Derek G Foster <derek.foster@intel.com>