### PR TITLE
Build system improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,9 @@ cmake_minimum_required(VERSION 3.5)
 
 project(networking-recipe VERSION 0.1 LANGUAGES C CXX)
 
-include(FindPkgConfig)
 include(CMakePrintHelpers)
+include(FindPkgConfig)
+include(GNUInstallDirs)
 
 # Default: Release with Debug Info
 set(CMAKE_BUILD_TYPE "RelWithDebInfo")
@@ -20,7 +21,8 @@ option(SET_RPATH "Set RPATH in libraries and executables" OFF)
 # Symbolic path definitions #
 #############################
 
-set(DEPEND_INSTALL_DIR "" CACHE PATH "Dependencies install directory")
+set(DEPEND_INSTALL_DIR "$ENV{DEPEND_INSTALL}" CACHE PATH
+    "Dependencies install directory")
 
 set(OVS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}" CACHE PATH
     "OVS install directory")
@@ -28,7 +30,8 @@ set(OVS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}" CACHE PATH
 set(OVS_SOURCE_DIR "${CMAKE_SOURCE_DIR}/ovs/ovs" CACHE PATH
     "OVS source directory")
 
-set(SDE_INSTALL_DIR "/opt/sde" CACHE PATH "SDE install directory")
+set(SDE_INSTALL_DIR "$ENV{SDE_INSTALL}" CACHE PATH
+    "SDE install directory")
 
 set(PROTO_OUT_DIR "${CMAKE_BINARY_DIR}/pb.out" CACHE PATH
     "Path to generated Protobuf files")
@@ -98,6 +101,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # CMAKE_PREFIX_PATH specifies the directories to be searched by
 # find_file(), find_library(), find_path(), and find_program().
+# We only specify the install directory. The individual commands
+# each have their own lists of subdirectories to search.
 
 if(NOT DEPEND_INSTALL_DIR STREQUAL "")
     list(APPEND CMAKE_PREFIX_PATH ${DEPEND_INSTALL_DIR})
@@ -132,7 +137,8 @@ endif()
 # system), we can omit the SDE or DEPEND element in favor of
 # the ORIGIN element.
 #
-# The ORIGIN element is equivalent to ${CMAKE_PREFIX_PATH}/lib.
+# The ORIGIN element is equivalent to ${CMAKE_PREFIX_PATH}/lib or
+# ${CMAKE_PREFIX_PATH}/lib64.
 #
 # The elements will need to expanded to include /lib64 paths where
 # appropriate.
@@ -143,11 +149,30 @@ endif()
 # that we do need to include the DPDK library directory in the RPATH, we
 # can use DPDK_LIBRARY_DIRS, which is defined by pkg_check_modules(DPDK).
 
-set(SDE_ELEMENT ${SDE_INSTALL_DIR}/lib)
+if(EXISTS ${SDE_INSTALL_DIR}/lib)
+    list(APPEND SDE_ELEMENT ${SDE_INSTALL_DIR}/lib)
+endif()
+if(EXISTS ${SDE_INSTALL_DIR}/lib64)
+    list(APPEND SDE_ELEMENT ${SDE_INSTALL_DIR}/lib64)
+endif()
 
 if(NOT DEPEND_INSTALL_DIR STREQUAL "")
-    set(DEP_ELEMENT ${DEPEND_INSTALL_DIR}/lib)
+    if(EXISTS ${DEPEND_INSTALL_DIR}/lib)
+        list(APPEND DEP_ELEMENT ${DEPEND_INSTALL_DIR}/lib)
+    endif()
+    if(EXISTS ${DEPEND_INSTALL_DIR}/lib64)
+        list(APPEND DEP_ELEMENT ${DEPEND_INSTALL_DIR}/lib64)
+    endif()
 endif()
+
+set(_libdir ${CMAKE_INSTALL_LIBDIR})
+if(EXISTS ${CMAKE_INSTALL_PREFIX}/lib OR _libdir STREQUAL "lib")
+    list(APPEND EXEC_ELEMENT $ORIGIN/../lib)
+endif()
+if(EXISTS ${CMAKE_INSTALL_PREFIX}/lib64 OR _libdir STREQUAL "lib64")
+    list(APPEND EXEC_ELEMENT $ORIGIN/../lib64)
+endif()
+unset(_libdir)
 
 ###################
 # RPATH functions #

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(gnmi_cli
     ${STRATUM_SOURCE_DIR}/stratum/tools/gnmi/gnmi_cli.cc
 )
 
