### PR TITLE
Create scripts to patch DPDK and ES2K SDEs

### DIFF
--- a/scripts/dpdk/patch-dpdk-sde-rpaths.sh
+++ b/scripts/dpdk/patch-dpdk-sde-rpaths.sh
@@ -1,0 +1,95 @@
+# Copyright 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+# Patches several libraries in the DPDK Target SDE so infrap4d can be run
+# without requiring that LD_LIBRARY_PATH be set.
+#
+# Note that P4 Control Plane must be built with the RPATH option enabled
+# for this to work.
+#
+
+# Abort on error.
+set -e
+
+# Libraries to patch.
+dpdk_infra_lib=libdpdk_infra.so
+dpdk_infra_path=${SDE_INSTALL}/lib/${dpdk_infra_lib}
+
+driver_lib=libdriver.so
+driver_path=${SDE_INSTALL}/lib/${driver_lib}
+
+pipeline_lib=librte_pipeline.so
+
+# Error checks.
+if [ -z "${SDE_INSTALL}" ]; then
+    echo "SDE_INSTALL not defined!"
+    exit 1
+fi
+
+if [ ! -e "${dpdk_infra_path}" ]; then
+    echo "Not a DPDK SDE!"
+    exit 1
+fi
+
+# RTE library paths.
+libx86_64=${SDE_INSTALL}/lib/x86_64-linux-gnu
+lib64=${SDE_INSTALL}/lib64
+
+# RTE libraries are in lib/x86_64-linux-gnu directory.
+patch_lib_x86_64_libs() {
+    echo "Patching ${dpdk_infra_path}"
+    patchelf --set-rpath '$ORIGIN/x86_64-linux-gnu' ${dpdk_infra_path}
+    patchelf --print-rpath ${dpdk_infra_path}
+
+    echo "Patching ${driver_path}"
+    patchelf --set-rpath '$ORIGIN:$ORIGIN/x86_64-linux-gnu' ${driver_path}
+    patchelf --print-rpath ${driver_path}
+
+    filename="${SDE_INSTALL}/lib/x86_64-linux-gnu/${pipeline_lib}"
+    echo "Patching ${filename}"
+    patchelf --set-rpath '$ORIGIN' ${filename}
+    patchelf --print-rpath ${filename}
+}
+
+# RTE libraries are in lib64 directory.
+patch_lib64_libs() {
+    echo "Patching ${dpdk_infra_path}"
+    patchelf --set-rpath '$ORIGIN/../lib64' ${dpdk_infra_path}
+    patchelf --print-rpath ${dpdk_infra_path}
+
+    echo "Patching ${driver_path}"
+    patchelf --set-rpath '$ORIGIN:$ORIGIN/../lib64' ${driver_path}
+    patchelf --print-rpath ${driver_path}
+
+    filename="${SDE_INSTALL}/lib64/${pipeline_lib}"
+    echo "Patching ${filename}"
+    patchelf --set-rpath '$ORIGIN' ${filename}
+    patchelf --print-rpath ${filename}
+}
+
+# RTE libraries are in lib directory.
+patch_lib_libs() {
+    echo "Patching ${dpdk_infra_path}"
+    patchelf --set-rpath '$ORIGIN' ${dpdk_infra_path}
+    patchelf --print-rpath ${dpdk_infra_path}
+
+    echo "Patching ${driver_path}"
+    patchelf --set-rpath '$ORIGIN' ${driver_path}
+    patchelf --print-rpath ${driver_path}
+
+    filename="${SDE_INSTALL}/lib/${pipeline_lib}"
+    echo "Patching ${filename}"
+    patchelf --set-rpath '$ORIGIN' ${filename}
+    patchelf --print-rpath ${filename}
+}
+
+# Patch libraries.
+if [ -e "${libx86_64}/${pipeline_lib}" ]; then
+    patch_lib_x86_64_libs
+elif [ -e "${lib64}/${pipeline_lib}" ]; then
+    patch_lib64_libs
+elif [ -e "${SDE_INSTALL}/lib/${pipeline_lib}" ]; then
+    patch_lib_libs
+else
+    echo "No libraries patched!"
+fi

--- a/scripts/dpdk/set-dpdk-sde-target.sh
+++ b/scripts/dpdk/set-dpdk-sde-target.sh
@@ -1,0 +1,31 @@
+# Copyright 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+# Creates a share/TARGET file that identifies this as an ES2K SDE.
+# This allows Bazel (or any other tool) to determine the SDE type.
+#
+
+# Abort on error.
+set -e
+
+# Error check.
+if [ -z "${SDE_INSTALL}" ]; then
+    echo "SDE_INSTALL not defined!"
+    exit 1
+fi
+
+print_target_type() {
+    read TYPE
+    echo "Target type is '$TYPE'"
+}
+
+# Create TARGET file.
+filename="${SDE_INSTALL}/share/TARGET"
+if [ ! -e "${filename}" ]; then
+    echo "Creating ${filename}"
+    echo "DPDK" > ${filename}
+    echo "TARGET file created"
+else
+    echo "TARGET file already exists"
+    print_target_type < ${filename}
+fi

