### PR TITLE
Remove KRNLMON_SUPPORT compile-time conditional

### DIFF
--- a/infrap4d/CMakeLists.txt
+++ b/infrap4d/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Builds infrap4d daemon
+#
+# Copyright 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+
 cmake_minimum_required(VERSION 3.12)
 
 project(infrap4d VERSION 0.1.0 LANGUAGES C CXX)
@@ -21,7 +27,6 @@ target_include_directories(infrap4d PRIVATE ${STRATUM_SOURCE_DIR})
 
 if(WITH_KRNLMON)
     target_include_directories(infrap4d PRIVATE ${KRNLMON_SOURCE_DIR})
-    target_compile_definitions(infrap4d PRIVATE KRNLMON_SUPPORT)
 endif()
 
 target_link_libraries(infrap4d PRIVATE

--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -1,7 +1,8 @@
 # CMake build file for Stratum code.
 #
-# Copyright 2022 Intel Corporation
+# Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
+#
 
 cmake_minimum_required(VERSION 3.5)
 project(stratum)
@@ -280,10 +281,6 @@ target_include_directories(stratum_target_o PRIVATE
     ${STRATUM_INCLUDES}
     ${SDE_INSTALL_DIR}/include
 )
-
-if(WITH_KRNLMON)
-    target_compile_definitions(stratum_target_o PRIVATE KRNLMON_SUPPORT)
-endif()
 
 add_dependencies(stratum_target_o stratum_proto)
 


### PR DESCRIPTION
- Removed CMake commands to define the KRNLMON_SUPPORT conditional when building stratum and infrap4d. This conditional was eliminated as part of the krnlmon synchronization rework.

Signed-off-by: Derek G Foster <derek.foster@intel.com>