### PR TITLE
CMake script refinements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Type of build to perform")
 endif()
 
-project(networking-recipe VERSION 0.1 LANGUAGES C CXX)
+project(networking-recipe VERSION 23.01 LANGUAGES C CXX)
 
 include(CMakePrintHelpers)
 include(FindPkgConfig)
@@ -39,9 +39,9 @@ set(OVS_SOURCE_DIR "${CMAKE_SOURCE_DIR}/ovs/ovs" CACHE PATH
 set(SDE_INSTALL_DIR "$ENV{SDE_INSTALL}" CACHE PATH
     "SDE install directory")
 
-set(PROTO_OUT_DIR "${CMAKE_BINARY_DIR}/pb.out" CACHE PATH
+set(PB_OUT_DIR "${CMAKE_BINARY_DIR}/pb.out" CACHE PATH
     "Path to generated Protobuf files")
-file(MAKE_DIRECTORY ${PROTO_OUT_DIR})
+file(MAKE_DIRECTORY ${PB_OUT_DIR})
 
 ############################
 # Target selection options #

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -20,7 +20,7 @@ set_install_rpath(gnmi_cli ${EXEC_ELEMENT} ${DEP_ELEMENT})
 
 target_link_libraries(gnmi_cli
     PUBLIC
-        stratum
+        stratum_static
         gnmi_proto grpc_proto
         grpc protobuf gflags grpc++
         pthread re2
@@ -33,7 +33,7 @@ endif()
 target_include_directories(gnmi_cli
     PRIVATE
         ${STRATUM_SOURCE_DIR}
-        ${PROTO_OUT_DIR}
+        ${PB_OUT_DIR}
 )
 
 add_dependencies(gnmi_cli
@@ -61,7 +61,7 @@ set_install_rpath(tdi_pipeline_builder ${EXEC_ELEMENT} ${DEP_ELEMENT})
 target_include_directories(tdi_pipeline_builder
     PRIVATE
         ${STRATUM_SOURCE_DIR}
-        ${PROTO_OUT_DIR}
+        ${PB_OUT_DIR}
 )
 
 target_link_libraries(tdi_pipeline_builder PUBLIC stratum_proto p4runtime_proto)
@@ -70,8 +70,8 @@ target_link_libraries(tdi_pipeline_builder PUBLIC
     protobuf gflags glog grpc grpc++
 )
 
-target_link_libraries(tdi_pipeline_builder PRIVATE stratum)
+target_link_libraries(tdi_pipeline_builder PRIVATE stratum_static)
 
-add_dependencies(tdi_pipeline_builder stratum p4runtime_proto stratum_proto)
+add_dependencies(tdi_pipeline_builder p4runtime_proto stratum_proto)
 
 install(TARGETS tdi_pipeline_builder RUNTIME)

--- a/clients/gnmi-ctl/CMakeLists.txt
+++ b/clients/gnmi-ctl/CMakeLists.txt
@@ -19,7 +19,7 @@ set_install_rpath(gnmi-ctl ${EXEC_ELEMENT} ${DEP_ELEMENT})
 
 target_link_libraries(gnmi-ctl
     PUBLIC
-        stratum
+        stratum_static
         gnmi_proto grpc_proto
         grpc protobuf gflags grpc++
         pthread re2
@@ -28,7 +28,7 @@ target_link_libraries(gnmi-ctl
 target_include_directories(gnmi-ctl
     PRIVATE
         ${STRATUM_SOURCE_DIR}
-        ${PROTO_OUT_DIR}
+        ${PB_OUT_DIR}
 )
 
 add_dependencies(gnmi-ctl

--- a/infrap4d/CMakeLists.txt
+++ b/infrap4d/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 
 target_link_libraries(infrap4d PRIVATE
     -Wl,--whole-archive
-    stratum
+    stratum_static
     -Wl,--no-whole-archive
 )
 

--- a/ovs-p4rt/CMakeLists.txt
+++ b/ovs-p4rt/CMakeLists.txt
@@ -9,7 +9,7 @@ include(CheckLibraryExists)
 
 set(PROTO_INCLUDES
     # Protobuf C++ header files.
-    ${PROTO_OUT_DIR}
+    ${PB_OUT_DIR}
 )
 
 ###################
@@ -106,8 +106,8 @@ target_link_libraries(ovs-vswitchd PUBLIC
     absl::flags
 )
 
-target_link_libraries(ovs-vswitchd PUBLIC stratum)
-add_dependencies(ovs-vswitchd stratum)
+target_link_libraries(ovs-vswitchd PUBLIC stratum_static)
+#add_dependencies(ovs-vswitchd stratum_static)
 
 target_link_libraries(ovs-vswitchd PUBLIC
     stratum_proto
@@ -148,7 +148,7 @@ target_link_libraries(ovs-testcontroller PUBLIC
     absl::flags
 )
 
-target_link_libraries(ovs-testcontroller PUBLIC stratum)
+target_link_libraries(ovs-testcontroller PUBLIC stratum_static)
 
 target_link_libraries(ovs-testcontroller PUBLIC
     stratum_proto

--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -10,7 +10,7 @@ project(stratum)
 # Symbolic path definitions #
 #############################
 
-set(GOOGLE_SOURCE_DIR
+set(GOOGLEAPIS_SOURCE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/googleapis" CACHE PATH
     "Path to Google APIs source directory")
 
@@ -22,14 +22,14 @@ set(STRATUM_SOURCE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/stratum" CACHE PATH
     "Path to Stratum source directory")
 
-set(PROTO_OUT_DIR "${CMAKE_BINARY_DIR}/pb.out" CACHE PATH
+set(PB_OUT_DIR "${CMAKE_BINARY_DIR}/pb.out" CACHE PATH
     "Path to generated Protobuf files")
-file(MAKE_DIRECTORY ${PROTO_OUT_DIR})
+file(MAKE_DIRECTORY ${PB_OUT_DIR})
 
 set(STRATUM_INCLUDES
     ${STRATUM_SOURCE_DIR}
     # Protobuf C++ header files.
-    ${PROTO_OUT_DIR}
+    ${PB_OUT_DIR}
 )
 
 #####################
@@ -86,7 +86,7 @@ add_library(stratum_lib_o OBJECT
 
 target_include_directories(stratum_lib_o PRIVATE ${STRATUM_INCLUDES})
 
-add_dependencies(stratum_lib_o stratum_proto)
+add_dependencies(stratum_lib_o stratum_proto gnmi_proto)
 
 ############################
 # stratum_hal_lib_common_o #
@@ -318,11 +318,11 @@ target_include_directories(stratum_main_o PRIVATE
 
 add_dependencies(stratum_main_o stratum_proto gnmi_proto)
 
-##############
-# libstratum #
-##############
+#####################
+# libstratum_static #
+#####################
 
-add_library(stratum STATIC
+add_library(stratum_static STATIC
     $<TARGET_OBJECTS:stratum_glue_o>
     $<TARGET_OBJECTS:stratum_lib_o>
     $<TARGET_OBJECTS:stratum_hal_lib_common_o>
@@ -333,7 +333,7 @@ add_library(stratum STATIC
     $<TARGET_OBJECTS:stratum_main_o>
 )
 
-target_link_libraries(stratum PUBLIC
+target_link_libraries(stratum_static PUBLIC
     absl::strings absl::synchronization absl::graphcycles_internal
     absl::stacktrace absl::symbolize absl::malloc_internal
     absl::debugging_internal absl::demangle_internal absl::time
@@ -345,10 +345,10 @@ target_link_libraries(stratum PUBLIC
     absl::bad_variant_access
 )
 
-target_link_libraries(stratum PUBLIC glog gflags grpc protobuf grpc++)
-target_link_libraries(stratum PUBLIC pthread)
+target_link_libraries(stratum_static PUBLIC glog gflags grpc protobuf grpc++)
+target_link_libraries(stratum_static PUBLIC pthread)
 
-target_link_libraries(stratum PUBLIC
+target_link_libraries(stratum_static PUBLIC
     openconfig_proto
     stratum_proto
     gnmi_proto
@@ -356,7 +356,7 @@ target_link_libraries(stratum PUBLIC
     p4runtime_proto
 )
 
-target_link_libraries(stratum PUBLIC pthread)
+target_link_libraries(stratum_static PUBLIC pthread)
 
 # tdi
 find_library(LIBTDI tdi ${SDE_INSTALL_DIR}/lib)
@@ -396,7 +396,7 @@ if(TOFINO_TARGET)
     add_library(driver SHARED IMPORTED)
     set_property(TARGET driver PROPERTY IMPORTED_LOCATION ${LIBDRIVER})
 
-    target_link_libraries(stratum PUBLIC
+    target_link_libraries(stratum_static PUBLIC
         driver
         tdi
         tdi_json_parser
@@ -432,7 +432,7 @@ elseif(DPDK_TARGET)
     set_property(TARGET target_utils
                  PROPERTY IMPORTED_LOCATION ${LIBTARGET_UTILS})
 
-    target_link_libraries(stratum PUBLIC
+    target_link_libraries(stratum_static PUBLIC
         driver
         bf_switchd_lib
         tdi
@@ -441,9 +441,9 @@ elseif(DPDK_TARGET)
         target_sys
     )
 
-    target_link_directories(stratum PUBLIC
+    target_link_directories(stratum_static PUBLIC
         ${SDE_INSTALL}/lib
         ${DPDK_LIBRARY_DIRS})
 
-    target_link_options(stratum PUBLIC ${DPDK_LD_FLAGS} ${DPDK_LDFLAGS_OTHER})
+    target_link_options(stratum_static PUBLIC ${DPDK_LD_FLAGS} ${DPDK_LDFLAGS_OTHER})
 endif()

--- a/stratum/proto/CMakeLists.txt
+++ b/stratum/proto/CMakeLists.txt
@@ -26,7 +26,7 @@ set(PROTO_PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 # List of directories to be searched for Protobuf inputs.
 string(JOIN ":" PROTO_IMPORT_PATH
     ${PROTO_PARENT_DIR}
-    ${GOOGLE_SOURCE_DIR}
+    ${GOOGLEAPIS_SOURCE_DIR}
     ${P4RUNTIME_SOURCE_DIR}/proto
     ${STRATUM_SOURCE_DIR}
     /usr/local/include
@@ -92,8 +92,8 @@ function(generate_proto_files PROTO_FILES SRC_DIR)
         get_filename_component(_path ${_file} DIRECTORY)
         get_filename_component(_name ${_file} NAME_WE)
 
-        set(_src ${PROTO_OUT_DIR}/${_path}/${_name}.pb.cc)
-        set(_hdr ${PROTO_OUT_DIR}/${_path}/${_name}.pb.h)
+        set(_src ${PB_OUT_DIR}/${_path}/${_name}.pb.cc)
+        set(_hdr ${PB_OUT_DIR}/${_path}/${_name}.pb.h)
 
         set_source_files_properties(${_src} ${_hdr} PROPERTIES GENERATED TRUE)
 
@@ -103,7 +103,7 @@ function(generate_proto_files PROTO_FILES SRC_DIR)
             COMMAND
                 ${PROTOBUF_PROTOC_EXECUTABLE}
                 --proto_path=${PROTO_IMPORT_PATH}
-                --cpp_out=${PROTO_OUT_DIR}
+                --cpp_out=${PB_OUT_DIR}
                 -I${STRATUM_SOURCE_DIR}
                 ${_file}
             WORKING_DIRECTORY
@@ -137,8 +137,8 @@ function(generate_grpc_files PROTO_FILES SRC_DIR)
         get_filename_component(_path ${_file} DIRECTORY)
         get_filename_component(_name ${_file} NAME_WE)
 
-        set(_src ${PROTO_OUT_DIR}/${_path}/${_name}.grpc.pb.cc)
-        set(_hdr ${PROTO_OUT_DIR}/${_path}/${_name}.grpc.pb.h)
+        set(_src ${PB_OUT_DIR}/${_path}/${_name}.grpc.pb.cc)
+        set(_hdr ${PB_OUT_DIR}/${_path}/${_name}.grpc.pb.h)
 
         set_source_files_properties(${_src} ${_hdr} PROPERTIES GENERATED TRUE)
 
@@ -148,7 +148,7 @@ function(generate_grpc_files PROTO_FILES SRC_DIR)
             COMMAND
                 ${PROTOBUF_PROTOC_EXECUTABLE}
                 --proto_path=${PROTO_IMPORT_PATH}
-                --grpc_out=${PROTO_OUT_DIR}
+                --grpc_out=${PB_OUT_DIR}
                 --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN}
                 -I${STRATUM_SOURCE_DIR}
                 ${_file}
@@ -176,7 +176,7 @@ endfunction(generate_grpc_files)
 # Generate c++ protobuf files #
 ###############################
 
-generate_proto_files("${RPC_PROTO_FILES}" "${GOOGLE_SOURCE_DIR}")
+generate_proto_files("${RPC_PROTO_FILES}" "${GOOGLEAPIS_SOURCE_DIR}")
 
 generate_proto_files("${P4V1_PROTO_FILES}" "${P4RUNTIME_SOURCE_DIR}/proto")
 generate_grpc_files("p4/v1/p4runtime.proto" "${P4RUNTIME_SOURCE_DIR}/proto")
@@ -198,15 +198,15 @@ generate_proto_files("${STRATUM_BF_PROTO_FILES}" "${STRATUM_SOURCE_DIR}")
 
 # Internal target
 add_library(grpc_proto SHARED
-    ${PROTO_OUT_DIR}/google/rpc/status.pb.cc
-    ${PROTO_OUT_DIR}/google/rpc/status.pb.h
-    ${PROTO_OUT_DIR}/google/rpc/code.pb.cc
-    ${PROTO_OUT_DIR}/google/rpc/code.pb.h
+    ${PB_OUT_DIR}/google/rpc/status.pb.cc
+    ${PB_OUT_DIR}/google/rpc/status.pb.h
+    ${PB_OUT_DIR}/google/rpc/code.pb.cc
+    ${PB_OUT_DIR}/google/rpc/code.pb.h
 )
 
 set_install_rpath(grpc_proto ${DEP_ELEMENT})
 
-target_include_directories(grpc_proto PRIVATE ${PROTO_OUT_DIR})
+target_include_directories(grpc_proto PRIVATE ${PB_OUT_DIR})
 target_link_libraries(grpc_proto PUBLIC protobuf)
 
 install(TARGETS grpc_proto LIBRARY)
@@ -218,21 +218,21 @@ install(TARGETS grpc_proto LIBRARY)
 
 # External target
 add_library(p4runtime_proto SHARED
-    ${PROTO_OUT_DIR}/p4/v1/p4runtime.pb.cc
-    ${PROTO_OUT_DIR}/p4/v1/p4runtime.pb.h
-    ${PROTO_OUT_DIR}/p4/v1/p4runtime.grpc.pb.cc
-    ${PROTO_OUT_DIR}/p4/v1/p4runtime.grpc.pb.h
-    ${PROTO_OUT_DIR}/p4/v1/p4data.pb.cc
-    ${PROTO_OUT_DIR}/p4/v1/p4data.pb.h
-    ${PROTO_OUT_DIR}/p4/config/v1/p4types.pb.cc
-    ${PROTO_OUT_DIR}/p4/config/v1/p4types.pb.h
-    ${PROTO_OUT_DIR}/p4/config/v1/p4info.pb.cc
-    ${PROTO_OUT_DIR}/p4/config/v1/p4info.pb.h
+    ${PB_OUT_DIR}/p4/v1/p4runtime.pb.cc
+    ${PB_OUT_DIR}/p4/v1/p4runtime.pb.h
+    ${PB_OUT_DIR}/p4/v1/p4runtime.grpc.pb.cc
+    ${PB_OUT_DIR}/p4/v1/p4runtime.grpc.pb.h
+    ${PB_OUT_DIR}/p4/v1/p4data.pb.cc
+    ${PB_OUT_DIR}/p4/v1/p4data.pb.h
+    ${PB_OUT_DIR}/p4/config/v1/p4types.pb.cc
+    ${PB_OUT_DIR}/p4/config/v1/p4types.pb.h
+    ${PB_OUT_DIR}/p4/config/v1/p4info.pb.cc
+    ${PB_OUT_DIR}/p4/config/v1/p4info.pb.h
 )
 
 set_install_rpath(p4runtime_proto $ORIGIN ${DEP_ELEMENT})
 
-target_include_directories(p4runtime_proto PRIVATE ${PROTO_OUT_DIR})
+target_include_directories(p4runtime_proto PRIVATE ${PB_OUT_DIR})
 
 target_link_libraries(p4runtime_proto PUBLIC grpc_proto absl::synchronization)
 add_dependencies(p4runtime_proto grpc_proto)
@@ -244,19 +244,19 @@ install(TARGETS p4runtime_proto LIBRARY)
 #######################
 
 add_library(gnmi_proto SHARED
-    ${PROTO_OUT_DIR}/gnmi/gnmi.grpc.pb.cc
-    ${PROTO_OUT_DIR}/gnmi/gnmi.grpc.pb.h
-    ${PROTO_OUT_DIR}/gnmi/gnmi.pb.cc
-    ${PROTO_OUT_DIR}/gnmi/gnmi.pb.h
-    ${PROTO_OUT_DIR}/gnmi/gnmi_ext.pb.cc
-    ${PROTO_OUT_DIR}/gnmi/gnmi_ext.pb.h
+    ${PB_OUT_DIR}/gnmi/gnmi.grpc.pb.cc
+    ${PB_OUT_DIR}/gnmi/gnmi.grpc.pb.h
+    ${PB_OUT_DIR}/gnmi/gnmi.pb.cc
+    ${PB_OUT_DIR}/gnmi/gnmi.pb.h
+    ${PB_OUT_DIR}/gnmi/gnmi_ext.pb.cc
+    ${PB_OUT_DIR}/gnmi/gnmi_ext.pb.h
 )
 
 set_install_rpath(gnmi_proto ${DEP_ELEMENT})
 
 add_dependencies(gnmi_proto grpc_proto)
 
-target_include_directories(gnmi_proto PRIVATE ${PROTO_OUT_DIR})
+target_include_directories(gnmi_proto PRIVATE ${PB_OUT_DIR})
 
 target_link_libraries(gnmi_proto
     PUBLIC
@@ -275,45 +275,45 @@ install(TARGETS gnmi_proto LIBRARY)
 
 # ywrapper_proto_o
 add_library(ywrapper_proto_o OBJECT
-    ${PROTO_OUT_DIR}/${YGOT_PROTO_PATH}/yext/yext.pb.cc
-    ${PROTO_OUT_DIR}/${YGOT_PROTO_PATH}/yext/yext.pb.h
-    ${PROTO_OUT_DIR}/${YGOT_PROTO_PATH}/ywrapper/ywrapper.pb.cc
-    ${PROTO_OUT_DIR}/${YGOT_PROTO_PATH}/ywrapper/ywrapper.pb.h
+    ${PB_OUT_DIR}/${YGOT_PROTO_PATH}/yext/yext.pb.cc
+    ${PB_OUT_DIR}/${YGOT_PROTO_PATH}/yext/yext.pb.h
+    ${PB_OUT_DIR}/${YGOT_PROTO_PATH}/ywrapper/ywrapper.pb.cc
+    ${PB_OUT_DIR}/${YGOT_PROTO_PATH}/ywrapper/ywrapper.pb.h
 )
 
-target_include_directories(ywrapper_proto_o PRIVATE ${PROTO_OUT_DIR})
+target_include_directories(ywrapper_proto_o PRIVATE ${PB_OUT_DIR})
 
 # openconfig_enums_proto_o
 add_library(openconfig_enums_proto_o OBJECT
-    ${PROTO_OUT_DIR}/openconfig/enums/enums.pb.cc
-    ${PROTO_OUT_DIR}/openconfig/enums/enums.pb.h
+    ${PB_OUT_DIR}/openconfig/enums/enums.pb.cc
+    ${PB_OUT_DIR}/openconfig/enums/enums.pb.h
 )
 
 add_dependencies(openconfig_enums_proto_o ywrapper_proto_o)
 
 target_include_directories(
-    openconfig_enums_proto_o PRIVATE ${PROTO_OUT_DIR})
+    openconfig_enums_proto_o PRIVATE ${PB_OUT_DIR})
 
 # openconfig_proto_o
 add_library(openconfig_proto_o OBJECT
-    ${PROTO_OUT_DIR}/openconfig/openconfig.pb.cc
-    ${PROTO_OUT_DIR}/openconfig/openconfig.pb.h
+    ${PB_OUT_DIR}/openconfig/openconfig.pb.cc
+    ${PB_OUT_DIR}/openconfig/openconfig.pb.h
 )
 
 add_dependencies(openconfig_proto_o openconfig_enums_proto_o)
 
-target_include_directories(openconfig_proto_o PRIVATE ${PROTO_OUT_DIR})
+target_include_directories(openconfig_proto_o PRIVATE ${PB_OUT_DIR})
 
 # openconfig_goog_bcm_proto_o
 add_library(openconfig_goog_bcm_proto_o OBJECT
-    ${PROTO_OUT_DIR}/stratum/public/proto/openconfig-goog-bcm.pb.cc
-    ${PROTO_OUT_DIR}/stratum/public/proto/openconfig-goog-bcm.pb.h
+    ${PB_OUT_DIR}/stratum/public/proto/openconfig-goog-bcm.pb.cc
+    ${PB_OUT_DIR}/stratum/public/proto/openconfig-goog-bcm.pb.h
 )
 
 add_dependencies(openconfig_goog_bcm_proto_o ywrapper_proto_o)
 
 target_include_directories(
-    openconfig_goog_bcm_proto_o PRIVATE ${PROTO_OUT_DIR})
+    openconfig_goog_bcm_proto_o PRIVATE ${PB_OUT_DIR})
 
 # openconfig_proto
 add_library(openconfig_proto SHARED
@@ -331,38 +331,38 @@ install(TARGETS openconfig_proto LIBRARY)
 
 # stratum_proto1_o
 add_library(stratum_proto1_o OBJECT
-    ${PROTO_OUT_DIR}/stratum/public/proto/p4_table_defs.pb.h
-    ${PROTO_OUT_DIR}/stratum/public/proto/p4_table_defs.pb.cc
-    ${PROTO_OUT_DIR}/stratum/public/proto/p4_annotation.pb.h
-    ${PROTO_OUT_DIR}/stratum/public/proto/p4_annotation.pb.cc
-    ${PROTO_OUT_DIR}/stratum/hal/lib/p4/p4_control.pb.h
-    ${PROTO_OUT_DIR}/stratum/hal/lib/p4/p4_control.pb.cc
-    ${PROTO_OUT_DIR}/stratum/hal/lib/p4/common_flow_entry.pb.h
-    ${PROTO_OUT_DIR}/stratum/hal/lib/p4/common_flow_entry.pb.cc
-    ${PROTO_OUT_DIR}/stratum/hal/lib/p4/p4_table_map.pb.h
-    ${PROTO_OUT_DIR}/stratum/hal/lib/p4/p4_table_map.pb.cc
-    ${PROTO_OUT_DIR}/stratum/hal/lib/p4/p4_pipeline_config.pb.h
-    ${PROTO_OUT_DIR}/stratum/hal/lib/p4/p4_pipeline_config.pb.cc
-    ${PROTO_OUT_DIR}/stratum/hal/lib/common/common.pb.cc
-    ${PROTO_OUT_DIR}/stratum/hal/lib/common/common.pb.h
-    ${PROTO_OUT_DIR}/stratum/hal/lib/tdi/tdi.pb.h
-    ${PROTO_OUT_DIR}/stratum/hal/lib/tdi/tdi.pb.cc
+    ${PB_OUT_DIR}/stratum/public/proto/p4_table_defs.pb.h
+    ${PB_OUT_DIR}/stratum/public/proto/p4_table_defs.pb.cc
+    ${PB_OUT_DIR}/stratum/public/proto/p4_annotation.pb.h
+    ${PB_OUT_DIR}/stratum/public/proto/p4_annotation.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_control.pb.h
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_control.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/common_flow_entry.pb.h
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/common_flow_entry.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_table_map.pb.h
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_table_map.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_pipeline_config.pb.h
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_pipeline_config.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/common/common.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/common/common.pb.h
+    ${PB_OUT_DIR}/stratum/hal/lib/tdi/tdi.pb.h
+    ${PB_OUT_DIR}/stratum/hal/lib/tdi/tdi.pb.cc
 )
 
 # Ensure that the header files on which we depend have been generated
 # before we start building the current library.
 add_dependencies(stratum_proto1_o p4runtime_proto)
 
-target_include_directories(stratum_proto1_o PRIVATE ${PROTO_OUT_DIR})
+target_include_directories(stratum_proto1_o PRIVATE ${PB_OUT_DIR})
 
 # stratum_proto2_o
 add_library(stratum_proto2_o OBJECT
-    ${PROTO_OUT_DIR}/stratum/public/proto/error.pb.cc
-    ${PROTO_OUT_DIR}/stratum/public/proto/error.pb.h
-    ${PROTO_OUT_DIR}/stratum/hal/lib/p4/forwarding_pipeline_configs.pb.cc
-    ${PROTO_OUT_DIR}/stratum/hal/lib/p4/forwarding_pipeline_configs.pb.h
-    ${PROTO_OUT_DIR}/stratum/hal/lib/phal/db.pb.cc
-    ${PROTO_OUT_DIR}/stratum/hal/lib/phal/db.pb.h
+    ${PB_OUT_DIR}/stratum/public/proto/error.pb.cc
+    ${PB_OUT_DIR}/stratum/public/proto/error.pb.h
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/forwarding_pipeline_configs.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/forwarding_pipeline_configs.pb.h
+    ${PB_OUT_DIR}/stratum/hal/lib/phal/db.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/phal/db.pb.h
 )
 
 # Ensure that the header files on which we depend have been generated
@@ -370,7 +370,7 @@ add_library(stratum_proto2_o OBJECT
 add_dependencies(stratum_proto2_o p4runtime_proto)
 add_dependencies(stratum_proto2_o stratum_proto1_o)
 
-target_include_directories(stratum_proto2_o PRIVATE ${PROTO_OUT_DIR})
+target_include_directories(stratum_proto2_o PRIVATE ${PB_OUT_DIR})
 
 # stratum_proto
 add_library(stratum_proto SHARED


### PR DESCRIPTION
- Renamed the `GOOGLE_SOURCE_DIR` variable to `GOOGLEAPIS_SOURCE_DIR`, to emphasize its association with the `googleapis` directory.

- Renamed the `PROTO_OUT_DIR` variable to `PB_OUT_DIR`, to emphasize its association with the `pb.out` directory.

- Renamed the `stratum` target to `stratum_static`, to emphasize the fact that the library is static by design. This reserves the `stratum` target name for possible use for a shared library.

- Made `stratum_lib_o` dependent on the `gnmi_proto` target, to ensure that `gnmi.pb.h` is generated before we attempt to compile `credentials_manager.cc`.

- Changed networking-recipe project version to 23.01, to match external numbering.

Signed-off-by: Derek G Foster <derek.foster@intel.com>