--- a/scripts/es2k/patch-es2k-sde-rpaths.sh
+++ b/scripts/es2k/patch-es2k-sde-rpaths.sh
@@ -1,0 +1,94 @@
+# Copyright 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+# Patches several libraries in the ES2K Target SDE so infrap4d can be run
+# without requiring that LD_LIBRARY_PATH be set.
+#
+# Note that P4 Control Plane must be built with the RPATH option enabled
+# for this to work.
+#
+
+# Abort on error.
+set -e
+
+# Libraries to patch.
+es2k_infra_lib=libcpf_pmd_infra.so
+es2k_infra_path=${SDE_INSTALL}/lib/${es2k_infra_lib}
+
+driver_lib=libdriver.so
+driver_path=${SDE_INSTALL}/lib/${driver_lib}
+
+net_idpf_lib=librte_net_idpf.so
+
+# Error checks.
+if [ -z "${SDE_INSTALL}" ]; then
+    echo "SDE_INSTALL not defined!"
+    exit 1
+fi
+
+if [ ! -e "${es2k_infra_path}" ]; then
+    echo "Not an ES2K SDE!"
+    exit 1
+fi
+
+# RTE library paths.
+libx86_64=${SDE_INSTALL}/lib/x86_64-linux-gnu
+lib64=${SDE_INSTALL}/lib64
+
+# RTE libraries are in lib/x86_64-linux-gnu directory.
+patch_lib_x86_64_libs() {
+    echo "Patching ${es2k_infra_path}"
+    patchelf --set-rpath '$ORIGIN/x86_64-linux-gnu' ${es2k_infra_path}
+    patchelf --print-rpath ${es2k_infra_path}
+
+    echo "Patching ${driver_path}"
+    patchelf --set-rpath '$ORIGIN:$ORIGIN/x86_64-linux-gnu' ${driver_path}
+    patchelf --print-rpath ${driver_path}
+
+    filename="${SDE_INSTALL}/lib/x86_64-linux-gnu/${net_idpf_lib}"
+    echo "Patching ${filename}"
+    patchelf --set-rpath '$ORIGIN' ${filename}
+    patchelf --print-rpath ${filename}
+}
+
+# RTE libraries are in lib64 directory.
+patch_lib64_libs() {
+    echo "Patching ${es2k_infra_path}"
+    patchelf --set-rpath '$ORIGIN/../lib64' ${es2k_infra_path}
+    patchelf --print-rpath ${es2k_infra_path}
+
+    echo "Patching ${driver_path}"
+    patchelf --set-rpath '$ORIGIN:$ORIGIN/../lib64' ${driver_path}
+    patchelf --print-rpath ${driver_path}
+
+    filename="${SDE_INSTALL}/lib64/${net_idpf_lib}"
+    echo "Patching ${filename}"
+    patchelf --set-rpath '$ORIGIN' ${filename}
+}
+
+# RTE libraries are in lib directory.
+patch_lib_libs() {
+    echo "Patching ${es2k_infra_path}"
+    patchelf --set-rpath '$ORIGIN' ${es2k_infra_path}
+    patchelf --print-rpath ${es2k_infra_path}
+
+    echo "Patching ${driver_path}"
+    patchelf --set-rpath '$ORIGIN' ${driver_path}
+    patchelf --print-rpath ${driver_path}
+
+    filename="${SDE_INSTALL}/lib/${net_idpf_lib}"
+    echo "Patching ${filename}"
+    patchelf --set-rpath '$ORIGIN' ${filename}
+    patchelf --print-rpath ${filename}
+}
+
+# Patch libraries.
+if [ -e "${libx86_64}/${net_idpf_lib}" ]; then
+    patch_lib_x86_64_libs
+elif [ -e "${lib64}/${net_idpf_lib}" ]; then
+    patch_lib64_libs
+elif [ -e "${SDE_INSTALL}/lib/${net_idpf_lib}" ]; then
+    patch_lib_libs
+else
+    echo "No libraries patched!"
+fi

--- a/scripts/es2k/set-es2k-sde-target.sh
+++ b/scripts/es2k/set-es2k-sde-target.sh
@@ -1,0 +1,31 @@
+# Copyright 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+# Creates a share/TARGET file that identifies this as an DPDK SDE.
+# This allows Bazel (or any other tool) to determine the SDE type.
+#
+
+# Abort on error.
+set -e
+
+# Error check.
+if [ -z "${SDE_INSTALL}" ]; then
+    echo "SDE_INSTALL not defined!"
+    exit 1
+fi
+
+print_target_type() {
+    read TYPE
+    echo "Target type is '$TYPE'"
+}
+
+# Create TARGET file.
+filename="${SDE_INSTALL}/share/TARGET"
+if [ ! -e "${filename}" ]; then
+    echo "Creating ${filename}"
+    echo "ES2K" > ${filename}
+    echo "TARGET file created"
+else
+    echo "TARGET file already exists"
+    print_target_type < ${filename}
+fi


### PR DESCRIPTION
- Implement scripts to create a TARGET file in the SDE `share` directory that specifies the target type. Bazel uses this file to verify the SDE type when building ES2K targets.

- Implement scripts to patch several SDE target libraries so `infrap4d` can be loaded without requiring the `LD_LIBRARY_PATH` environment variable. Note that P4 Control Plane needs to be built with the RPATH option enabled for this to work.