### PR TITLE
Disable krnlmon and sidecar library on main branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ endif()
 ##################
 
 if(DPDK_TARGET)
-    set(WITH_KRNLMON ON)
+    set(WITH_KRNLMON OFF)
 endif()
 
 if(WITH_KRNLMON)
@@ -116,6 +116,6 @@ if(WITH_STRATUM)
 endif()
 
 add_subdirectory(infrap4d)
-if(DPDK_TARGET)
+if(WITH_KRNLMON)
     add_subdirectory(ovs-p4rt)
 endif()


### PR DESCRIPTION
Krnlmon support will be available as part of different branch until issues with latest P4 SDE for DPDK are resolved

Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>