### PR TITLE
Dependency setup script improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,11 @@
 [submodule "ovs/ovs"]
 	path = ovs/ovs
 	url = https://github.com/ipdk-io/ovs
-	branch = split-arch
+	branch = ipdk-latest
 [submodule "stratum/stratum"]
 	path = stratum/stratum
 	url = https://github.com/ipdk-io/stratum-dev.git
+	branch = split-arch
 [submodule "stratum/p4runtime"]
 	path = stratum/p4runtime
 	url = https://github.com/p4lang/p4runtime.git

--- a/setup/.gitignore
+++ b/setup/.gitignore
@@ -1,10 +1,15 @@
+# build directories
 /build
+/install
+
+# download directories
 /abseil-cpp
-/protobuf
-/grpc
 /cctz
 /gflags
 /glog
 /gmock-gbl
+/grpc
 /gtest
 /json
+/protobuf
+/zlib

--- a/setup/CMakeLists.txt
+++ b/setup/CMakeLists.txt
@@ -8,6 +8,10 @@ project(dependencies VERSION 1 LANGUAGES C CXX)
 include(ExternalProject)
 include(CMakePrintHelpers)
 
+if(${CMAKE_VERSION} VERSION_EQUAL 3.24 OR ${CMAKE_VERSION} VERSION_EQUAL 3.25)
+  message(FATAL_ERROR "Protobuf build is broken in CMake version ${CMAKE_VERSION}")
+endif()
+
 option(ON_DEMAND    "Build targets on demand" OFF)
 option(USE_SUDO     "Use sudo when installing" OFF)
 
@@ -48,29 +52,55 @@ if(ON_DEMAND)
   set_target_properties(abseil-cpp PROPERTIES EXCLUDE_FROM_ALL TRUE)
 endif()
 
+########
+# ZLIB #
+########
+
+set(ZLIB_GIT_TAG 04f42ceca40f73e2978b50e93806c2a18c1281fc) # v1.2.13
+
+ExternalProject_Add(zlib
+  GIT_REPOSITORY  https://github.com/madler/zlib
+  GIT_TAG         ${ZLIB_GIT_FLAG}
+  GIT_PROGRESS    ON
+
+  SOURCE_DIR
+    ${CMAKE_SOURCE_DIR}/zlib
+  CMAKE_ARGS
+    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+  INSTALL_COMMAND
+    ${SUDO_CMD} ${CMAKE_MAKE_PROGRAM} install
+    ${LDCONFIG_CMD}
+)
+if(ON_DEMAND)
+  set_target_properties(zlib PROPERTIES EXCLUDE_FROM_ALL TRUE)
+endif()
+
 ############
 # PROTOBUF #
 ############
 
-set(PROTOBUF_GIT_TAG v3.18.1)
+set(PROTOBUF_GIT_TAG 0dab03ba7bc438d7ba3eac2b2c1eb39ed520f928) # v3.18.1
 
 ExternalProject_Add(protobuf
   GIT_REPOSITORY  https://github.com/google/protobuf.git
   GIT_TAG         ${PROTOBUF_GIT_TAG}
-  GIT_SHALLOW     ON    # depth=1
   GIT_PROGRESS    ON
 
   SOURCE_DIR
     ${CMAKE_SOURCE_DIR}/protobuf
   CMAKE_ARGS
-    -S ${CMAKE_SOURCE_DIR}/protobuf/cmake
     -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
     -DCMAKE_POSITION_INDEPENDENT_CODE=on
+    -DCMAKE_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}
     -DBUILD_SHARED_LIBS=on
     -Dprotobuf_BUILD_TESTS=off
+  SOURCE_SUBDIR
+    cmake
   INSTALL_COMMAND
     ${SUDO_CMD} ${CMAKE_MAKE_PROGRAM} install
     ${LDCONFIG_CMD}
+  DEPENDS
+    zlib
 )
 if(ON_DEMAND)
   set_target_properties(protobuf PROPERTIES EXCLUDE_FROM_ALL TRUE)
@@ -88,13 +118,22 @@ ExternalProject_Add(grpc
   GIT_SHALLOW     ON    # depth=1
   GIT_PROGRESS    ON
 
+  PATCH_COMMAND
+    patch -i ${CMAKE_SOURCE_DIR}/grpc.patch -p1
   SOURCE_DIR
     ${CMAKE_SOURCE_DIR}/grpc
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    -DCMAKE_INSTALL_RPATH=$ORIGIN
     -DCMAKE_POSITION_INDEPENDENT_CODE=on
+    -DCMAKE_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}
     -DBUILD_SHARED_LIBS=on
+    -DgRPC_ABSL_PROVIDER=package
+    -DgRPC_PROTOBUF_PROVIDER=package
+	# gRPC builds BoringSSL, which is incompatible with libpython.
+	# We use whatever version of OpenSSL is installed instead.
     -DgRPC_SSL_PROVIDER=package
