### PR TITLE
Update CMake build to support gNOI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ set(SDE_INSTALL_PREFIX "/opt/sde" CACHE PATH "SDE install directory")
 # Build options #
 #################
 
+option(WITH_GNOI        "Build with gNOI enabled" OFF)
+option(WITH_PROCMON     "Build with process monitor" OFF)
 option(WITH_STRATUM     "Build with Stratum" ON)
 
 ############################

--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -340,6 +340,23 @@ target_link_libraries(stratum PUBLIC
 target_link_libraries(stratum PUBLIC glog gflags grpc protobuf grpc++)
 target_link_libraries(stratum PUBLIC pthread)
 
+# Protobuf libraries
+
+if(WITH_GNIO)
+    target_link_libraries(stratum PUBLIC
+        gnio_cert
+        gnio_diag
+        gnio_file
+        gnio_system
+        gnio_common
+        gnio_types
+    )
+endif()
+
+if(WITH_PROCMON)
+    target_link_libraries(stratum PUBLIC procmon_proto)
+endif()
+
 target_link_libraries(stratum PUBLIC
     openconfig_proto
     stratum_proto
@@ -347,6 +364,8 @@ target_link_libraries(stratum PUBLIC
     rpc_proto
     p4v1_proto
 )
+
+# P4 driver libraries
 
 find_library(LIBTDI tdi ${SDE_INSTALL_PREFIX}/lib)
 if(NOT LIBTDI)

--- a/stratum/proto/CMakeLists.txt
+++ b/stratum/proto/CMakeLists.txt
@@ -50,32 +50,15 @@ set(P4V1_PROTO_FILES
     p4/config/v1/p4types.proto
 )
 
+set(PROCMON_PROTO_FILES
+    stratum/procmon/procmon.proto
+)
+
 set(STRATUM_P4_PROTO_FILES
     stratum/public/proto/error.proto
     stratum/hal/lib/common/common.proto
     stratum/hal/lib/p4/forwarding_pipeline_configs.proto
     stratum/hal/lib/phal/db.proto
-)
-
-set(GNMI_PROTO_FILES
-    gnmi/gnmi.proto
-    gnmi/gnmi_ext.proto
-)
-
-set(YGOT_PROTO_PATH github.com/openconfig/ygot/proto)
-
-set(YGOT_PROTO_FILES
-    ${YGOT_PROTO_PATH}/yext/yext.proto
-    ${YGOT_PROTO_PATH}/ywrapper/ywrapper.proto
-)
-
-set(OPENCONFIG_PROTO_FILES
-    openconfig/enums/enums.proto
-    openconfig/openconfig.proto
-)
-
-set(STRATUM_OC_PROTO_FILES
-    stratum/public/proto/openconfig-goog-bcm.proto
 )
 
 set(STRATUM_BF_PROTO_FILES
@@ -125,7 +108,7 @@ function(generate_proto_files PROTO_FILES SRC_DIR)
         install(FILES ${_hdr} DESTINATION
                 ${CMAKE_INSTALL_PREFIX}/include/stratum/pb/${_path})
 
-        if(INSTALL-PROTO)
+        if(INSTALL_PROTO)
             # Install protobuf files in share/stratum/proto.
             install(FILES ${SRC_DIR}/${_file} DESTINATION
                     ${CMAKE_INSTALL_PREFIX}/share/stratum/proto/${_path})
@@ -189,14 +172,12 @@ generate_grpc_files("p4/v1/p4runtime.proto" "${P4RUNTIME_SOURCE_DIR}/proto")
 
 generate_proto_files("${STRATUM_P4_PROTO_FILES}" "${STRATUM_SOURCE_DIR}")
 
-generate_proto_files("${GNMI_PROTO_FILES}" "${PROTO_PARENT_DIR}")
-generate_grpc_files("gnmi/gnmi.proto" "${PROTO_PARENT_DIR}")
-
-generate_proto_files("${YGOT_PROTO_FILES}" "${PROTO_PARENT_DIR}")
-generate_proto_files("${OPENCONFIG_PROTO_FILES}" "${PROTO_PARENT_DIR}")
-generate_proto_files("${STRATUM_OC_PROTO_FILES}" "${STRATUM_SOURCE_DIR}")
-
 generate_proto_files("${STRATUM_BF_PROTO_FILES}" "${STRATUM_SOURCE_DIR}")
+
+if(WITH_PROCMON)
+    generate_proto_files("${PROCMON_PROTO_FILES}" "${STRATUM_SOURCE_DIR}")
+    generate_grpc_files("${PROCMON_PROTO_FILES}" "${STRATUM_SOURCE_DIR}")
+endif()
 
 ######################
 # Build librpc_proto #
@@ -241,93 +222,34 @@ add_dependencies(p4v1_proto rpc_proto)
 
 install(TARGETS p4v1_proto LIBRARY)
 
-#######################
-# Build libgnmi_proto #
-#######################
-
-add_library(gnmi_proto SHARED
-    ${PROTO_OUT_DIR}/gnmi/gnmi.grpc.pb.cc
-    ${PROTO_OUT_DIR}/gnmi/gnmi.grpc.pb.h
-    ${PROTO_OUT_DIR}/gnmi/gnmi.pb.cc
-    ${PROTO_OUT_DIR}/gnmi/gnmi.pb.h
-    ${PROTO_OUT_DIR}/gnmi/gnmi_ext.pb.cc
-    ${PROTO_OUT_DIR}/gnmi/gnmi_ext.pb.h
-)
-
-add_dependencies(gnmi_proto rpc_proto)
-
-target_include_directories(gnmi_proto PRIVATE ${PROTO_OUT_DIR})
-
-target_link_libraries(gnmi_proto
-    PUBLIC
-        rpc_proto
-        absl_hash
-        absl_strings
-        absl_synchronization
-        absl_time
-)
-
-install(TARGETS gnmi_proto LIBRARY)
-
 ###########################
-#  Build openconfig_proto #
+# Build libprocmon_proto  #
 ###########################
 
-# ygot_proto_o
-add_library(ygot_proto_o OBJECT
-    ${PROTO_OUT_DIR}/${YGOT_PROTO_PATH}/yext/yext.pb.cc
-    ${PROTO_OUT_DIR}/${YGOT_PROTO_PATH}/yext/yext.pb.h
-    ${PROTO_OUT_DIR}/${YGOT_PROTO_PATH}/ywrapper/ywrapper.pb.cc
-    ${PROTO_OUT_DIR}/${YGOT_PROTO_PATH}/ywrapper/ywrapper.pb.h
-)
+if(WITH_PROCMON)
+    add_library(procmon_proto SHARED
+        ${PROTO_OUT_DIR}/stratum/procmon/procmon.pb.cc
+        ${PROTO_OUT_DIR}/stratum/procmon/procmon.pb.h
+        ${PROTO_OUT_DIR}/stratum/procmon/procmon.grpc.pb.cc
+        ${PROTO_OUT_DIR}/stratum/procmon/procmon.grpc.pb.h
+    )
+    target_include_directories(procmon_proto PUBLIC ${PROTO_OUT_DIR})
+    install(TARGETS procmon_proto LIBRARY)
+endif()
 
-target_include_directories(ygot_proto_o PRIVATE ${PROTO_OUT_DIR})
+##############################
+# Build openconfig libraries #
+##############################
 
-# openconfig_enums_proto_o
-add_library(openconfig_enums_proto_o OBJECT
-    ${PROTO_OUT_DIR}/openconfig/enums/enums.pb.cc
-    ${PROTO_OUT_DIR}/openconfig/enums/enums.pb.h
-)
+add_subdirectory(gnmi)
+if(WITH_GNOI)
+    add_subdirectory(gnoi)
+endif()
+add_subdirectory(openconfig)
 
-add_dependencies(openconfig_enums_proto_o ygot_proto_o)
-
-target_include_directories(
-    openconfig_enums_proto_o PRIVATE ${PROTO_OUT_DIR})
-
-# openconfig_proto_o
-add_library(openconfig_proto_o OBJECT
-    ${PROTO_OUT_DIR}/openconfig/openconfig.pb.cc
-    ${PROTO_OUT_DIR}/openconfig/openconfig.pb.h
-)
-
-add_dependencies(openconfig_proto_o openconfig_enums_proto_o)
-
-target_include_directories(openconfig_proto_o PRIVATE ${PROTO_OUT_DIR})
-
-# openconfig_goog_bcm_proto_o
-add_library(openconfig_goog_bcm_proto_o OBJECT
-    ${PROTO_OUT_DIR}/stratum/public/proto/openconfig-goog-bcm.pb.cc
-    ${PROTO_OUT_DIR}/stratum/public/proto/openconfig-goog-bcm.pb.h
-)
-
-add_dependencies(openconfig_goog_bcm_proto_o ygot_proto_o)
-
-target_include_directories(
-    openconfig_goog_bcm_proto_o PRIVATE ${PROTO_OUT_DIR})
-
-# openconfig_proto
-add_library(openconfig_proto SHARED
-    $<TARGET_OBJECTS:ygot_proto_o>
-    $<TARGET_OBJECTS:openconfig_enums_proto_o>
-    $<TARGET_OBJECTS:openconfig_proto_o>
-    $<TARGET_OBJECTS:openconfig_goog_bcm_proto_o>
-)
-
-install(TARGETS openconfig_proto LIBRARY)
-
-###########################
-#  Build libstratum_proto #
-###########################
+##########################
+# Build libstratum_proto #
+##########################
 
 # stratum_proto1_o
 add_library(stratum_proto1_o OBJECT
@@ -378,3 +300,44 @@ add_library(stratum_proto SHARED
 )
 
 install(TARGETS stratum_proto LIBRARY)
+
+################################
+# Download gNOI Protobuf files #
+################################
+
+include(ExternalProject)
+
+# Update to correspond to the version used by Stratum.
+# The definitions can be found in stratum/stratum/bazel/deps.bzl.
+set(GNOI_COMMIT 437c62e630389aa4547b4f0521d0bca3fb2bf811)
+set(GNOI_SHA 77d8c271adc22f94a18a5261c28f209370e87a5e615801a4e7e0d09f06da531f)
+
+# Path to the stratum/proto/gnoi directory.
+set(PROTO_GNOI_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gnoi)
+
+ExternalProject_Add(fetch-gnoi
+  URL https://github.com/openconfig/gnoi/archive/${GNOI_COMMIT}.zip
+  URL_HASH SHA256=${GNOI_SHA}
+  PATCH_COMMAND
+    find . -name *.proto | xargs sed -i -e "s#github.com/openconfig/##g"
+  COMMAND
+    cp -v cert/cert.proto ${PROTO_GNOI_DIR}/cert
+  COMMAND
+    cp -v common/common.proto ${PROTO_GNOI_DIR}/common
+  COMMAND
+    cp -v diag/diag.proto ${PROTO_GNOI_DIR}/diag
+  COMMAND
+    cp -v file/file.proto ${PROTO_GNOI_DIR}/file
+  COMMAND
+    cp -v system/system.proto ${PROTO_GNOI_DIR}/system
+  COMMAND
+    cp -v types/types.proto ${PROTO_GNOI_DIR}/types
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+)
+
+# The target is only built when expressly requested to do so.
+#     cmake --build build --target fetch-gnoi
+set_target_properties(fetch-gnoi PROPERTIES EXCLUDE_FROM_ALL TRUE)
+

--- a/stratum/proto/CMakeLists.txt
+++ b/stratum/proto/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Builds protobuf object libraries
+# Builds Protobuf libraries
 
 cmake_minimum_required(VERSION 3.5)
 

--- a/stratum/proto/gnmi/CMakeLists.txt
+++ b/stratum/proto/gnmi/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Builds stratum/proto/openconfig
+# Builds gNMI Protobuf library
+
 cmake_minimum_required(VERSION 3.5)
 
 set(GNMI_PROTO_FILES

--- a/stratum/proto/gnmi/CMakeLists.txt
+++ b/stratum/proto/gnmi/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Builds stratum/proto/openconfig
+cmake_minimum_required(VERSION 3.5)
+
+set(GNMI_PROTO_FILES
+    gnmi/gnmi.proto
+    gnmi/gnmi_ext.proto
+)
+
+generate_proto_files("${GNMI_PROTO_FILES}" "${PROTO_PARENT_DIR}")
+generate_grpc_files("gnmi/gnmi.proto" "${PROTO_PARENT_DIR}")
+
+add_library(gnmi_proto SHARED
+    ${PROTO_OUT_DIR}/gnmi/gnmi.grpc.pb.cc
+    ${PROTO_OUT_DIR}/gnmi/gnmi.grpc.pb.h
+    ${PROTO_OUT_DIR}/gnmi/gnmi.pb.cc
+    ${PROTO_OUT_DIR}/gnmi/gnmi.pb.h
+    ${PROTO_OUT_DIR}/gnmi/gnmi_ext.pb.cc
+    ${PROTO_OUT_DIR}/gnmi/gnmi_ext.pb.h
+)
+
+add_dependencies(gnmi_proto rpc_proto)
+
+target_include_directories(gnmi_proto PRIVATE ${PROTO_OUT_DIR})
+
+target_link_libraries(gnmi_proto
+    PUBLIC
+        rpc_proto
+        absl_hash
+        absl_strings
+        absl_synchronization
+        absl_time
+)
+
+install(TARGETS gnmi_proto LIBRARY)

--- a/stratum/proto/gnoi/CMakeLists.txt
+++ b/stratum/proto/gnoi/CMakeLists.txt
@@ -1,0 +1,87 @@
+# Builds stratum/proto/gnoi
+cmake_minimum_required(VERSION 3.5)
+
+set(GNOI_COMMON_FILES
+    gnoi/common/common.proto
+    gnoi/types/types.proto
+)
+
+set(GNOI_SERVICE_FILES
+    gnoi/cert/cert.proto
+    gnoi/diag/diag.proto
+    gnoi/file/file.proto
+    gnoi/system/system.proto
+)
+
+generate_proto_files("${GNOI_COMMON_FILES}" "${PROTO_PARENT_DIR}")
+generate_proto_files("${GNOI_SERVICE_FILES}" "${PROTO_PARENT_DIR}")
+generate_grpc_files("${GNOI_SERVICE_FILES}" "${PROTO_PARENT_DIR}")
+
+# gnoi_types
+add_library(gnoi_types SHARED
+    ${PROTO_OUT_DIR}/gnoi/types/types.pb.cc
+    ${PROTO_OUT_DIR}/gnoi/types/types.pb.h
+)
+
+target_include_directories(gnoi_types PUBLIC ${PROTO_OUT_DIR})
+
+# gnoi_common
+add_library(gnoi_common SHARED
+    ${PROTO_OUT_DIR}/gnoi/common/common.pb.cc
+    ${PROTO_OUT_DIR}/gnoi/common/common.pb.h
+)
+add_dependencies(gnoi_common gnoi_types)
+
+target_include_directories(gnoi_common PUBLIC ${PROTO_OUT_DIR})
+target_link_libraries(gnoi_common PUBLIC gnoi_types)
+
+# gnoi_cert
+add_library(gnoi_cert SHARED
+    ${PROTO_OUT_DIR}/gnoi/cert/cert.pb.cc
+    ${PROTO_OUT_DIR}/gnoi/cert/cert.pb.h
+    ${PROTO_OUT_DIR}/gnoi/cert/cert.grpc.pb.cc
+    ${PROTO_OUT_DIR}/gnoi/cert/cert.grpc.pb.h
+)
+add_dependencies(gnoi_cert gnoi_types)
+
+target_include_directories(gnoi_cert PUBLIC ${PROTO_OUT_DIR})
+target_link_libraries(gnoi_cert PUBLIC gnoi_types)
+
+# gnoi_diag
+add_library(gnoi_diag SHARED
+    ${PROTO_OUT_DIR}/gnoi/diag/diag.pb.cc
+    ${PROTO_OUT_DIR}/gnoi/diag/diag.pb.h
+    ${PROTO_OUT_DIR}/gnoi/diag/diag.grpc.pb.cc
+    ${PROTO_OUT_DIR}/gnoi/diag/diag.grpc.pb.h
+)
+add_dependencies(gnoi_diag gnoi_types)
+
+target_include_directories(gnoi_diag PUBLIC ${PROTO_OUT_DIR})
+target_link_libraries(gnoi_diag PUBLIC gnoi_types)
+
+# gnoi_file
+add_library(gnoi_file SHARED
+    ${PROTO_OUT_DIR}/gnoi/file/file.pb.cc
+    ${PROTO_OUT_DIR}/gnoi/file/file.pb.h
+    ${PROTO_OUT_DIR}/gnoi/file/file.grpc.pb.cc
+    ${PROTO_OUT_DIR}/gnoi/file/file.grpc.pb.h
+)
+add_dependencies(gnoi_file gnoi_types)
+
+target_include_directories(gnoi_file PUBLIC ${PROTO_OUT_DIR})
+target_link_libraries(gnoi_file PUBLIC gnoi_types)
+
+# gnoi_system
+add_library(gnoi_system SHARED
+    ${PROTO_OUT_DIR}/gnoi/system/system.pb.cc
+    ${PROTO_OUT_DIR}/gnoi/system/system.pb.h
+    ${PROTO_OUT_DIR}/gnoi/system/system.grpc.pb.cc
+    ${PROTO_OUT_DIR}/gnoi/system/system.grpc.pb.h
+)
+add_dependencies(gnoi_system gnoi_common gnoi_types)
+
+target_include_directories(gnoi_system PUBLIC ${PROTO_OUT_DIR})
+target_link_libraries(gnoi_system PUBLIC gnoi_common gnoi_types)
+
+install(TARGETS gnoi_types gnoi_common LIBRARY)
+install(TARGETS gnoi_cert gnoi_diag gnoi_file gnoi_system LIBRARY)

--- a/stratum/proto/gnoi/CMakeLists.txt
+++ b/stratum/proto/gnoi/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Builds stratum/proto/gnoi
+# Builds gNOI Protobuf libraries
+
 cmake_minimum_required(VERSION 3.5)
 
 set(GNOI_COMMON_FILES

--- a/stratum/proto/gnoi/README.md
+++ b/stratum/proto/gnoi/README.md
@@ -1,0 +1,54 @@
+# gNOI Protobuf files for Stratum
+
+The files should be updated if the Stratum version changes.
+
+You will need to edit the file paths in the *import* statements for the
+Protobufs to build correctly.
+
+The following CMake snippet downloads and patches the specified version of
+the gNOI Protobuf files. It is equivalent to what the Bazel build does.
+
+## stratum/proto/CMakeLists.txt
+
+```cmake
+################################
+# Download gNOI Protobuf files #
+################################
+
+include(ExternalProject)
+
+# Update to correspond to the version used by Stratum.
+# The definitions can be found in stratum/stratum/bazel/deps.bzl.
+set(GNOI_COMMIT 437c62e630389aa4547b4f0521d0bca3fb2bf811)
+set(GNOI_SHA 77d8c271adc22f94a18a5261c28f209370e87a5e615801a4e7e0d09f06da531f)
+
+# Path to the stratum/proto/gnoi directory.
+set(PROTO_GNOI_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gnoi)
+
+ExternalProject_Add(fetch-gnoi
+  URL https://github.com/openconfig/gnoi/archive/${GNOI_COMMIT}.zip
+  URL_HASH SHA256=${GNOI_SHA}
+  SOURCE_DIR gnoi-temp
+  PATCH_COMMAND
+    find . -name *.proto | xargs sed -i -e "s#github.com/openconfig/##g"
+  COMMAND
+    cp -v cert/cert.proto ${PROTO_GNOI_DIR}/cert
+  COMMAND
+    cp -v common/common.proto ${PROTO_GNOI_DIR}/common
+  COMMAND
+    cp -v diag/diag.proto ${PROTO_GNOI_DIR}/diag
+  COMMAND
+    cp -v file/file.proto ${PROTO_GNOI_DIR}/file
+  COMMAND
+    cp -v system/system.proto ${PROTO_GNOI_DIR}/system
+  COMMAND
+    cp -v types/types.proto ${PROTO_GNOI_DIR}/types
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+)
+
+# The target is only built when explicitly requested.
+#     cmake --build build --target fetch-gnoi
+set_target_properties(fetch-gnoi PROPERTIES EXCLUDE_FROM_ALL TRUE)
+```

--- a/stratum/proto/gnoi/cert/cert.proto
+++ b/stratum/proto/gnoi/cert/cert.proto
@@ -1,0 +1,408 @@
+//
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// This file defines the gNOI API to be used for certificate installation and
+// rotation.
+syntax = "proto3";
+
+import "gnoi/types/types.proto";
+
+package gnoi.certificate;
+
+option (types.gnoi_version) = "0.1.0";
+
+// The Certificate Management Service exported by targets.
+// The service primarily exports two main RPCs, Install & Rotate which are used
+// for installation of a new certificate, and rotation of an existing
+// certificate on a target, along with a few management related RPCs.
+service CertificateManagement {
+
+  // Rotate will replace an existing Certificate on the target by creating a
+  // new CSR request and placing the new Certificate based on the CSR on the
+  // target. If the stream is broken or any steps in the process fail the
+  // target must rollback to the original Certificate.
+  //
+  // The following describes the sequence of messages that must be exchanged
+  // in the Rotate() RPC.
+  //
+  // Sequence of expected messages:
+  // Case 1: When Target generates the CSR.
+  //
+  //   Step 1: Start the stream
+  //     Client <---- Rotate() RPC stream begin ------> Target
+  //
+  //   Step 2: CSR
+  //     Client -----> GenerateCSRRequest----> Target
+  //     Client <----- GenerateCSRResponse <--- Target
+  //
+  //   Step 3: Certificate Signing
+  //     Client gets the certificate signed by the CA.
+  //
+  //   Step 4: Send Certificate to Target.
+  //     Client --> LoadCertificateRequest ----> Target
+  //     Client <-- LoadCertificateResponse <--- Target
+  //
+  //   Step 5: Test/Validation by the client.
+  //     This step should be to create a new connection to the target using
+  //     The new certificate and validate that the certificate works.
+  //     Once verfied, the client will then proceed to finalize the rotation.
+  //     If the new connection cannot be completed the client will cancel the
+  //     RPC thereby forcing the target to rollback the certificate.
+  //
+  //   Step 6: Final commit.
+  //     Client ---> FinalizeRequest ----> Target
+  //
+  //
+  // Case 2: When Client generates the CSR.
+  //   Step 1: Start the stream
+  //     Client <---- Rotate() RPC stream begin ----> Target
+  //
+  //   Step 2: CSR
+  //     Client generates its own certificate.
+  //
+  //   Step 3: Certificate Signing
+  //     Client gets the certificate signed by the CA.
+  //
+  //   Step 4: Send Certificate to Target.
+  //     Client ---> LoadCertificateRequest ----> Target
+  //     Client <--- LoadCertificateResponse <--- Target
+  //
+  //   Step 5: Test/Validation by the client.
+  //
+  //   Step 6: Final commit.
+  //     Client ---> FinalizeRequest ----> Target
+  rpc Rotate(stream RotateCertificateRequest)
+      returns (stream RotateCertificateResponse);
+
+  // Install will put a new Certificate on the target by creating a new CSR
+  // request and placing the new Certificate based on the CSR on the target.The
+  // new Certificate will be associated with a new Certificate Id on the target.
+  // If the target has a pre existing Certificate with the given Certificate Id,
+  // the operation should fail.
+  // If the stream is broken or any steps in the process fail the target must
+  // revert any changes in state.
+  //
+  // The following describes the sequence of messages that must be exchanged
+  // in the Install() RPC.
+  //
+  // Sequence of expected messages:
+  // Case 1: When Target generates the CSR-------------------------:
+  //
+  //   Step 1: Start the stream
+  //     Client <---- Install() RPC stream begin ------> Target
+  //
+  //   Step 2: CSR
+  //     Client -----> GenerateCSRRequest() ----> Target
+  //     Client <---- GenerateCSRResponse() <---- Target
+  //
+  //   Step 3: Certificate Signing
+  //     Client gets the certificate signed by the CA.
+  //
+  //   Step 4: Send Certificate to Target.
+  //     Client -> LoadCertificateRequest() ----> Target
+  //     Client <- LoadCertificateResponse() <--- Target
+  //
+  // Case 2: When Client generates the CSR-------------------------:
+  //   Step 1: Start the stream
+  //     Client <---- Install() RPC stream begin ------> Target
+  //
+  //   Step 2: CSR
+  //     Client generates its own certificate.
+  //
+  //   Step 3: Certificate Signing
+  //     Client gets the certificate signed by the CA.
+  //
+  //   Step 4: Send Certificate to Target.
+  //     Client -> LoadCertificateRequest() ----> Target
+  //     Client <- LoadCertificateResponse() <--- Target
+  //
+  rpc Install(stream InstallCertificateRequest)
+      returns (stream InstallCertificateResponse);
+
+  // An RPC to get the certificates on the target.
+  rpc GetCertificates(GetCertificatesRequest) returns (GetCertificatesResponse);
+
+  // An RPC to revoke specific certificates.
+  // If a certificate is not present on the target, the request should silently
+  // succeed. Revoking a certificate should render the existing certificate
+  // unusable by any endpoints.
+  rpc RevokeCertificates(RevokeCertificatesRequest)
+      returns (RevokeCertificatesResponse);
+
+  // An RPC to ask a target if it can generate a Certificate.
+  rpc CanGenerateCSR(CanGenerateCSRRequest) returns (CanGenerateCSRResponse);
+}
+
+// Request messages to rotate existing certificates on the target.
+message RotateCertificateRequest {
+  // Request Messages.
+  oneof rotate_request {
+    GenerateCSRRequest generate_csr = 1;
+    LoadCertificateRequest load_certificate = 2;
+    FinalizeRequest finalize_rotation = 3;
+  }
+}
+
+// Response Messages from the target.
+message RotateCertificateResponse {
+  // Response messages.
+  oneof rotate_response {
+    GenerateCSRResponse generated_csr = 1;
+    LoadCertificateResponse load_certificate = 2;
+  }
+}
+
+// Request messages to install new certificates on the target.
+message InstallCertificateRequest {
+  // Request Messages.
+  oneof install_request {
+    GenerateCSRRequest generate_csr = 1;
+    LoadCertificateRequest load_certificate = 2;
+  }
+}
+
+// Response Messages from the target for the InstallCertificateRequest.
+message InstallCertificateResponse {
+  // Response messages.
+  oneof install_response {
+    GenerateCSRResponse generated_csr = 1;
+    LoadCertificateResponse load_certificate = 2;
+  }
+}
+
+// Request to generate the CSR.
+// When this request is made for rotating an existing certificate as part of the
+// Rotate() RPC, then the target must ensure that the "certificate_id" is
+// already created and exists on the target. If the Certificate Rotation
+// proceeds to load the certificate, it must associate the new certificate with
+// the previously created "certificate_id".
+//
+// When this request is made for installing a completely new certificate as part
+// of the Install() RPC , then the target must ensure that the "certificate_id"
+// is completely new and no entities on the target are should be bound to this
+// certificate_id. If any existing certificate matches the certificate_id, then
+// this request should fail.
+//
+// If there is another ongoing Rotate/Install RPC with the same certificate_id,
+// the GenerateCSRRequest should fail.
+message GenerateCSRRequest {
+  // Parameters for creating a CSR.
+  CSRParams csr_params = 1;
+  // The certificate id with which this CSR will be associated. The target
+  // configuration should bind an entity which wants to use a certificate to
+  // the certificate_id it should use.
+  string certificate_id = 2;
+}
+
+// Parameters to be used when generating a Certificate Signing Request.
+message CSRParams {
+  // The type of certificate which will be associated for this CSR.
+  CertificateType type = 1;
+
+  // Minimum size of the key to be used by the target when generating a
+  // public/private key pair.
+  uint32 min_key_size = 2;
+
+  // If provided, the target must use the provided key type. If the target
+  // cannot use the algorithm specified in the key_type, it should cancel the
+  // stream with an Unimplemented error.
+  KeyType key_type = 3;
+
+  // --- common set of parameters applicable for any type of certificate --- //
+  string common_name = 4;           // e.g "device.corp.google.com"
+  string country = 5;               // e.g "US"
+  string state = 6;                 // e.g "CA"
+  string city = 7;                  // e.g "Mountain View"
+  string organization = 8;          // e.g "Google"
+  string organizational_unit = 9;   // e.g "Security"
+  string ip_address = 10;
+  string email_id = 11;
+
+  // TODO(lokagarw): Define a way to add any other parameters/extensions to be
+  // used for generating the CSR depending upon the type of certificate being
+  // requested.
+}
+
+// GenerateCSRResponse contains the CSR associated with the Certificate ID
+// supplied in the GenerateCSRRequest. When a Certificate is subsequently
+// installed on the target in the same streaming RPC session, it must be
+// associated to that Certificate ID.
+//
+// An Unimplemented error will be returned if the target cannot generate a CSR
+// as per the request. In this case, the caller must generate its own key pair.
+message GenerateCSRResponse {
+  CSR csr = 1;
+}
+
+// LoadCertificateRequest instructs the target to store the given certificate.
+//
+// Case 1: Target Generated CSR and Key Pair.
+// If the target generated the CSR (and the public/private key pair) during the
+// GenerateCSR request, then the target must associate the certificate with the
+// certificate ID specified in the preceding GenerateCSR request.
+//
+// Case 2: Externally Generated Key Pair.
+// If the target can not generate a CSR, then the public/private key pair is
+// generated externally. In this case provide the target with the key pair,
+// and the certificate_id to be associated with the new certificate.
+//
+// If there is another ongoing Rotate/Install RPC with the same certificate_id,
+// the LoadCertificateRequest must fail.
+message LoadCertificateRequest {
+  // The certificate to be Loaded on the target.
+  Certificate certificate = 1;
+
+  // The key pair to be used with the certificate. This is provided in the event
+  // that the target cannot generate a CSR (and the corresponding public/private
+  // keys).
+  KeyPair key_pair = 2;
+
+  // Certificate Id of the above certificate. This is to be provided only when
+  // there is an externally generated key pair.
+  string certificate_id = 3;
+
+  // Optional bundle of CA certificates. When not empty, the provided
+  // certificates should squash the existing bundle. This field provides a
+  // simplified means to provision a CA bundle that can be used to validate
+  // other peer's certificates.
+  repeated Certificate ca_certificates = 4;
+}
+
+// Response from target after Loading a Certificate.
+// If the target could not load the certificate, it must end the RPC stream with
+// a suitable RPC error about why the Certificate was not loaded.
+message LoadCertificateResponse {
+}
+
+// A Finalize message is sent to the target to confirm the Rotation of
+// the certificate and that the certificate should not be rolled back when
+// the RPC concludes. The certificate must be rolled back if the target returns
+// an error after receiving a Finalize message.
+message FinalizeRequest {
+}
+
+// The request to query all the certificates on the target.
+message GetCertificatesRequest {
+}
+
+// Response from the target about the certificates that exist on the target what
+// what is using them.
+message GetCertificatesResponse {
+  repeated CertificateInfo certificate_info = 1;
+}
+
+message CertificateInfo {
+  string certificate_id = 1;
+  Certificate certificate = 2;
+
+  // List of endpoints using this certificate.
+  repeated Endpoint endpoints = 3;
+
+  // System modification time when the certificate was installed/rotated in
+  // nanoseconds since epoch.
+  int64 modification_time = 4;
+}
+
+message RevokeCertificatesRequest {
+  // Certificates to revoke.
+  repeated string certificate_id = 1;
+}
+
+message RevokeCertificatesResponse {
+  // List of certificates successfully revoked.
+  repeated string revoked_certificate_id = 1;
+
+  // List of errors why certain certificates could not be revoked.
+  repeated CertificateRevocationError certificate_revocation_error = 2;
+}
+
+// An error message indicating why a certificate id could not be revoked.
+message CertificateRevocationError {
+  string certificate_id = 1;
+  string error_message = 2;
+}
+
+// A request to ask the target if it can generate key pairs.
+message CanGenerateCSRRequest {
+  KeyType key_type = 1;
+  CertificateType certificate_type = 2;
+  uint32 key_size = 3;
+}
+
+// Response from the target about whether it can generate a CSR with the given
+// parameters.
+message CanGenerateCSRResponse {
+  bool can_generate = 4;
+}
+
+// Types of certificates.
+enum CertificateType {
+  // 1 - 500 for public use.
+  // 501 onwards for private use.
+  CT_UNKNOWN = 0;
+  CT_X509 = 1;
+}
+
+// A certificate.
+message Certificate {
+  // Type of certificate.
+  CertificateType type = 1;
+
+  // Actual certificate.
+  // The exact encoding depends upon the type of certificate.
+  // for X509, this should be a PEM encoded Certificate.
+  bytes certificate = 2;
+}
+
+// A Certificate Signing Request.
+message CSR {
+  // Type of certificate.
+  CertificateType type = 1;
+
+  // Bytes representing the CSR.
+  // The exact encoding depends upon the type of certificate requested.
+  // for X509: This should be the PEM encoded CSR.
+  bytes csr = 2;
+}
+
+// A message representing a pair of public/private keys.
+message KeyPair {
+  bytes private_key = 1;
+  bytes public_key = 2;
+}
+
+// Algorithm to be used for generation the key pair.
+enum KeyType {
+  // 1 - 500, for known types.
+  // 501 and onwards for private use.
+  KT_UNKNOWN = 0;
+  KT_RSA = 1;
+}
+
+// An endpoint represents an entity on the target which can use a certificate.
+message Endpoint {
+  // Type of endpoint that can use a cert. This list is to be extended based on
+  // conversation with vendors.
+  enum Type {
+    EP_UNSPECIFIED = 0;
+    EP_IPSEC_TUNNEL = 1;
+    EP_DAEMON = 2;
+  }
+  Type type = 1;
+
+  // Human readable identifier for an endpoint.
+  string endpoint = 2;
+}

--- a/stratum/proto/gnoi/common/common.proto
+++ b/stratum/proto/gnoi/common/common.proto
@@ -1,0 +1,42 @@
+//
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package gnoi.common;
+
+import "gnoi/types/types.proto";
+
+// RemoteDownload defines the details for a device to initiate a file transfer
+// from or to a remote location.
+message RemoteDownload {
+  // The path information containing where to download the data from or to.
+  // For HTTP(S), this will be the URL (i.e. foo.com/file.tbz2).
+  // For SFTP and SCP, this will be the address:/path/to/file
+  // (i.e. host.foo.com:/bar/baz).
+  string path = 1;
+
+  enum Protocol {
+    UNKNOWN = 0;
+    SFTP = 1;
+    HTTP = 2;
+    HTTPS = 3;
+    SCP = 4;
+  }
+  Protocol protocol = 2;
+
+  types.Credentials credentials = 3;
+}

--- a/stratum/proto/gnoi/diag/diag.proto
+++ b/stratum/proto/gnoi/diag/diag.proto
@@ -1,0 +1,251 @@
+//
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// This file defines the gNOI APIs used to perform diagnostic operations on a
+// network device.
+syntax = "proto3";
+
+package gnoi.diag;
+
+import "gnoi/types/types.proto";
+
+option (types.gnoi_version) = "0.1.0";
+
+// The Diag service exports to main set of RPCs:
+// 1- BERT related RPCs: Used to perform Bit Error Rate Test (BERT)
+//    operations on a set of ports.
+// 2- BURNIN related RPCs: Used to perform a vendor-provided Burnin test on the
+//    network device to ensure the device is ready to start serving traffic.
+//    Burnin tests are typically run in the field, as part of turnup or repair
+//    workflow.
+// Note: The RPCs defined here are are stateless operations and them
+// failing/passing should not leave any permanent artifact on the network device
+//  (unless there is something wrong HW-wise).
+// Note: By "port" we refer to a channelized frontpanel or backplane port on a
+// chassis. In OpenConfig YANG models, there is a one-to-one relationship
+// between a port as used here and an "interface". Therefore, the "types.Path"
+// fields below for ports correspond to "/interfaces/interface" in YANG models.
+service Diag {
+  // Starts BERT operation on a set of ports. Each BERT operation is uniquely
+  // identified by an ID, which is given by the caller. The caller can then
+  // use this ID (as well as the list of the ports) to stop the BERT operation
+  // and/or get the BERT results. This RPC is expected to return an error status
+  // in the following situations:
+  // - When BERT operation is supported on none of the ports specified by
+  //   the request.
+  // - When BERT is already in progress on any port specified by the request.
+  // - In case of any low-level HW/SW internal errors.
+  // The RPC returns an OK status of none of these situations is encountered.
+  rpc StartBERT(StartBERTRequest) returns(StartBERTResponse) {}
+
+  // Stops an already in-progress BERT operation on a set of ports. The caller
+  // uses the BERT operation ID it previously used when starting the operation
+  // to stop it. The RPC is expected to return an error status in the following
+  // situations:
+  // - When there is at least one BERT operation in progress on a port which
+  //   cannot be stopped in the middle of the operation (either due to lack of
+  //   support or internal problems).
+  // - When no BERT operation, which matches the given BERT operation ID, is in
+  //   progress or completed on any of the ports specified by the request.
+  // - When the BERT operation ID does not match the in progress or completed
+  //   BERT operation on any of the ports specified by the request.
+  // The RPC returns an OK status of none of these situations is encountered.
+  // Note that a BERT operation is considered completed if the device has a
+  // record/history of it. Also note that it is OK to receive a stop request for
+  // a port which has completed BERT, as long as the recorded BERT operation ID
+  // matches the one specified by the request.
+  rpc StopBERT(StopBERTRequest) returns(StopBERTResponse) {}
+
+  // Gets BERT results during the BERT operation or after it completes. The
+  // caller uses the BERT operation ID it previously used when starting the
+  // operation to query it. The device is expected to keep the results for
+  // last N BERT operations for some amount of time, as specified by the
+  // product requirement. This RPC is expected to return error status in the
+  // following situations:
+  // - When no BERT operation, which matches the given BERT operation ID, is in
+  //   progress or completed on any of the ports specified by the request.
+  // - When the BERT operation ID does not match the in progress or completed
+  //   BERT operation on any of the ports specified by the request.
+  // The RPC returns an OK status of none of these situations is encountered.
+  // Note that a BERT operation is considered completed if device has a
+  // record of it.
+  rpc GetBERTResult(GetBERTResultRequest) returns(GetBERTResultResponse) {}
+
+  // TODO(aghaffar): Add BURNIN related RPCs.
+}
+
+// Common sequence generating monic polynomials used for PRBS.
+enum PrbsPolynomial {
+  PRBS_POLYNOMIAL_UNKNOWN = 0;  // default invalid choice.
+  PRBS_POLYNOMIAL_PRBS7 = 1;
+  PRBS_POLYNOMIAL_PRBS9 = 2;
+  PRBS_POLYNOMIAL_PRBS15 = 3;
+  PRBS_POLYNOMIAL_PRBS20 = 4;
+  PRBS_POLYNOMIAL_PRBS23 = 5;
+  PRBS_POLYNOMIAL_PRBS31 = 6;
+}
+
+// Status returned for each per-port BERT request.
+enum BertStatus {
+  // default invalid choice.
+  BERT_STATUS_UNKNOWN = 0;
+  // BERT requests (Start, Stop, GetStatus) were processed successfully.
+  BERT_STATUS_OK = 1;
+  // The specified port was not found.
+  BERT_STATUS_NON_EXISTENT_PORT = 2;
+  // HW error was encountered while performing BERT operation.
+  BERT_STATUS_HARDWARE_ACCESS_ERROR = 3;
+  // PRBS generating polynomial is not supported by the target.
+  BERT_STATUS_UNSUPPORTED_PRBS_POLYNOMIAL = 4;
+  // There is already a BERT running on the specified port. Returned when
+  // `StartBert` RPC tries to add run BERT on an already in-use port.
+  BERT_STATUS_PORT_ALREADY_IN_BERT = 5;
+  // There is no BERT running on the specified port. Returned when `StopBert`
+  // or `GetBertResult` RPC was called for an idle port.
+  BERT_STATUS_PORT_NOT_RUNNING_BERT = 6;
+  // The specified test duration is too small.
+  BERT_STATUS_TEST_DURATION_TOO_SHORT = 7;
+  // The specified test duration is larger than maximum allowed.
+  BERT_STATUS_TEST_DURATION_TOO_LONG = 8;
+  // The given BERT operation ID is not known. Returned for `StopBert` and
+  // `GetBertResult` RPCs.
+  BERT_STATUS_OPERATION_ID_NOT_FOUND = 9;
+  // The given BERT operation ID is already in use. Returned when `StartBert`
+  // RPC uses an ID which is already memorized for a BERT operation.
+  BERT_STATUS_OPERATION_ID_IN_USE = 10;
+  // Failure to get the peer lock.
+  BERT_STATUS_PEER_LOCK_FAILURE = 11;
+  // Lost the peer lock after locking once.
+  BERT_STATUS_PEER_LOCK_LOST = 12;
+  // Misc internal errors that cannot be categorized by any of the previous
+  // error codes.
+  BERT_STATUS_INTERNAL_ERROR = 13;
+}
+
+message StartBERTRequest {
+  // Per port BERT start requests.
+  message PerPortRequest {
+    // Path to the interface corresponding to the port.
+    types.Path interface = 1;  // required
+    // The selected PRBS generating polynomial for BERT.
+    PrbsPolynomial prbs_polynomial = 2;  // required
+    // BERT duration in seconds. Must be a positive number.
+    uint32 test_duration_in_secs = 3;  // required
+  }
+  // Unique BERT operation ID specified by the client. Multiple BERTs run on
+  // different ports can have the same BERT operation ID. This ID will be used
+  // later to stop the operation and/or get its results.
+  // TODO: Investigate whether we can use numerical IDs instead.
+  string bert_operation_id = 1;
+  // All the per-port BERTs that are considered one BERT operation and have the
+  // same BERT operation ID.
+  repeated PerPortRequest per_port_requests = 2;
+}
+
+message StartBERTResponse {
+  // Per-port BERT start responses.
+  message PerPortResponse {
+    // Path to the interface corresponding to the port.
+    types.Path interface = 1;
+    // BERT start status for this port.
+    BertStatus status = 2;
+  }
+  // The same BERT operation ID given by the request.
+  string bert_operation_id = 1;
+  // Captures the results of starting BERT on a per-port basis.
+  repeated PerPortResponse per_port_responses = 2;
+}
+
+message StopBERTRequest {
+  // Per-port BERT stop requests.
+  message PerPortRequest {
+    // Path to the interface corresponding to the port.
+    types.Path interface = 1;
+  }
+  // The same BERT operation ID given when BERT operation was started.
+  string bert_operation_id = 1;
+  // All the per-port BERTs that need to be stopped. Must be part of the BERT
+  // operation specified by the `bert_operation_id` above.
+  repeated PerPortRequest per_port_requests = 2;
+}
+
+message StopBERTResponse {
+  // Per-port BERT stop responses.
+  message PerPortResponse {
+    // Path to the interface corresponding to the port.
+    types.Path interface = 1;
+    // BERT stop status for this port.
+    BertStatus status = 2;
+  }
+  // The same BERT operation ID given by the request.
+  string bert_operation_id = 1;
+  // Captures the results of stopping BERT on a per-port basis.
+  repeated PerPortResponse per_port_responses = 2;
+}
+
+// TODO: If there is no use case to get the BERT results for all the ports
+// independent of the bert_operation_id, we can simplify this message and
+// return the results for all the ports associated with an operation ID.
+message GetBERTResultRequest {
+  // Per-port BERT get result requests.
+  message PerPortRequest {
+    // Path to the interface corresponding to the port.
+    types.Path interface = 1;
+  }
+  // The same BERT operation ID given when BERT operation was started.
+  string bert_operation_id = 1;
+  // All the per-port BERTs result of which we want to query. Must be part of
+  // the BERT operation specified by the `bert_operation_id` above.
+  repeated PerPortRequest per_port_requests = 2;
+  // If set to true, the results for all the per-port BERTs will be returned.
+  // `bert_operation_id` and `per_port_requests` will be ignored will be
+  // ignored in that case.
+  bool result_from_all_ports = 3;
+}
+
+message GetBERTResultResponse {
+  // Per-port BERT results/status.
+  message PerPortResponse {
+    // Path to the interface corresponding to the port.
+    types.Path interface = 1;
+    // BERT result get status for this port. Only if the status is
+    // BERT_STATUS_OK are the rest of the fields meaningful.
+    BertStatus status = 2;
+    // The ID of the BERT operation running on this port. Since the caller
+    // can query the BERT results for all the ports, ID can potentially be
+    // different for different ports.
+    string bert_operation_id = 3;
+    // The selected PRBS generating polynomial for BERT on this port.
+    PrbsPolynomial prbs_polynomial = 4;
+    // The last time BERT started on this port.
+    uint64 last_bert_start_timestamp = 5;
+    // The last time BERT results were read for this port.
+    uint64 last_bert_get_result_timestamp = 6;
+    // Indicate whether BERT peer lock has was established. If false,
+    // `bert_lock_lost`, `error_count_per_minute`, and `total_errors` will not
+    // be meaningful.
+    bool peer_lock_established = 7;
+    // Indicate whether BERT peer lock was lost after being established
+    // once.
+    bool peer_lock_lost = 8;
+    // Sequence of bit errors per min since lock was established.
+    repeated uint32 error_count_per_minute = 9;
+    // Total number of bit errors accumulated since lock was established.
+    uint64 total_errors = 10;
+  }
+  // Captures the BERT results on a per-port basis.
+  repeated PerPortResponse per_port_responses = 1;
+}

--- a/stratum/proto/gnoi/file/file.proto
+++ b/stratum/proto/gnoi/file/file.proto
@@ -1,0 +1,154 @@
+//
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package gnoi.file;
+
+import "gnoi/types/types.proto";
+import "gnoi/common/common.proto";
+
+option (types.gnoi_version) = "0.1.0";
+
+service File {
+  // Get reads and streams the contents of a file from the target.
+  // The file is streamed by sequential messages, each containing up to
+  // 64KB of data. A final message is sent prior to closing the stream
+  // that contains the hash of the data sent. An error is returned
+  // if the file does not exist or there was an error reading the file.
+  rpc Get(GetRequest) returns (stream GetResponse) {}
+
+  // TransferToRemote transfers the contents of a file from the target to a
+  // specified remote location. The response contains the hash of the data
+  // transferred. An error is returned if the file does not exist, the file
+  // transfer fails, or if there was an error reading the file. This is a
+  // blocking call until the file transfer is complete.
+  rpc TransferToRemote(TransferToRemoteRequest) returns (TransferToRemoteResponse) {}
+
+  // Put streams data into a file on the target. The file is sent in
+  // sequential messages, each message containing up to 64KB of data. A final
+  // message must be sent that includes the hash of the data sent. An
+  // error is returned if the location does not exist or there is an error
+  // writing the data. If no checksum is received, the target must assume the
+  // operation is incomplete and remove the partially transmitted file. The
+  // target should initially write the file to a temporary location so a failure
+  // does not destroy the original file.
+  rpc Put(stream PutRequest) returns (PutResponse) {}
+
+
+  // Stat returns metadata about a file on the target. An error is returned
+  // if the file does not exist of there is an error in accessing the metadata.
+  rpc Stat(StatRequest) returns (StatResponse) {}
+
+  // Remove removes the specified file from the target. An error is
+  // returned if the file does not exist, is a directory, or the remove
+  // operation encounters an error (e.g., permission denied).
+  rpc Remove(RemoveRequest) returns (RemoveResponse) {}
+}
+
+// A PutRequest is used to send data to be written on a file on the target.
+//
+// The initial message contains an Open message. The Open message contains
+// information name of the file and the file's permisssions.
+//
+// The remote_file must be an absolute path. If remote_file already exists on
+// the target, it is overwritten, otherwise it is created. If the path to
+// remote_file doesn't exist it will be created.
+//
+// The contents to be written are streamed through multiple messages using the
+// contents field. Each message may contain up to 64KB of data.
+//
+// The final message of the RPC contains the hash of the file contents.
+message PutRequest {
+  message Details {
+    string remote_file = 1;
+    // Permissions are represented as the octal format of standard UNIX
+    // file permissions.
+    // ex. 775: user read/write/execute, group read/write/execute,
+    // global read/execute.
+    uint32 permissions = 2;
+  }
+  oneof request {
+    Details open = 1;
+    bytes contents = 2;
+    types.HashType hash = 3; // hash of the file.
+  }
+}
+
+message PutResponse {}
+
+// A GetRequest specifies the remote_file to be streamed back
+// to the caller. The remote_file must be an absolute path to an
+// existing file.
+message GetRequest {
+  string remote_file = 1;
+}
+
+// A GetResponse either contains the next set of bytes read from the
+// file or, as the last message, the hash of the data.
+message GetResponse {
+  oneof response {
+    bytes contents = 1;
+    types.HashType hash = 2; // hash of the file.
+  }
+}
+
+// A TransferToRemoteRequest specifies the local path to transfer to and the
+// details on where to transfer the data from. The local_path must be an
+// absolute path to the file.
+message TransferToRemoteRequest {
+  string local_path = 1;
+
+  // Details to download the remote_file being requested to a remote location.
+  common.RemoteDownload remote_download = 2;
+}
+
+// A TransferToRemoteResponse contains the hash of the data transferred.
+message TransferToRemoteResponse {
+  types.HashType hash = 1; // hash of the file.
+}
+
+// StatRequest will list files at the provided path.
+message StatRequest {
+  string path = 1;
+}
+
+// StatResponse contains list of stat info of the provided path.
+message StatResponse {
+  repeated StatInfo stats = 1;
+}
+
+// StatInfo provides a file system information about a particular path.
+message StatInfo {
+  string path = 1;
+  uint64 last_modified = 2; // Nanoseconds since epoch.
+  // Permissions are represented as the octal format of standard UNIX
+  // file permissions.
+  // ex. 775: user read/write/execute, group read/write/execute,
+  // global read/execute.
+  uint32 permissions = 3;
+  uint64 size = 4;
+  // Default file creation mask. Represented as the octal format of
+  // standard UNIX mask.
+  uint32 umask = 5;
+}
+
+// A RemoveRequest specifies a file to be removed from the target.
+message RemoveRequest {
+  string remote_file = 1;
+}
+
+message RemoveResponse {}

--- a/stratum/proto/gnoi/system/system.proto
+++ b/stratum/proto/gnoi/system/system.proto
@@ -1,0 +1,310 @@
+//
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Generic Network Operation Interface, GNOI, defines a set of RPC's used for
+// the operational aspects of network targets. These services are meant to be
+// used in conjunction with GNMI for all target state and operational aspects
+// of a network target. The gnoi.system.Service is the only mandatory vendor
+// implementation.
+
+syntax = "proto3";
+
+package gnoi.system;
+
+import "gnoi/common/common.proto";
+import "gnoi/types/types.proto";
+
+option (types.gnoi_version) = "0.1.0";
+
+// The gNOI service is a collection of operational RPC's that allow for the
+// management of a target outside of the configuration and telemetry pipeline.
+service System {
+  // Ping executes the ping command on the target and streams back
+  // the results.  Some targets may not stream any results until all
+  // results are in.  If a packet count is not explicitly provided,
+  // 5 is used.
+  rpc Ping(PingRequest) returns (stream PingResponse) {}
+
+  // Traceroute executes the traceroute command on the target and streams back
+  // the results.  Some targets may not stream any results until all
+  // results are in.  If a hop count is not explicitly provided,
+  // 30 is used.
+  rpc Traceroute(TracerouteRequest) returns (stream TracerouteResponse) {}
+
+  // Time returns the current time on the target.  Time is typically used to
+  // test if a target is actually responding.
+  rpc Time(TimeRequest) returns (TimeResponse) {}
+
+  // SetPackage places a software package (possibly including bootable images)
+  // on the target. The file is sent in sequential messages, each message
+  // up to 64KB of data. A final message must be sent that includes the hash
+  // of the data sent. An error is returned if the location does not exist or
+  // there is an error writing the data. If no checksum is received, the target
+  // must assume the operation is incomplete and remove the partially
+  // transmitted file. The target should initially write the file to a temporary
+  // location so a failure does not destroy the original file.
+  rpc SetPackage(stream SetPackageRequest) returns (SetPackageResponse) {}
+
+  // SwitchControlProcessor will switch from the current route processor to the
+  // provided route processor. If the current route processor is the same as the
+  // one provided it is a NOOP. If the target does not exist an error is
+  // returned.
+  rpc SwitchControlProcessor(SwitchControlProcessorRequest) returns (SwitchControlProcessorResponse) {}
+
+  // Reboot causes the target to reboot, possibly at some point in the future.
+  // If the method of reboot is not supported then the Reboot RPC will fail.
+  // If the reboot is immediate the command will block until the subcomponents
+  // have restarted.
+  // If a reboot on the active control processor is pending the service must
+  // reject all other reboot requests.
+  // If a reboot request for active control processor is initiated with other
+  // pending reboot requests it must be rejected.
+  rpc Reboot(RebootRequest) returns (RebootResponse) {}
+
+  // RebootStatus returns the status of reboot for the target.
+  rpc RebootStatus(RebootStatusRequest) returns (RebootStatusResponse) {}
+
+  // CancelReboot cancels any pending reboot request.
+  rpc CancelReboot(CancelRebootRequest) returns (CancelRebootResponse) {}
+
+  // TODO(hines): Add RotateCertificate workflow
+  // TODO(hines): Add SetSSHPrivateKey
+}
+
+message SwitchControlProcessorRequest {
+  types.Path control_processor = 1;
+}
+
+message SwitchControlProcessorResponse {
+  types.Path control_processor = 1;
+  string version = 2; // Current software version.
+  int64 uptime = 3;   // Uptime in nanoseconds since epoch.
+}
+
+// A RebootRequest requests the specified target be rebooted using the specified
+// method aftar the specified delay.  Only the DEFAULT method with a delay of 0
+// is guaranteed to be accepted for all target types.
+message RebootRequest {
+  RebootMethod method = 1;
+  // Delay in nanoseconds before issuing reboot.
+  uint64 delay = 2;
+  // Informational reason for the reboot.
+  string message = 3;
+  // Optional sub-components to reboot.
+  repeated types.Path subcomponents = 4;
+  // Force reboot if sanity checks fail. (ex. uncommited configuration)
+  bool force = 5;
+}
+
+message RebootResponse {
+}
+
+// A RebootMethod determines what should be done with a target when a Reboot is
+// requested.  Only the COLD method is required to be supported by all
+// targets.  Methods the target does not support should result in failure.
+//
+// It is vendor defined if a WARM reboot is the same as an NSF reboot.
+enum RebootMethod {
+  UNKNOWN = 0;     // Invalid default method.
+  COLD = 1;        // Shutdown and restart OS and all hardware.
+  POWERDOWN = 2;   // Halt and power down, if possible.
+  HALT = 3;        // Halt, if possible.
+  WARM = 4;        // Reload configuration but not underlying hardware.
+  NSF = 5;         // Non-stop-forwarding reboot, if possible.
+  RESET = 6;       // Reboot to factory defaults.
+  POWERUP = 7;     // Apply power, no-op if power is already on.
+}
+
+// A CancelRebootRequest requests the cancelation of any outstanding reboot
+// request.
+message CancelRebootRequest {
+  string message = 1;      // informational reason for the cancel
+  repeated types.Path subcomponents = 2; // optional sub-components.
+}
+
+message CancelRebootResponse {
+}
+
+message RebootStatusRequest {
+  repeated types.Path subcomponents = 1; // optional sub-component.
+}
+
+message RebootStatusResponse {
+  bool active = 1;      // If reboot is active.
+  uint64 wait = 2;      // Time left until reboot.
+  uint64 when = 3;      // Time to reboot in nanoseconds since the epoch.
+  string reason = 4;    // Reason for reboot.
+  uint32 count = 5;     // Number of reboots since active.
+}
+
+// A TimeRequest requests the current time accodring to the target.
+message TimeRequest {
+}
+
+message TimeResponse {
+  uint64 time = 1;           // Current time in nanoseconds since epoch.
+}
+
+// A PingRequest describes the ping operation to perform.  Only the destination
+// fields is required.  Any field not specified is set to a reasonable server
+// specified value.  Not all fields are supported by all vendors.
+//
+// A count of 0 defaults to a vendor specified value, typically 5.  A count of
+// -1 means continue until the RPC times out or is canceled.
+//
+// If the interval is -1 then a flood ping is issued.
+//
+// If the size is 0, the vendor default size will be used (typically 56 bytes).
+message PingRequest {
+  string destination = 1;   // Destination address to ping. required.
+  string source = 2;        // Source address to ping from.
+  int32 count = 3;          // Number of packets.
+  int64 interval = 4;       // Nanoseconds between requests.
+  int64 wait = 5;           // Nanoseconds to wait for a response.
+  int32 size = 6;           // Size of request packet. (excluding ICMP header)
+  bool do_not_fragment = 7; // Set the do not fragment bit. (IPv4 destinations)
+  bool do_not_resolve = 8;  // Do not try resolve the address returned.
+  types.L3Protocol l3protocol = 9; // Layer3 protocol requested for the ping.
+}
+
+// A PingResponse represents either the reponse to a single ping packet
+// (the bytes field is non-zero) or the summary statistics (sent is non-zero).
+//
+// For a single ping packet, time is the round trip time, in nanoseconds.  For
+// summary statistics, it is the time spent by the ping operation.  The time is
+// not always present in summary statistics.  The std_dev is not always present
+// in summary statistics.
+message PingResponse {
+  string source = 1;        // Source of received bytes.
+  int64 time = 2;
+
+  int32 sent = 3;           // Total packets sent.
+  int32 received = 4;       // Total packets received.
+  int64 min_time = 5;       // Minimum round trip time in nanoseconds.
+  int64 avg_time = 6;       // Average round trip time in nanoseconds.
+  int64 max_time = 7;       // Maximum round trip time in nanoseconds.
+  int64 std_dev = 8;        // Standard deviation in round trip time.
+
+  int32 bytes = 11;         // Bytes received.
+  int32 sequence = 12;      // Sequence number of received packet.
+  int32 ttl = 13;           // Remaining time to live value.
+}
+
+// A TracerouteRequest describes the traceroute operation to perform.  Only the
+// destination field is required.  Any field not specified is set to a
+// reasonable server specified value.  Not all fields are supported by all
+// vendors.
+//
+// If the hop_count is -1 the traceroute will continue forever.
+//
+message TracerouteRequest {
+  string source = 1;         // Source address to ping from.
+  string destination = 2;    // Destination address to ping.
+  uint32 initial_ttl = 3;    // Initial TTL. (default=1)
+  int32 max_ttl = 4;         // Maximum number of hops. (default=30)
+  int64 wait = 5;            // Nanoseconds to wait for a response.
+  bool do_not_fragment = 6;  // Set the do not fragment bit. (IPv4 destinations)
+  bool do_not_resolve = 7;   // Do not try resolve the address returned.
+  types.L3Protocol l3protocol = 8; // Layer-3 protocol requested for the ping.
+  enum L4Protocol {
+    ICMP = 0; // Use ICMP ECHO for probes.
+    TCP = 1;  // Use TCP SYN for probes.
+    UDP = 2;  // Use UDP for probes.
+  }
+  L4Protocol l4protocol = 9;
+}
+
+// A TraceRouteResponse contains the result of a single traceoute packet.
+//
+// There may be an optional initial response that provides information about the
+// traceroute request itself and contains at least one of the fields in the the
+// initial block of fields and none of the fields following that block.  All
+// subsequent responses should not contain any of these fields.
+//
+// Typically multiple responses are received for each hop, as the packets are
+// received.
+//
+// The mpls field maps names to values.  Example names include "Label", "CoS",
+// "TTL", "S", and "MRU".
+// [Perhaps we should list the canonical names that must be used when
+// applicable].
+message TracerouteResponse {
+  // The following fields are only filled in for the first message.
+  // If any of these fields are specified, all fields following this
+  // block are left unspecified.
+  string destination_name = 1;
+  string destination_address = 2;
+  int32 hops = 3;
+  int32 packet_size = 4;
+
+  // State is the resulting state of a single traceoroute packet.
+  enum State {
+    DEFAULT = 0;               // Normal hop response.
+    NONE = 1;                  // No response.
+    UNKNOWN = 2;               // Unknown response state.
+    ICMP = 3;                  // See icmp_code field.
+    HOST_UNREACHABLE = 4;      // Host unreachable.
+    NETWORK_UNREACHABLE = 5;   // Network unreachable.
+    PROTOCOL_UNREACHABLE = 6;  // Protocol unreachable.
+    SOURCE_ROUTE_FAILED = 7;   // Source route failed.
+    FRAGMENTATION_NEEDED = 8;  // Fragmentation needed.
+    PROHIBITED = 9;            // Communication administratively prohibited.
+    PRECEDENCE_VIOLATION = 10; // Host precedence violation.
+    PRECEDENCE_CUTOFF = 11;    // Precedence cutoff in  effect.
+  }
+
+  // The following fields provide the disposition of a single traceroute
+  // packet.
+  int32 hop = 5;                // Hop number. required.
+  string address = 6;           // Address of responding hop. required.
+  string name = 7;              // Name of responding hop.
+  int64 rtt = 8;                // Round trip time in nanoseconds.
+  State state = 9;              // State of this hop.
+  int32 icmp_code = 10;          // Code terminating hop.
+  map<string, string> mpls = 11; // MPLS key/value pairs.
+  repeated int32 as_path = 12;   // AS path.
+}
+
+// Package defines a single package file to be placed on the target.
+message Package {
+  // Destination path and filename of the package.
+  string filename = 1;
+  // Version of the package. (vendor internal name)
+  string version = 4;
+  // Indicates that the package should be made active after receipt on
+  // the device. For system image packages, the new image is expected to
+  // be active after a reboot.
+  bool activate = 5;
+  // Details for the device to download the package from a remote location.
+  common.RemoteDownload remote_download = 6;
+}
+
+// SetPackageRequest will place the package onto the target and optionally mark
+// it as the next bootable image. The initial message must be a package
+// message containing the filename and information about the file. Following the
+// initial message the contents are then streamed in maximum 64k chunks. The
+// final message must be a hash message contains the hash of the file contents.
+message SetPackageRequest {
+  oneof request {
+   Package package = 1;
+   bytes contents = 2;
+   types.HashType hash = 3;    // Verification hash of data.
+ }
+}
+
+
+message SetPackageResponse {
+}

--- a/stratum/proto/gnoi/types/types.proto
+++ b/stratum/proto/gnoi/types/types.proto
@@ -1,0 +1,73 @@
+//
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+
+package gnoi.types;
+
+// Define a protobuf FileOption that defines the gNOI service version.
+extend google.protobuf.FileOptions {
+  // The gNOI service semantic version.
+  string gnoi_version = 1002;
+}
+
+// Generic Layer 3 Protocol enumeration.
+enum L3Protocol {
+  UNSPECIFIED = 0;
+  IPV4 = 1;
+  IPV6 = 2;
+}
+
+// HashType defines the valid hash methods for data verification.  UNSPECIFIED
+// should be treated an error.
+message HashType {
+  enum HashMethod {
+    UNSPECIFIED = 0;
+    SHA256 = 1;
+    SHA512 = 2;
+    MD5 = 3;
+  }
+  HashMethod method = 1;
+  bytes hash = 2;
+}
+
+// Path encodes a data tree path as a series of repeated strings, with
+// each element of the path representing a data tree node name and the
+// associated attributes.
+// Reference: gNMI Specification Section 2.2.2.
+message Path {
+  string origin = 2;                              // Label to disambiguate path.
+  repeated PathElem elem = 3;                     // Elements of the path.
+}
+
+// PathElem encodes an element of a gNMI path, along with any attributes (keys)
+// that may be associated with it.
+// Reference: gNMI Specification Section 2.2.2.
+message PathElem {
+  string name = 1;                    // The name of the element in the path.
+  map<string, string> key = 2;        // Map of key (attribute) name to value.
+}
+
+// Credentials defines credentials needed to perform authentication on a device.
+message Credentials {
+  string username = 1;
+  oneof password {
+    string cleartext = 2;
+    HashType hashed = 3;
+  }
+}

--- a/stratum/proto/openconfig/CMakeLists.txt
+++ b/stratum/proto/openconfig/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Builds stratum/proto/openconfig
+# Builds OpenConfig Protobuf library
+
 cmake_minimum_required(VERSION 3.5)
 
 set(YGOT_PROTO_PATH github.com/openconfig/ygot/proto)

--- a/stratum/proto/openconfig/CMakeLists.txt
+++ b/stratum/proto/openconfig/CMakeLists.txt
@@ -1,0 +1,74 @@
+# Builds stratum/proto/openconfig
+cmake_minimum_required(VERSION 3.5)
+
+set(YGOT_PROTO_PATH github.com/openconfig/ygot/proto)
+
+set(YGOT_PROTO_FILES
+    ${YGOT_PROTO_PATH}/yext/yext.proto
+    ${YGOT_PROTO_PATH}/ywrapper/ywrapper.proto
+)
+
+set(OPENCONFIG_PROTO_FILES
+    openconfig/enums/enums.proto
+    openconfig/openconfig.proto
+)
+
+set(STRATUM_OC_PROTO_FILES
+    stratum/public/proto/openconfig-goog-bcm.proto
+)
+
+generate_proto_files("${YGOT_PROTO_FILES}" "${PROTO_PARENT_DIR}")
+generate_proto_files("${OPENCONFIG_PROTO_FILES}" "${PROTO_PARENT_DIR}")
+generate_proto_files("${STRATUM_OC_PROTO_FILES}" "${STRATUM_SOURCE_DIR}")
+
+# ygot_proto_o
+add_library(ygot_proto_o OBJECT
+    ${PROTO_OUT_DIR}/${YGOT_PROTO_PATH}/yext/yext.pb.cc
+    ${PROTO_OUT_DIR}/${YGOT_PROTO_PATH}/yext/yext.pb.h
+    ${PROTO_OUT_DIR}/${YGOT_PROTO_PATH}/ywrapper/ywrapper.pb.cc
+    ${PROTO_OUT_DIR}/${YGOT_PROTO_PATH}/ywrapper/ywrapper.pb.h
+)
+
+target_include_directories(ygot_proto_o PRIVATE ${PROTO_OUT_DIR})
+
+# openconfig_enums_proto_o
+add_library(openconfig_enums_proto_o OBJECT
+    ${PROTO_OUT_DIR}/openconfig/enums/enums.pb.cc
+    ${PROTO_OUT_DIR}/openconfig/enums/enums.pb.h
+)
+
+add_dependencies(openconfig_enums_proto_o ygot_proto_o)
+
+target_include_directories(
+    openconfig_enums_proto_o PRIVATE ${PROTO_OUT_DIR})
+
+# openconfig_proto_o
+add_library(openconfig_proto_o OBJECT
+    ${PROTO_OUT_DIR}/openconfig/openconfig.pb.cc
+    ${PROTO_OUT_DIR}/openconfig/openconfig.pb.h
+)
+
+add_dependencies(openconfig_proto_o openconfig_enums_proto_o)
+
+target_include_directories(openconfig_proto_o PRIVATE ${PROTO_OUT_DIR})
+
+# openconfig_goog_bcm_proto_o
+add_library(openconfig_goog_bcm_proto_o OBJECT
+    ${PROTO_OUT_DIR}/stratum/public/proto/openconfig-goog-bcm.pb.cc
+    ${PROTO_OUT_DIR}/stratum/public/proto/openconfig-goog-bcm.pb.h
+)
+
+add_dependencies(openconfig_goog_bcm_proto_o ygot_proto_o)
+
+target_include_directories(
+    openconfig_goog_bcm_proto_o PRIVATE ${PROTO_OUT_DIR})
+
+# openconfig_proto
+add_library(openconfig_proto SHARED
+    $<TARGET_OBJECTS:ygot_proto_o>
+    $<TARGET_OBJECTS:openconfig_enums_proto_o>
+    $<TARGET_OBJECTS:openconfig_proto_o>
+    $<TARGET_OBJECTS:openconfig_goog_bcm_proto_o>
+)
+
+install(TARGETS openconfig_proto LIBRARY)


### PR DESCRIPTION
- Added copies of the gnoi files needed to build Stratum.

- Updated CMake to build Protobuf libraries for gNOI and Procmon.

- Moved code to build the gnmi, gnoi, and openconfig Protobuf libraries to their own CMakeLists files.

- Provided an optional target to download and patch the gnoi files.

- Added a README file for the gnoi files.

Signed-off-by: Derek G Foster <derek.foster@intel.com>