### PR TITLE
Update krnlmon reference point

### DIFF
--- a/krnlmon/CMakeLists.txt
+++ b/krnlmon/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.15)
 
 project(krnlmon)
 
-include_directories(.)
-
 set(SAI_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/SAI" CACHE PATH
     "SAI source directory")
 


### PR DESCRIPTION
- Also removed unnecessary include_directories() command.

Signed-off-by: Derek G Foster <derek.foster@intel.com>