-set_install_rpath(gnmi_cli $ORIGIN/../lib ${DEP_ELEMENT})
+set_install_rpath(gnmi_cli ${EXEC_ELEMENT} ${DEP_ELEMENT})
 
 target_link_libraries(gnmi_cli
     PUBLIC
@@ -56,7 +56,7 @@ add_executable(tdi_pipeline_builder
 # Suppress "warning: attribute ignored" on ABSL_MUST_USE_RESULT [[nodiscard]]
 target_compile_options(tdi_pipeline_builder PRIVATE -Wno-attributes)
 
-set_install_rpath(tdi_pipeline_builder $ORIGIN/../lib ${DEP_ELEMENT})
+set_install_rpath(tdi_pipeline_builder ${EXEC_ELEMENT} ${DEP_ELEMENT})
 
 target_include_directories(tdi_pipeline_builder
     PRIVATE

--- a/clients/gnmi-ctl/CMakeLists.txt
+++ b/clients/gnmi-ctl/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(gnmi-ctl
     gnmi_ctl_utils.h
 )
 
-set_install_rpath(gnmi-ctl $ORIGIN/../lib ${DEP_ELEMENT})
+set_install_rpath(gnmi-ctl ${EXEC_ELEMENT} ${DEP_ELEMENT})
 
 target_link_libraries(gnmi-ctl
     PUBLIC

--- a/infrap4d/CMakeLists.txt
+++ b/infrap4d/CMakeLists.txt
@@ -10,14 +10,10 @@ set(STRATUM_BFRT_BIN_DIR ${STRATUM_SOURCE_DIR}/stratum/hal/bin/barefoot)
 if(WITH_KRNLMON)
     add_executable(infrap4d infrap4d_main.cc)
 elseif(DPDK_TARGET)
-    set(INFRAP4D_MAIN ${STRATUM_TDI_BIN_DIR}/dpdk/main.cc)
-    add_executable(infrap4d ${INFRAP4D_MAIN})
+    add_executable(infrap4d ${STRATUM_TDI_BIN_DIR}/dpdk/main.cc)
 elseif(TOFINO_TARGET)
-    set(INFRAP4D_MAIN ${STRATUM_TDI_BIN_DIR}/tofino/main.cc)
-    add_executable(infrap4d ${INFRAP4D_MAIN})
+    add_executable(infrap4d ${STRATUM_TDI_BIN_DIR}/tofino/main.cc)
 endif()
-
-set_install_rpath(infrap4d $ORIGIN/../lib ${SDE_ELEMENT} ${DEP_ELEMENT})
 
 target_sources(infrap4d PRIVATE $<TARGET_OBJECTS:daemon_o>)
 
@@ -37,6 +33,8 @@ target_link_libraries(infrap4d PRIVATE
 if(WITH_KRNLMON)
     target_link_libraries(infrap4d PRIVATE krnlmon pthread)
 endif()
+
+set_install_rpath(infrap4d ${EXEC_ELEMENT} ${SDE_ELEMENT} ${DEP_ELEMENT})
 
 install(TARGETS infrap4d DESTINATION sbin)
 

--- a/ovs-p4rt/CMakeLists.txt
+++ b/ovs-p4rt/CMakeLists.txt
@@ -95,7 +95,7 @@ target_link_libraries(ovs-vswitchd
         rt m pthread
 )
 
-set_install_rpath(ovs-vswitchd $ORIGIN/../lib ${DEP_ELEMENT})
+set_install_rpath(ovs-vswitchd ${EXEC_ELEMENT} ${DEP_ELEMENT})
 
 target_link_libraries(ovs-vswitchd PUBLIC
     absl::strings
@@ -122,7 +122,7 @@ add_executable(ovs-testcontroller
     $<TARGET_OBJECTS:ovs_sidecar_o>
 )
 
-set_install_rpath(ovs-testcontroller $ORIGIN/../lib ${DEP_ELEMENT})
+set_install_rpath(ovs-testcontroller ${EXEC_ELEMENT} ${DEP_ELEMENT})
 
 target_link_libraries(ovs-testcontroller
     PRIVATE


### PR DESCRIPTION
1) Added support for both lib and lib64 when setting RUNPATH on binary
   executables.

2) Implemented --rpath and --no-rpath options in make-all.sh.

3) Made DEPEND_INSTALL_DIR and SDE_INSTALL_DIR default to the values
   of the DEPEND_INSTALL and SDE_INSTALL environment variables.

Signed-off-by: Derek G Foster <derek.foster@intel.com>