### PR TITLE
fixing `gmock-gbl` dependency

### DIFF
--- a/setup/CMakeLists.txt
+++ b/setup/CMakeLists.txt
@@ -241,7 +241,8 @@ endif()
 #############
 
 ExternalProject_Add(gmock-gbl
-  GIT_REPOSITORY  https://github.com/apriorit/gmock-global-sample.git
+  GIT_REPOSITORY  ${GMOCK_GBL_GIT_URL}
+  GIT_TAG         ${GMOCK_GBL_GIT_TAG}
   GIT_PROGRESS    ON
 
   SOURCE_DIR

--- a/setup/deps.cmake
+++ b/setup/deps.cmake
@@ -19,6 +19,9 @@ set(GLOG_GIT_TAG a8e0007e96ff96145022c488e367da10f835c75d) # v0.6.0-rc1
 set(GRPC_GIT_URL https://github.com/google/grpc.git)
 set(GRPC_GIT_TAG 90ccf24d22b6fc909a1021ebd89fd8c838467d26) # v1.50.1
 
+set(GMOCK_GBL_GIT_URL https://github.com/apriorit/gmock-global-sample.git)
+set(GMOCK_GBL_GIT_TAG v1.11.0) # uses googletest v1.11.0
+
 set(GTEST_GIT_URL https://github.com/google/googletest.git)
 set(GTEST_GIT_TAG release-1.11.0)
 


### PR DESCRIPTION
gmock-gbl branch `master` uses an older version of googletest which gives a compiling error in GCC 11, 12 ([as described by this SO post](https://stackoverflow.com/q/69935158)). my PR uses gmock-gbl's branch `v1.11.0` with the correct googletest version