### PR TITLE
Introduce daemon support for infrap4d for DPDK target

### DIFF
--- a/docs/ipdk-dpdk.md
+++ b/docs/ipdk-dpdk.md
@@ -91,6 +91,10 @@ alias sudo='sudo PATH="$PATH" HOME="$HOME" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" SD
 cd $IPDK_RECIPE
 sudo ./install/sbin/infrap4d
 ```
+ *Note*: By default, infrap4d runs in detached mode. If user wants to run infrap4d in attached mode, use --nodetach option.
+All infrap4d logs are by default logged under /var/log/stratum.
+All P4SDE logs are logged in p4_driver.log under $IPDK_RECIPE.
+All OVS logs are logged under /tmp/ovs-vswitchd.log.
 
 ### Run a sample program
 

--- a/infrap4d/CMakeLists.txt
+++ b/infrap4d/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 
 project(infrap4d VERSION 0.1.0 LANGUAGES C CXX)
 
+add_subdirectory(daemon)
+
 set(STRATUM_TDI_BIN_DIR ${STRATUM_SOURCE_DIR}/stratum/hal/bin/tdi)
 set(STRATUM_BFRT_BIN_DIR ${STRATUM_SOURCE_DIR}/stratum/hal/bin/barefoot)
 
@@ -14,6 +16,8 @@ elseif(TOFINO_TARGET)
     set(INFRAP4D_MAIN ${STRATUM_TDI_BIN_DIR}/tofino/main.cc)
     add_executable(infrap4d ${INFRAP4D_MAIN})
 endif()
+
+target_sources(infrap4d PRIVATE $<TARGET_OBJECTS:daemon_o>)
 
 set_target_properties(infrap4d
     PROPERTIES INSTALL_RPATH $ORIGIN/../lib

--- a/infrap4d/daemon/CMakeLists.txt
+++ b/infrap4d/daemon/CMakeLists.txt
@@ -1,0 +1,14 @@
+# CMake build file for infrap4d/daemon
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+cmake_minimum_required(VERSION 3.5)
+
+add_library(daemon_o OBJECT
+   daemon.c
+   daemon.h
+   daemon-unix.c
+   fatal-signal.c
+   fatal-signal.h
+)

--- a/infrap4d/daemon/daemon-unix.c
+++ b/infrap4d/daemon/daemon-unix.c
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2015 Nicira, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "daemon.h"
+#include <stdio.h>
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <grp.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "fatal-signal.h"
+
+#ifdef __linux__
+#define LINUX 1
+#else
+#define LINUX 0
+#endif
+
+/* --detach: Should we run in the background? */
+bool infrap4d_detach = true;             /* Was --detach specified? */
+static bool infrap4d_detached;           /* Have we already detached? */
+
+/* --pidfile: Name of pidfile (null if none). */
+char *infrap4d_pidfile;
+
+/* File descriptor used by daemonize_start() and daemonize_complete(). */
+int infrap4d_daemonize_fd = -1;
+
+static pid_t fork_and_clean_up(void);
+static void daemonize_post_detach(void);
+
+int
+read_fully(int fd, void *p_, size_t size, size_t *bytes_read)
+{
+    char *p = p_;
+
+    *bytes_read = 0;
+    while (size > 0) {
+        ssize_t retval = read(fd, p, size);
+        if (retval > 0) {
+            *bytes_read += retval;
+            size -= retval;
+            p += retval;
+        } else if (retval == 0) {
+            return EOF;
+        } else if (errno != EINTR) {
+            return errno;
+        }
+    }
+    return 0;
+}
+
+int
+write_fully(int fd, const void *p_, size_t size, size_t *bytes_written)
+{
+    const char *p = p_;
+
+    *bytes_written = 0;
+    while (size > 0) {
+        ssize_t retval = write(fd, p, size);
+        if (retval > 0) {
+            *bytes_written += retval;
+            size -= retval;
+            p += retval;
+        } else if (retval == 0) {
+            return EPROTO;
+        } else if (errno != EINTR) {
+            return errno;
+        }
+    }
+    return 0;
+}
+
+/* Calls fork() and on success returns its return value.  On failure, logs an
+ * error and exits unsuccessfully.
+ *
+ * Post-fork, but before returning, this function calls a few other functions
+ * that are generally useful if the child isn't planning to exec a new
+ * process. */
+static pid_t
+fork_and_clean_up(void)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        printf("fork failed\n");
+    }
+    else if (pid > 0) {
+        /* Running in parent process. */
+        fatal_signal_fork();
+    }
+    return pid;
+}
+
+/* Forks, then:
+ *
+ *   - In the parent, waits for the child to signal that it has completed its
+ *     startup sequence.  Then stores -1 in '*fdp' and returns the child's
+ *     pid in '*child_pid' argument.
+ *
+ *   - In the child, stores a fd in '*fdp' and returns 0 through '*child_pid'
+ *     argument.  The caller should pass the fd to fork_notify_startup() after
+ *     it finishes its startup sequence.
+ *
+ * Returns 0 on success.  If something goes wrong and child process was not
+ * able to signal its readiness by calling fork_notify_startup(), then this
+ * function returns -1. However, even in case of failure it still sets child
+ * process id in '*child_pid'. */
+static int
+fork_and_wait_for_startup(int *fdp, pid_t *child_pid)
+{
+    int fds[2];
+    pid_t pid;
+    int ret = 0;
+
+    if (pipe(fds)) {
+        printf("failed to create pipe \n");
+    }
+    pid = fork_and_clean_up();
+    if (pid > 0) {
+        /* Running in parent process. */
+        size_t bytes_read;
+        char c;
+
+        close(fds[1]);
+        if (read_fully(fds[0], &c, 1, &bytes_read) != 0) {
+            int retval;
+            int status;
+
+            do {
+                retval = waitpid(pid, &status, 0);
+            } while (retval == -1 && errno == EINTR);
+
+            if (retval == pid) {
+                if (WIFEXITED(status) && WEXITSTATUS(status)) {
+                    /* Child exited with an error.  Convey the same error
+                     * to our parent process as a courtesy. */
+                    exit(WEXITSTATUS(status));
+                } else {
+		    ret = -1;
+                }
+            } else {
+                abort();
+            }
+        }
+        *fdp = fds[0];
+    } else if (!pid) {
+        /* Running in child process. */
+        close(fds[0]);
+        *fdp = fds[1];
+    }
+    *child_pid = pid;
+    return ret;
+}
+
+static void
+fork_notify_startup(int fd)
+{
+    if (fd != -1) {
+        size_t bytes_written;
+        int error;
+
+        error = write_fully(fd, "", 1, &bytes_written);
+        if (error) {
+            printf("pipe write failed \n");
+        }
+    }
+}
+
+/* If daemonization is configured, then starts daemonization, by forking and
+ * returning in the child process.  The parent process hangs around until the
+ * child lets it know either that it completed startup successfully (by calling
+ * daemonize_complete()) or that it failed to start up (by exiting with a
+ * nonzero exit code). */
+void
+daemonize_start(bool access_datapath)
+{
+    infrap4d_daemonize_fd = -1;
+
+    if (infrap4d_detach) {
+        pid_t pid;
+
+        if (fork_and_wait_for_startup(&infrap4d_daemonize_fd, &pid)) {
+            printf("could not detach from foreground session \n");
+        }
+        if (pid > 0) {
+            /* Running in parent process. */
+            exit(0);
+        } else {    
+            /* Running in daemon or monitor process. */
+            setsid();
+        }
+    }
+}
+
+/* If daemonization is configured, then this function notifies the parent
+ * process that the child process has completed startup successfully.  It also
+ * call daemonize_post_detach().
+ *
+ * Calling this function more than once has no additional effect. */
+void
+daemonize_complete(void)
+{
+    if (infrap4d_pidfile) {
+        free(infrap4d_pidfile);
+        infrap4d_pidfile = NULL;
+    }
+
+    if (!infrap4d_detached) {
+        infrap4d_detached = true;
+
+        fork_notify_startup(infrap4d_daemonize_fd);
+        daemonize_post_detach();
+    }
+}
+
+/* If daemonization is configured, then this function does traditional Unix
+ * daemonization behavior: join a new session, chdir to the root (if not
+ * disabled), and close the standard file descriptors.
+ *
+ * It only makes sense to call this function as part of an implementation of a
+ * special daemon subprocess.  A normal daemon should just call
+ * daemonize_complete(). */
+static void
+daemonize_post_detach(void)
+{
+    if (infrap4d_detach) {
+        close_standard_fds();
+    }
+}

--- a/infrap4d/daemon/daemon.c
+++ b/infrap4d/daemon/daemon.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2014 Nicira, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "daemon.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <assert.h>
+#include <stdio.h>
+
+/* For each of the standard file descriptors, whether to replace it by
+ * /dev/null (if false) or keep it for the daemon to use (if true). */
+static bool infrap4d_save_fds[3];
+
+/* A daemon doesn't normally have any use for the file descriptors for stdin,
+ * stdout, and stderr after it detaches.  To keep these file descriptors from
+ * e.g. holding an SSH session open, by default detaching replaces each of
+ * these file descriptors by /dev/null.  But a few daemons expect the user to
+ * redirect stdout or stderr to a file, in which case it is desirable to keep
+ * these file descriptors.  This function, therefore, disables replacing 'fd'
+ * by /dev/null when the daemon detaches. */
+void
+daemon_save_fd(int fd)
+{
+    assert(fd == STDIN_FILENO ||
+           fd == STDOUT_FILENO ||
+           fd == STDERR_FILENO);
+    infrap4d_save_fds[fd] = true;
+}
+
+/* Returns a readable and writable fd for /dev/null, if successful, otherwise
+ * a negative errno value.  The caller must not close the returned fd (because
+ * the same fd will be handed out to subsequent callers). */
+static int
+get_null_fd(void)
+{
+    static int null_fd;
+    char *device = "/dev/null";
+
+    if (!null_fd) {
+        null_fd = open(device, O_RDWR);
+        if (null_fd < 0) {
+            int error = errno;
+            null_fd = -error;
+        }
+    }
+
+    return null_fd;
+}
+
+/* Close standard file descriptors (except any that the client has requested we
+ * leave open by calling daemon_save_fd()).  If we're started from e.g. an SSH
+ * session, then this keeps us from holding that session open artificially. */
+void
+close_standard_fds(void)
+{
+    int null_fd = get_null_fd();
+    if (null_fd >= 0) {
+        int fd;
+
+        for (fd = 0; fd < 3; fd++) {
+            if (!infrap4d_save_fds[fd]) {
+                dup2(null_fd, fd);
+            }
+        }
+    }
+}

--- a/infrap4d/daemon/daemon.h
+++ b/infrap4d/daemon/daemon.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008, 2009, 2010, 2011, 2012 Nicira, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DAEMON_H
+#define DAEMON_H 1
+
+#include <limits.h>
+#include <stdbool.h>
+#include <sys/types.h>
+
+void set_detach(void);
+pid_t read_pidfile(const char *name);
+
+bool get_detach(void);
+void daemon_save_fd(int fd);
+void daemonize_start(bool access_datapath);
+void daemonize_complete(void);
+void close_standard_fds(void);
+
+#endif /* daemon.h */

--- a/infrap4d/daemon/fatal-signal.c
+++ b/infrap4d/daemon/fatal-signal.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013 Nicira, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fatal-signal.h"
+#include <errno.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <signal.h>
+
+#ifndef SIG_ATOMIC_MAX
+#define SIG_ATOMIC_MAX TYPE_MAXIMUM(sig_atomic_t)
+#endif
+
+/* Signals to catch. */
+static const int fatal_signals[] = { SIGTERM, SIGINT, SIGHUP, SIGALRM,
+                                     SIGSEGV };
+
+/* Hooks to call upon catching a signal */
+struct infrap4d_hook {
+    void (*hook_cb)(void *aux);
+    void (*cancel_cb)(void *aux);
+    void *aux;
+    bool run_at_exit;
+};
+#define MAX_HOOKS 32
+static struct infrap4d_hook infrap4d_hooks[MAX_HOOKS];
+static size_t infrap4d_n_hooks;
+
+static int infrap4d_signal_fds[2];
+static volatile sig_atomic_t infrap4d_stored_sig_nr = SIG_ATOMIC_MAX;
+
+/* Clears all of the fatal signal hooks without executing them.  If any of the
+ * hooks passed a 'cancel_cb' function to fatal_signal_add_hook(), then those
+ * functions will be called, allowing them to free resources, etc.
+ *
+ * Following a fork, one of the resulting processes can call this function to
+ * allow it to terminate without calling the hooks registered before calling
+ * this function.  New hooks registered after calling this function will take
+ * effect normally. */
+void
+fatal_signal_fork(void)
+{
+    size_t i;
+
+    for (i = 0; i < infrap4d_n_hooks; i++) {
+        struct infrap4d_hook *h = &infrap4d_hooks[i];
+        if (h->cancel_cb) {
+            h->cancel_cb(h->aux);
+        }
+    }
+    infrap4d_n_hooks = 0;
+
+    /* Raise any signals that we have already received with the default
+     * handler. */
+    if (infrap4d_stored_sig_nr != SIG_ATOMIC_MAX) {
+        raise(infrap4d_stored_sig_nr);
+    }
+}

--- a/infrap4d/daemon/fatal-signal.h
+++ b/infrap4d/daemon/fatal-signal.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008, 2009, 2010, 2013 Nicira, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FATAL_SIGNAL_H
+#define FATAL_SIGNAL_H 1
+
+#include <stdbool.h>
+
+/* Basic interface. */
+void fatal_signal_fork(void);
+
+#endif /* fatal-signal.h */

--- a/infrap4d/infrap4d_main.cc
+++ b/infrap4d/infrap4d_main.cc
@@ -7,7 +7,14 @@
 #include "stratum/hal/bin/tdi/tofino/tofino_main.h"
 #endif
 
+extern "C"  {
+#include "daemon/daemon.h"
+}
+
 #include "krnlmon_main.h"
+#include "gflags/gflags.h"
+
+DEFINE_bool(detach, true, "Run infrap4d in attached mode");
 
 pthread_cond_t rpc_start_cond = PTHREAD_COND_INITIALIZER;
 pthread_mutex_t rpc_start_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -21,6 +28,12 @@ int main(int argc, char* argv[]) {
 #if defined(TOFINO_TARGET)
   return stratum::hal::tdi::TofinoMain(argc, argv).error_code();
 #elif defined(DPDK_TARGET)
+  gflags::ParseCommandLineFlags(&argc, &argv, false);
+  if (FLAGS_detach) {
+      daemonize_start(false);
+      daemonize_complete();
+  }
+
   krnlmon_init();
 
   krnlmon_shutdown();
@@ -30,5 +43,7 @@ int main(int argc, char* argv[]) {
      //TODO: Figure out logging for infrap4d
      return status.error_code();
    }
+
+  return 0;
 #endif
 }


### PR DESCRIPTION
Add support to run infrap4d as daemon for DPDK target. By default, infrap4d runs in detached mode.
If user wants to run infrap4d in attached mode, use --nodetach option. Add logging information to documentation.

Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>