### PR TITLE
Check if FDB table entry exists before sending INSERT request

### DIFF
--- a/ovs-p4rt/ovs_p4rt_session.cc
+++ b/ovs-p4rt/ovs_p4rt_session.cc
@@ -106,7 +106,7 @@ absl::Status GetForwardingPipelineConfig(OvsP4rtSession* session,
   return absl::OkStatus();
 }
 
-absl::StatusOr<ReadResponse> SendReadRequest(OvsP4rtSession* session,
+absl::Status SendReadRequest(OvsP4rtSession* session,
                                              const ReadRequest& read_request) {
   grpc::ClientContext context;
   auto reader = session->Stub().Read(&context, read_request);
@@ -118,11 +118,8 @@ absl::StatusOr<ReadResponse> SendReadRequest(OvsP4rtSession* session,
   }
 
   grpc::Status reader_status = reader->Finish();
-  if (!reader_status.ok()) {
-    return GrpcStatusToAbslStatus(reader_status);
-  }
 
-  return std::move(response);
+  return GrpcStatusToAbslStatus(reader_status);
 }
 
 absl::Status SendWriteRequest(OvsP4rtSession* session,

--- a/ovs-p4rt/ovs_p4rt_session.h
+++ b/ovs-p4rt/ovs_p4rt_session.h
@@ -86,7 +86,7 @@ std::unique_ptr<p4::v1::P4Runtime::Stub> CreateP4RuntimeStub(
 
 // Functions that operate on a OvsP4rtSession.
 
-absl::StatusOr<p4::v1::ReadResponse> SendReadRequest(
+absl::Status SendReadRequest(
     OvsP4rtSession* session, const p4::v1::ReadRequest& read_request);
 
 absl::Status SendWriteRequest(OvsP4rtSession* session,


### PR DESCRIPTION
Check if entry was already programmed from previous mac learning using READ P4RT call before issuing a new INSERT call to program the FDB entry. This helps reduce the duplicate entry errors

Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>