### PR TITLE
Distinguish global symbols in infrap4d/daemon

### DIFF
--- a/infrap4d/daemon/daemon-unix.c
+++ b/infrap4d/daemon/daemon-unix.c
@@ -46,7 +46,7 @@ int infrap4d_daemonize_fd = -1;
 static pid_t fork_and_clean_up(void);
 static void daemonize_post_detach(void);
 
-int
+static int
 read_fully(int fd, void *p_, size_t size, size_t *bytes_read)
 {
     char *p = p_;
@@ -67,7 +67,7 @@ read_fully(int fd, void *p_, size_t size, size_t *bytes_read)
     return 0;
 }
 
-int
+static int
 write_fully(int fd, const void *p_, size_t size, size_t *bytes_written)
 {
     const char *p = p_;
@@ -103,7 +103,7 @@ fork_and_clean_up(void)
     }
     else if (pid > 0) {
         /* Running in parent process. */
-        fatal_signal_fork();
+        daemon_fatal_signal_fork();
     }
     return pid;
 }
@@ -153,7 +153,7 @@ fork_and_wait_for_startup(int *fdp, pid_t *child_pid)
                      * to our parent process as a courtesy. */
                     exit(WEXITSTATUS(status));
                 } else {
-		    ret = -1;
+                    ret = -1;
                 }
             } else {
                 abort();
@@ -202,7 +202,7 @@ daemonize_start(bool access_datapath)
         if (pid > 0) {
             /* Running in parent process. */
             exit(0);
-        } else {    
+        } else {
             /* Running in daemon or monitor process. */
             setsid();
         }
@@ -241,6 +241,6 @@ static void
 daemonize_post_detach(void)
 {
     if (infrap4d_detach) {
-        close_standard_fds();
+        daemon_close_standard_fds();
     }
 }

--- a/infrap4d/daemon/daemon.c
+++ b/infrap4d/daemon/daemon.c
@@ -64,7 +64,7 @@ get_null_fd(void)
  * leave open by calling daemon_save_fd()).  If we're started from e.g. an SSH
  * session, then this keeps us from holding that session open artificially. */
 void
-close_standard_fds(void)
+daemon_close_standard_fds(void)
 {
     int null_fd = get_null_fd();
     if (null_fd >= 0) {

--- a/infrap4d/daemon/daemon.h
+++ b/infrap4d/daemon/daemon.h
@@ -14,20 +14,16 @@
  * limitations under the License.
  */
 
-#ifndef DAEMON_H
-#define DAEMON_H 1
+#ifndef INFRAP4D_DAEMON_H
+#define INFRAP4D_DAEMON_H 1
 
 #include <limits.h>
 #include <stdbool.h>
 #include <sys/types.h>
 
-void set_detach(void);
-pid_t read_pidfile(const char *name);
-
-bool get_detach(void);
 void daemon_save_fd(int fd);
 void daemonize_start(bool access_datapath);
 void daemonize_complete(void);
-void close_standard_fds(void);
+void daemon_close_standard_fds(void);
 
 #endif /* daemon.h */

--- a/infrap4d/daemon/fatal-signal.c
+++ b/infrap4d/daemon/fatal-signal.c
@@ -56,7 +56,7 @@ static volatile sig_atomic_t infrap4d_stored_sig_nr = SIG_ATOMIC_MAX;
  * this function.  New hooks registered after calling this function will take
  * effect normally. */
 void
-fatal_signal_fork(void)
+daemon_fatal_signal_fork(void)
 {
     size_t i;
 

--- a/infrap4d/daemon/fatal-signal.h
+++ b/infrap4d/daemon/fatal-signal.h
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#ifndef FATAL_SIGNAL_H
-#define FATAL_SIGNAL_H 1
+#ifndef DAEMON_FATAL_SIGNAL_H
+#define DAEMON_FATAL_SIGNAL_H 1
 
 #include <stdbool.h>
 
 /* Basic interface. */
-void fatal_signal_fork(void);
+void daemon_fatal_signal_fork(void);
 
 #endif /* fatal-signal.h */


### PR DESCRIPTION
- Added a distinguishing prefix to several of function names in the files that were ported from ovs to infrap4d/daemon, to reduce the probability of collisions in the global namespace.

Signed-off-by: Derek G Foster <derek.foster@intel.com>