+    -DgRPC_ZLIB_PROVIDER=package
     -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=off
     -DgRPC_BUILD_GRPC_NODE_PLUGIN=off
     -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=off
@@ -108,6 +147,7 @@ ExternalProject_Add(grpc
   DEPENDS
     abseil-cpp
     protobuf
+    zlib
 )
 if(ON_DEMAND)
   set_target_properties(grpc PROPERTIES EXCLUDE_FROM_ALL TRUE)
@@ -177,6 +217,7 @@ ExternalProject_Add(glog
     ${CMAKE_SOURCE_DIR}/glog
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    -DCMAKE_INSTALL_RPATH=$ORIGIN
     -Dgflags_DIR:PATH=${CMAKE_INSTALL_PREFIX}/lib/cmake/gflags
     -DWITH_GTEST=OFF
   INSTALL_COMMAND
@@ -221,6 +262,7 @@ ExternalProject_Add(gtest
     ${CMAKE_SOURCE_DIR}/gtest
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    -DCMAKE_INSTALL_RPATH=$ORIGIN
     -DBUILD_SHARED_LIBS=on
   INSTALL_COMMAND
     ${SUDO_CMD} ${CMAKE_MAKE_PROGRAM} install

--- a/setup/CMakeLists.txt
+++ b/setup/CMakeLists.txt
@@ -12,7 +12,7 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.24)
   message(STATUS "CMake version is ${CMAKE_VERSION}")
   message(STATUS "Protobuf build is broken in CMake 3.24.x and 3.25.x")
   message(STATUS "Versions 3.16 through 3.22 are recommended")
-  message(FATAL_ERROR)
+  message(FATAL_ERROR "Invalid CMake version")
 endif()
 
 option(ON_DEMAND    "Build targets on demand" OFF)

--- a/setup/CMakeLists.txt
+++ b/setup/CMakeLists.txt
@@ -8,8 +8,11 @@ project(dependencies VERSION 1 LANGUAGES C CXX)
 include(ExternalProject)
 include(CMakePrintHelpers)
 
-if(${CMAKE_VERSION} VERSION_EQUAL 3.24 OR ${CMAKE_VERSION} VERSION_EQUAL 3.25)
-  message(FATAL_ERROR "Protobuf build is broken in CMake version ${CMAKE_VERSION}")
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.24)
+  message(STATUS "CMake version is ${CMAKE_VERSION}")
+  message(STATUS "Protobuf build is broken in CMake 3.24.x and 3.25.x")
+  message(STATUS "Versions 3.16 through 3.22 are recommended")
+  message(FATAL_ERROR)
 endif()
 
 option(ON_DEMAND    "Build targets on demand" OFF)

--- a/setup/cleanup.sh
+++ b/setup/cleanup.sh
@@ -1,1 +1,1 @@
-rm -fr abseil-cpp build cctz gflags glog gmock-gbl grpc gtest json protobuf
+rm -fr abseil-cpp build cctz gflags glog gmock-gbl grpc gtest json protobuf zlib

--- a/setup/grpc.patch
+++ b/setup/grpc.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 824886600..5ba8f9384 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11173,6 +11173,10 @@ add_executable(grpc_cpp_plugin
+   src/compiler/cpp_plugin.cc
+ )
+ 
++set_target_properties(grpc_cpp_plugin
++  PROPERTIES INSTALL_RPATH $ORIGIN/../lib
++)
++
+ target_include_directories(grpc_cpp_plugin
+   PRIVATE
+     ${CMAKE_CURRENT_SOURCE_DIR}
+@@ -11368,6 +11372,10 @@ add_executable(grpc_python_plugin
+   src/compiler/python_plugin.cc
+ )
+ 
++set_target_properties(grpc_python_plugin
++  PROPERTIES INSTALL_RPATH $ORIGIN/../lib
++)
++
+ target_include_directories(grpc_python_plugin
+   PRIVATE
+     ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
1) Add a check to abort the script if the CMake version is 3.24
   or 3.25. The Protobuf build fails under these versions due to
   a bug in CMake.

2) Modify script to use SHA1 tags for gRPC and Protobuf, to avoid
   unnecessary updates.

3) Specify CMAKE_PREFIX_PATH when building Protobuf and gRPC, to
   ensure that they link against the newly built versions of
   dependent libraries.

4) Download and build v1.2.13 of zlib instead of using the version
   packaged with gRPC, which has known security vulnerabilities.

5) Use the SOURCE_SUBDIR ExternalProject option when building
   Protobuf.

6) Specify the CMAKE_INSTALL_RPATH option when building gRPC,
   glog, and gtest. Use PATCH_COMMAND to update the gRPC
   CMakeLists.txt file to set the INSTALL_RPATH property
   when building the C++ and Python plugins.

Signed-off-by: Derek G Foster <derek.foster@intel.com>