### PR TITLE
Update readme to export SDE install env variable to sudo user

### DIFF
--- a/docs/ipdk-dpdk.md
+++ b/docs/ipdk-dpdk.md
@@ -82,7 +82,7 @@ sudo ./install/sbin/infrap4d
 
 Open a new terminal for setting the pipeline and trying the sample P4 program. Set all the environment variables and export all environment variables to sudo user
 ```bash
-   alias sudo='sudo PATH="$PATH" HOME="$HOME" LD_LIBRARY_PATH="$LD_LIBRARY_PATH"'
+   alias sudo='sudo PATH="$PATH" HOME="$HOME" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" SDE_INSTALL="$SDE_INSTALL"'
 ```
 
 #### Create 2 TAP ports

--- a/p4src/linux_networking/README_LINUX_NETWORKING.md
+++ b/p4src/linux_networking/README_LINUX_NETWORKING.md
@@ -84,6 +84,7 @@ Ex: vlan1, vlan2, vlan3 …. vlan4094
 
 #### 2. Export the environment variables LD_LIBRARY_PATH, IPDK_RECIPE and SDE_INSTALL and start running the infrap4d
 ```
+    alias sudo='sudo PATH="$PATH" HOME="$HOME" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" SDE_INSTALL="$SDE_INSTALL"
     sudo $IPDK_RECIPE/install/bin/infrap4d
 ```
 #### 3. Create two VHOST user ports:


### PR DESCRIPTION
Latest SDE use getenv on SDE_INSTALL variable to generate pipeline information dynamically instead of using spec file. Since, infrap4d executable is run in sudo mode, if environment variable is not exported for sudo user, it will failure generating pipeline info and setting the pipeline will fail.

Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>