### PR TITLE
Enable RPATH support by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ unset(_target_action)
 # Feature toggles #
 ###################
 
-option(SET_RPATH    "Set RPATH in libraries and executables" OFF)
+option(SET_RPATH    "Set RPATH in libraries and executables" ON)
 
 option(WITH_KRNLMON "Enable Kernel Monitor support" ON)
 option(WITH_OVSP4RT "Enable OVS support" ON)

--- a/config-cross-recipe.sh
+++ b/config-cross-recipe.sh
@@ -34,20 +34,24 @@ _TOOLFILE=${CMAKE_TOOLCHAIN_FILE}
 # Displays help text
 print_help() {
     echo ""
-    echo "Configure recipe build"
+    echo "Configure recipe build for ES2K"
     echo ""
-    echo "Options:"
+    echo "Paths:"
     echo "  --build=DIR      -B  Build directory path [${_BLD_DIR}]"
     echo "  --deps=DIR*      -D  Target dependencies directory [${_DEPS_DIR}]"
-    echo "  --dry-run        -n  Display cmake parameter values and exit"
-    echo "  --help           -h  Display this help text"
     echo "  --hostdeps=DIR*  -H  Host dependencies directory [${_HOST_DIR}]"
     echo "  --ovs=DIR*       -O  OVS install directory [${_OVS_DIR}]"
-    echo "  --no-krnlmon         Exclude Kernel Monitor"
-    echo "  --no-ovs             Exclude OVS support"
     echo "  --prefix=DIR*    -P  Install directory prefix [${_PREFIX}]"
     echo "  --sde=DIR*       -S  SDE install directory [${_SDE_DIR}]"
     echo "  --toolchain=FILE -T  CMake toolchain file"
+    echo ""
+    echo "Options:"
+    echo "  --dry-run        -n  Display cmake parameter values and exit"
+    echo "  --help           -h  Display this help text"
+    echo "  --no-krnlmon         Exclude Kernel Monitor"
+    echo "  --no-ovs             Exclude OVS support"
+    echo "  --no-rpath           Disable RPATH support"
+    echo "  --rpath              Enable RPATH support"
     echo ""
     echo "* '//' at the beginning of the directory path will be replaced"
     echo "  with the sysroot directory path."
@@ -62,15 +66,32 @@ print_help() {
     echo ""
 }
 
+# Displays CMake parameters
+print_cmake_params() {
+    echo ""
+    echo "CMAKE_BUILD_TYPE=${_BLD_TYPE}"
+    echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
+    echo "CMAKE_TOOLCHAIN_FILE=${_TOOLFILE}"
+    echo "DEPEND_INSTALL_DIR=${_DEPS_DIR}"
+    echo "HOST_DEPEND_DIR=${_HOST_DIR}"
+    echo "OVS_INSTALL_DIR=${_OVS_DIR}"
+    echo "SDE_INSTALL_DIR=${_SDE_DIR}"
+    [ -n "${_WITH_KRNLMON}" ] && echo "${_WITH_KRNLMON:2}"
+    [ -n "${_WITH_OVSP4RT}" ] && echo "${_WITH_OVSP4RT:2}"
+    [ -n "${_SET_RPATH}" ] && echo "${_SET_RPATH:2}"
+    echo ""
+}
+
 # Parse options
 SHORTOPTS=B:D:H:O:P:S:T:hn
 LONGOPTS=build:,deps:,dry-run,help,hostdeps:,ovs:,prefix:,sde:,toolchain:
-LONGOPTS=${LONGOPTS},no-krnlmon,no-ovs,rfs-enable
+LONGOPTS=${LONGOPTS},no-krnlmon,no-ovs,no-rpath,rpath
 
 eval set -- `getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@"`
 
 while true ; do
     case "$1" in
+    # Paths
     -B|--build)
         echo "Build directory: $2"
         _BLD_DIR=$2
@@ -78,21 +99,9 @@ while true ; do
     -D|--deps)
         _DEPS_DIR=$2
         shift 2 ;;
-    -n|--dry-run)
-        _DRY_RUN=true
-        shift 1 ;;
-    -h|--help)
-        print_help
-        exit 99 ;;
     -H|--hostdeps)
         _HOST_DIR=$2
         shift 2 ;;
-    --no-krnlmon)
-        _WITH_KRNLMON=FALSE
-        shift 1 ;;
-    --no-ovs)
-        _WITH_OVSP4RT=FALSE
-        shift 1 ;;
     -O|--ovs)
         _OVS_DIR=$2
         shift 2 ;;
@@ -106,6 +115,25 @@ while true ; do
     -T|--toolchain)
         _TOOLFILE=$2
         shift 2 ;;
+    # Options
+    -n|--dry-run)
+        _DRY_RUN=true
+        shift 1 ;;
+    -h|--help)
+        print_help
+        exit 99 ;;
+    --no-krnlmon)
+        _WITH_KRNLMON=FALSE
+        shift 1 ;;
+    --no-ovs)
+        _WITH_OVSP4RT=FALSE
+        shift 1 ;;
+    --no-rpath)
+        _SET_RPATH=FALSE
+        shift 1 ;;
+    --rpath)
+        _SET_RPATH=TRUE
+        shift 1 ;;
     --)
         shift
         break ;;
