### PR TITLE
Address issues with CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,20 @@
 
 cmake_minimum_required(VERSION 3.5)
 
+option(KLOCWORK "Configure for Klocwork scan" OFF)
+
+# CMAKE_BUILD_TYPE must be set before the first project() command.
+if(KLOCWORK)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Type of build to perform")
+else()
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Type of build to perform")
+endif()
+
 project(networking-recipe VERSION 0.1 LANGUAGES C CXX)
 
 include(CMakePrintHelpers)
 include(FindPkgConfig)
 include(GNUInstallDirs)
-
-# Default: Release with Debug Info
-set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 
 option(SET_RPATH "Set RPATH in libraries and executables" OFF)
 


### PR DESCRIPTION
The CMAKE_BUILD_TYPE definition in the top-level CMakeLists.txt file wasn't working as expected. It turns out that it has to be defined _before_ the project() command or it has no effect.

- Moved the definition of CMAKE_BUILD_TYPE before the project() command.
- Defined a new KLOCWORK command-line option, which defaults to OFF.
- Modified CMAKE_BUILD_TYPE to default to "Debug" if the KLOCWORK option is enabled or "RelWithDebInfo" if is is disabled.

When building in Debug mode, CMake suppresses the definition of the NDEBUG flag, thereby enabling any assert() statements in the code. We do this so Klocwork takes variable references in the assertions into account when doing static analysis.

Signed-off-by: Derek G Foster <derek.foster@intel.com>