### PR TITLE
Remove commands that result in error

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ To download the source code for the Networking Recipe:
 
 ```bash
 git clone --recursive https://github.com/ipdk-io/networking-recipe
-cd networking-recipe
-git submodule update init
 ```
 
 ## Targets

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ network devices.
    Server in infrap4d via gRPC, to program the P4 pipeline and insert/delete
    P4 table entries.
 
-3. `gnmi_cli`: A gRPC-based C++ network management interface client to handle
+3. `gnmi-ctl`: A gRPC-based C++ network management interface client to handle
    port configurations and program fixed functions in the P4 pipeline.
 
 ## Download

--- a/docs/ipdk-dpdk.md
+++ b/docs/ipdk-dpdk.md
@@ -110,8 +110,8 @@ Open a new terminal to set the pipeline and try the sample P4 program.
 Set up the environment and export all environment variables to sudo user.
 
 ```bash
-source ./scripts/setup_env.sh $IPDK_RECIPE $SDE_INSTALL $DEPEND_INSTALL
-./scripts/copy_config_files.sh $IPDK_RECIPE $SDE_INSTALL
+source ./scripts/dpdk/setup_env.sh $IPDK_RECIPE $SDE_INSTALL $DEPEND_INSTALL
+./scripts/dpdk/copy_config_files.sh $IPDK_RECIPE $SDE_INSTALL
 alias sudo='sudo PATH="$PATH" HOME="$HOME" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" SDE_INSTALL="$SDE_INSTALL"'
 ```
 


### PR DESCRIPTION
README had a `git clone --recursive` followed by `git submodule update init`, which results in an error. The recursive statement pulls everything. Removing the error statement from readme.

Signed-off-by: Sabeel Ansari <sabeel.ansari@intel.com>