@@ -125,19 +153,10 @@ done
 # Expand WITH_KRNLMON and WITH_OVSP4RT if not empty
 [ -n "${_WITH_KRNLMON}" ] && _WITH_KRNLMON=-DWITH_KRNLMON=${_WITH_KRNLMON}
 [ -n "${_WITH_OVSP4RT}" ] && _WITH_OVSP4RT=-DWITH_OVSP4RT=${_WITH_OVSP4RT}
+[ -n "${_SET_RPATH}" ] && _SET_RPATH=-DSET_RPATH=${_SET_RPATH}
 
 if [ "${_DRY_RUN}" = "true" ]; then
-    echo ""
-    echo "CMAKE_BUILD_TYPE=${_BLD_TYPE}"
-    echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
-    echo "CMAKE_TOOLCHAIN_FILE=${_TOOLFILE}"
-    echo "DEPEND_INSTALL_DIR=${_DEPS_DIR}"
-    echo "HOST_DEPEND_DIR=${_HOST_DIR}"
-    echo "OVS_INSTALL_DIR=${_OVS_DIR}"
-    echo "SDE_INSTALL_DIR=${_SDE_DIR}"
-    [ -n "${_WITH_KRNLMON}" ] && echo "${_WITH_KRNLMON:2}"
-    [ -n "${_WITH_OVSP4RT}" ] && echo "${_WITH_OVSP4RT:2}"
-    echo ""
+    print_cmake_params
     exit 0
 fi
 
@@ -152,5 +171,5 @@ cmake -S . -B ${_BLD_DIR} \
     -DOVS_INSTALL_DIR=${_OVS_DIR} \
     -DSDE_INSTALL_DIR=${_SDE_DIR} \
     ${_WITH_KRNLMON} ${_WITH_OVSP4RT} \
-    -DSET_RPATH=TRUE \
+    ${SET_RPATH} \
     -DES2K_TARGET=ON

--- a/make-all.sh
+++ b/make-all.sh
@@ -19,7 +19,6 @@ _HOST_DIR=${HOST_INSTALL}
 _JOBS=8
 _OVS_DIR="${OVS_INSTALL:-ovs/install}"
 _PREFIX="install"
-_RPATH=OFF
 _SDE_DIR=${SDE_INSTALL}
 _TGT_TYPE="DPDK"
 _TOOLFILE=${CMAKE_TOOLCHAIN_FILE}
@@ -52,6 +51,8 @@ print_help() {
     echo "  --jobs=NJOBS     -j  Number of build threads (Default: ${_JOBS})"
     echo "  --no-krnlmon         Exclude Kernel Monitor"
     echo "  --no-ovs             Exclude OVS support"
+    echo "  --no-rpath           Disable RPATH support"
+    echo "  --rpath              Enable RPATH support"
     echo "  --target=TARGET      Target to build (dpdk|es2k|tofino) [${_TGT_TYPE}]"
     echo ""
     echo "Configurations:"
@@ -171,28 +172,12 @@ while true ; do
     -P|--prefix)
         _PREFIX=$2
         shift 2 ;;
-    --rpath)
-        _RPATH=ON
-        shift 1 ;;
     -S|--sde)
         _SDE_DIR=$2
         shift 2 ;;
     -T|--toolchain)
         _TOOLFILE=$2
         shift 2 ;;
-    # Configurations
-    --debug)
-        _BLD_TYPE="Debug"
-        shift ;;
-    --minsize)
-        _BLD_TYPE="MinSizeRel"
-        shift ;;
-    --reldeb)
-        _BLD_TYPE="RelWithDebInfo"
-        shift ;;
-    --release)
-        _BLD_TYPE="Release"
-        shift ;;
     # Options
     --coverage)
         _COVERAGE="-DTEST_COVERAGE=ON"
@@ -223,6 +208,19 @@ while true ; do
         # convert to uppercase
         _TGT_TYPE=${2^^}
         shift 2 ;;
+    # Configurations
+    --debug)
+        _BLD_TYPE="Debug"
+        shift ;;
+    --minsize)
+        _BLD_TYPE="MinSizeRel"
+        shift ;;
+    --reldeb)
+        _BLD_TYPE="RelWithDebInfo"
+        shift ;;
+    --release)
+        _BLD_TYPE="Release"
+        shift ;;
     --)
         shift
         break ;;

--- a/make-cross-ovs.sh
+++ b/make-cross-ovs.sh
@@ -31,7 +31,7 @@ _TOOLFILE=${CMAKE_TOOLCHAIN_FILE}
 # Displays help text
 print_help() {
     echo ""
-    echo "Build and install Open vSwitch"
+    echo "Build and install OVS for ES2K"
     echo ""
     echo "Options:"
     echo "  --build=DIR      -B  Build directory path [${_BLD_DIR}]"


### PR DESCRIPTION
cmake build system:

- Change default value of SET_RPATH option from OFF to ON.

make-all.sh:

- Change default value of RPATH option from OFF to undefined. --rpath and --no-rpath cause the appropriate SET_RPATH argument to be specified on the cmake command line, overriding the default in the cmake command file.

- Add --rpath and --no-rpath options to the help text.

config-cross-recipe.sh:

- Add support for --rpath and --no-rpath options, with the same semantics as make-all.sh.

- Refactor code to display output for the dry-run option into a print_cmake_params() function.

- Separate help text into Paths and Options sections.