### PR TITLE
Revise naming conventions for CMake install path variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,15 +15,15 @@ include(CMakePrintHelpers)
 # Symbolic path definitions #
 #############################
 
-set(DEPEND_INSTALL_PREFIX "" CACHE PATH "Dependencies install directory")
+set(DEPEND_INSTALL_DIR "" CACHE PATH "Dependencies install directory")
 
-set(OVS_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE PATH
+set(OVS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}" CACHE PATH
     "OVS install directory")
 
 set(OVS_SOURCE_DIR "${CMAKE_SOURCE_DIR}/ovs/ovs" CACHE PATH
     "OVS source directory")
 
-set(SDE_INSTALL_PREFIX "/opt/sde" CACHE PATH "SDE install directory")
+set(SDE_INSTALL_DIR "/opt/sde" CACHE PATH "SDE install directory")
 
 #################
 # Build options #
@@ -70,9 +70,9 @@ if(DPDK_TARGET)
     add_compile_options(-DP4OVS_CHANGES)
 endif()
 
-if(DEPEND_INSTALL_PREFIX)
-    include_directories(${DEPEND_INSTALL_PREFIX}/include)
-    link_directories(${DEPEND_INSTALL_PREFIX}/lib)
+if(DEPEND_INSTALL_DIR)
+    include_directories(${DEPEND_INSTALL_DIR}/include)
+    link_directories(${DEPEND_INSTALL_DIR}/lib)
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -81,10 +81,10 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # External packages #
 #####################
 
-if(DEPEND_INSTALL_PREFIX)
-    list(APPEND CMAKE_PREFIX_PATH ${DEPEND_INSTALL_PREFIX})
+if(DEPEND_INSTALL_DIR)
+    list(APPEND CMAKE_PREFIX_PATH ${DEPEND_INSTALL_DIR})
 endif()
-list(APPEND CMAKE_PREFIX_PATH ${SDE_INSTALL_PREFIX})
+list(APPEND CMAKE_PREFIX_PATH ${SDE_INSTALL_DIR})
 
 if(WITH_STRATUM)
     find_package(absl REQUIRED)

--- a/make-all.sh
+++ b/make-all.sh
@@ -53,7 +53,7 @@ if [ -z "${SDE_INSTALL}" ]; then
 fi
 
 if [ -n "${DEPEND_INSTALL}" ]; then
-    DEPEND_INSTALL_OPTION=-DDEPEND_INSTALL_PREFIX=${DEPEND_INSTALL}
+    DEPEND_INSTALL_OPTION=-DDEPEND_INSTALL_DIR=${DEPEND_INSTALL}
 fi
 
 if [ ${DEVELOP} -ne 0 ]; then
@@ -74,8 +74,8 @@ cmake --build ${OVS_BUILD} -j6 -- V=0
 # Build the rest of the recipe.
 cmake -S . -B build \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DOVS_INSTALL_PREFIX=${OVS_INSTALL} \
-    -DSDE_INSTALL_PREFIX=${SDE_INSTALL} \
+    -DOVS_INSTALL_DIR=${OVS_INSTALL} \
+    -DSDE_INSTALL_DIR=${SDE_INSTALL} \
     ${DEPEND_INSTALL_OPTION} \
     -D${TARGET_TYPE}_TARGET=ON
 

--- a/ovs/CMakeLists.txt
+++ b/ovs/CMakeLists.txt
@@ -9,9 +9,6 @@ project(ovs LANGUAGES C)
 
 include(ExternalProject)
 
-set(OVS_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE PATH
-    "OVS install directory")
-
 set(OVS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ovs" CACHE PATH
     "OVS source directory")
 
