### PR TITLE
Fix protobuf header file dependencies

### DIFF
--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -117,6 +117,7 @@ target_include_directories(stratum_hal_lib_common_o PRIVATE
 
 add_dependencies(stratum_hal_lib_common_o
     gnmi_proto
+    openconfig_proto
     stratum_proto
 )
 
@@ -310,7 +311,7 @@ target_include_directories(stratum_main_o PRIVATE
     ${SDE_INSTALL_DIR}/include
 )
 
-add_dependencies(stratum_main_o stratum_proto)
+add_dependencies(stratum_main_o stratum_proto gnmi_proto)
 
 ##############
 # libstratum #


### PR DESCRIPTION
When the networking recipe is built with -j1, compilation of config_monitoring_service.cc fails because openconfig.pb.h has not yet been generated. Addressed this issue by making stratum_hal_lib_common_o dependent on the openconfig_proto target.

When the networking recipe is built in certain parallel build configurations, compilation of dpdk_main.cc fails because gnmi.grpc.pb.h has not yet been generated. Addressed this issue by making stratum_main_o dependent on the gnmi_proto target.

Signed-off-by: Derek G Foster <derek.foster@intel.com>