### PR TITLE
Fix tofino build breakage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,4 +116,6 @@ if(WITH_STRATUM)
 endif()
 
 add_subdirectory(infrap4d)
-add_subdirectory(ovs-p4rt)
+if(DPDK_TARGET)
+    add_subdirectory(ovs-p4rt)
+endif()


### PR DESCRIPTION
Signed-off-by: Ravi Vantipalli <ravi.vantipalli@intel.com>

Breakage observed with below command
./make-all.sh --dep-install /usr/local/ --sde-install $SDE_INSTALL --no-ovs