@@ -26,14 +23,14 @@ ExternalProject_Add(ovs
     cd ${OVS_SOURCE_DIR} && ./boot.sh
   COMMAND
     ${OVS_SOURCE_DIR}/configure
-    --prefix=${OVS_INSTALL_PREFIX}
+    --prefix=${CMAKE_INSTALL_PREFIX}
     ${P4OVS_OPTION}
     --disable-ssl
   BINARY_DIR
     ${CMAKE_CURRENT_BINARY_DIR}
   BUILD_COMMAND
-    # Using $(MAKE) causes CMake not to disable the jobserver, allowing
-    # us to do parallel builds. The number of jobs defaults the -jN value
+    # Using $(MAKE) causes CMake not to disable the jobserver, allowing us
+    # to do parallel builds. The number of jobs defaults to the -jN value
     # specified on the CMake command line IN ADDITION TO any CMake jobs.
     # This does not apply in our case because we've made p4ovs dependent
     # on ovs, so CMake won't continue until the ovs build completes.

--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -110,7 +110,7 @@ add_library(stratum_hal_lib_common_o OBJECT
 
 target_include_directories(stratum_hal_lib_common_o PRIVATE
     ${STRATUM_INCLUDES}
-    ${SDE_INSTALL_PREFIX}/include
+    ${SDE_INSTALL_DIR}/include
 )
 
 add_dependencies(stratum_hal_lib_common_o
@@ -270,7 +270,7 @@ target_compile_definitions(stratum_target_o PRIVATE SDE_9_11_0)
 
 target_include_directories(stratum_target_o PRIVATE
     ${STRATUM_INCLUDES}
-    ${SDE_INSTALL_PREFIX}/include
+    ${SDE_INSTALL_DIR}/include
 )
 
 add_dependencies(stratum_target_o stratum_proto)
@@ -303,7 +303,7 @@ target_compile_definitions(stratum_main_o PRIVATE SDE_9_5_0)
 
 target_include_directories(stratum_main_o PRIVATE
     ${STRATUM_INCLUDES}
-    ${SDE_INSTALL_PREFIX}/include
+    ${SDE_INSTALL_DIR}/include
 )
 
 add_dependencies(stratum_main_o stratum_proto)
@@ -348,23 +348,23 @@ target_link_libraries(stratum PUBLIC
     p4v1_proto
 )
 
-find_library(LIBTDI tdi ${SDE_INSTALL_PREFIX}/lib)
+find_library(LIBTDI tdi ${SDE_INSTALL_DIR}/lib)
 if(NOT LIBTDI)
     message(FATAL_ERROR "Cannot find library: tdi")
 endif()
 
-find_library(LIBTDI_JSON_PARSER tdi_json_parser ${SDE_INSTALL_PREFIX}/lib)
+find_library(LIBTDI_JSON_PARSER tdi_json_parser ${SDE_INSTALL_DIR}/lib)
 if(NOT LIBTDI_JSON_PARSER)
     message(FATAL_ERROR "Cannot find library: tdi_json_parser")
 endif()
 
-find_library(LIBTARGET_SYS target_sys ${SDE_INSTALL_PREFIX}/lib)
+find_library(LIBTARGET_SYS target_sys ${SDE_INSTALL_DIR}/lib)
 if(NOT LIBTARGET_SYS)
     message(FATAL_ERROR "Cannot find library: target_sys")
 endif()
 
 if(TOFINO_TARGET)
-    find_library(LIBDRIVER driver ${SDE_INSTALL_PREFIX}/lib)
+    find_library(LIBDRIVER driver ${SDE_INSTALL_DIR}/lib)
     if(NOT LIBDRIVER)
         message(FATAL_ERROR "Cannot find library: driver")
     endif()
@@ -376,17 +376,17 @@ if(TOFINO_TARGET)
         ${LIBTARGET_SYS}
     )
 elseif(DPDK_TARGET)
-    find_library(LIBDRIVER driver ${SDE_INSTALL_PREFIX}/lib)
+    find_library(LIBDRIVER driver ${SDE_INSTALL_DIR}/lib)
     if(NOT LIBDRIVER)
         message(FATAL_ERROR "Cannot find library: driver")
     endif()
 
-    find_library(LIBBF_SWITCHD bf_switchd_lib ${SDE_INSTALL_PREFIX}/lib)
+    find_library(LIBBF_SWITCHD bf_switchd_lib ${SDE_INSTALL_DIR}/lib)
     if(NOT LIBBF_SWITCHD)
         message(FATAL_ERROR "Cannot find library: bf_switchd_lib")
     endif()
 
-    find_library(LIBTARGET_UTILS target_utils ${SDE_INSTALL_PREFIX}/lib)
+    find_library(LIBTARGET_UTILS target_utils ${SDE_INSTALL_DIR}/lib)
     if(NOT LIBTARGET_UTILS)
         message(FATAL_ERROR "Cannot find library: target_utils")
     endif()


### PR DESCRIPTION
Renamed CMake variables to use `INSTALL_DIR` for input install paths and `INSTALL_PREFIX` for output install paths.

Input install paths:
- DEPEND_INSTALL_DIR (optional)
- OVS_INSTALL_DIR (optional)
- SDE_INSTALL_DIR (required)

Output install path:
- CMAKE_INSTALL_PREFIX (required)

CMAKE_INSTALL_PREFIX is also used as an input path.

Signed-off-by: Derek G Foster <derek.foster@intel.com>