### PR TITLE
Standardize cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: Apache 2.0
 #
 
-cmake_minimum_required(VERSION 3.5)
+# Version 3.15 is the baseline for P4 Control Plane.
+cmake_minimum_required(VERSION 3.15)
 
 # CMAKE_BUILD_TYPE must be set before the first project() command.
 set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Type of build to perform")

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -3,7 +3,6 @@
 # Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
-cmake_minimum_required(VERSION 3.5)
 
 add_subdirectory(gnmi-ctl)
 add_subdirectory(p4rt-ctl)

--- a/clients/gnmi-ctl/CMakeLists.txt
+++ b/clients/gnmi-ctl/CMakeLists.txt
@@ -1,9 +1,8 @@
 # Build file for gnmi-ctl.
 #
-# Copyright 2022 Intel Corporation
+# Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
-cmake_minimum_required(VERSION 3.5)
 
 ##################
 # Build gnmi-ctl #

--- a/clients/sgnmi_cli/CMakeLists.txt
+++ b/clients/sgnmi_cli/CMakeLists.txt
@@ -3,7 +3,6 @@
 # Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
-cmake_minimum_required(VERSION 3.5)
 
 ###################
 # Build sgnmi_cli #

--- a/infrap4d/CMakeLists.txt
+++ b/infrap4d/CMakeLists.txt
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache 2.0
 #
 
-cmake_minimum_required(VERSION 3.12)
-
 add_subdirectory(daemon)
 
 set(STRATUM_TDI_BIN_DIR ${STRATUM_SOURCE_DIR}/stratum/hal/bin/tdi)

--- a/infrap4d/daemon/CMakeLists.txt
+++ b/infrap4d/daemon/CMakeLists.txt
@@ -1,9 +1,7 @@
 # CMake build file for infrap4d/daemon
 #
-# Copyright 2022 Intel Corporation
+# Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
-
-cmake_minimum_required(VERSION 3.5)
 
 add_library(daemon_o OBJECT
    daemon.c

--- a/krnlmon/CMakeLists.txt
+++ b/krnlmon/CMakeLists.txt
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache 2.0
 #
 
-cmake_minimum_required(VERSION 3.15)
-
 # Path to SAI source directory (for krnlmon)
 set(SAI_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/SAI" CACHE PATH
     "Path to SAI source directory")

--- a/make-all.sh
+++ b/make-all.sh
@@ -43,10 +43,11 @@ print_help() {
     echo "  --ovs=DIR        -O  OVS install directory [${_OVS_DIR}]"
     echo "  --prefix=DIR     -P  Install directory prefix [${_PREFIX}]"
     echo "  --sde=DIR        -S  SDE install directory [${_SDE_DIR}]"
+    echo "  --staging=DIR        Staging directory prefix [${_STAGING}]"
     echo "  --toolchain=FILE -T  CMake toolchain file [${_TOOLFILE}]"
     echo ""
     echo "Options:"
-    echo "  --coverage           Measure unit test code coverage"
+    echo "  --coverage           Instrument build to measure code coverage"
     echo "  --dry-run        -n  Display cmake parameter values and exit"
     echo "  --help           -h  Display this help text"
     echo "  --jobs=NJOBS     -j  Number of build threads (Default: ${_JOBS})"
@@ -79,6 +80,7 @@ print_cmake_params() {
     echo ""
     echo "CMAKE_BUILD_TYPE=${_BLD_TYPE}"
     echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
+    [ -n "${_CMAKE_STAGING_PREFIX}" ] && echo "${_CMAKE_STAGING_PREFIX:2}"
     [ -n "${_CMAKE_TOOLCHAIN_FILE}" ] && echo "${_CMAKE_TOOLCHAIN_FILE:2}"
     echo "DEPEND_INSTALL_DIR=${_DEPS_DIR}"
     [ -n "${_HOST_DEPEND_DIR}" ] && echo "${_HOST_DEPEND_DIR:2}"
@@ -121,6 +123,7 @@ config_recipe() {
     cmake -S . -B ${_BLD_DIR} \
         -DCMAKE_BUILD_TYPE=${_BLD_TYPE} \
         -DCMAKE_INSTALL_PREFIX=${_PREFIX} \
+        ${_CMAKE_STAGING_PREFIX} \
         ${_CMAKE_TOOLCHAIN_FILE} \
         -DDEPEND_INSTALL_DIR=${_DEPS_DIR} \
         ${_HOST_DEPEND_DIR} \
@@ -147,7 +150,7 @@ build_recipe() {
 SHORTOPTS=D:H:O:P:S:T:
 SHORTOPTS=${SHORTOPTS}hj:n
 
-LONGOPTS=deps:,hostdeps:,ovs:,prefix:,sde:,target:,toolchain:
+LONGOPTS=deps:,hostdeps:,ovs:,prefix:,sde:,staging:,target:,toolchain:
 LONGOPTS=${LONGOPTS},debug,release,minsize,reldeb
 LONGOPTS=${LONGOPTS},dry-run,help,jobs:,no-krnlmon,no-ovs
 LONGOPTS=${LONGOPTS},coverage,rpath,no-rpath
@@ -171,11 +174,11 @@ while true ; do
     -P|--prefix)
         _PREFIX=$2
         shift 2 ;;
-    --rpath)
-        _RPATH=ON
-        shift 1 ;;
     -S|--sde)
         _SDE_DIR=$2
+        shift 2 ;;
+    --staging)
+        _STAGING=$2
         shift 2 ;;
     -T|--toolchain)
         _TOOLFILE=$2
@@ -239,6 +242,10 @@ done
 if [ -z "${_SDE_DIR}" ]; then
     echo "ERROR: SDE_INSTALL not defined!"
     exit 1
+fi
+
+if [ -n "${_STAGING}" ]; then
+    _CMAKE_STAGING_PREFIX=-DCMAKE_STAGING_PREFIX=${_STAGING}
 fi
 
 # --host and --toolfile are only used when cross-compiling

--- a/ovs-p4rt/CMakeLists.txt
+++ b/ovs-p4rt/CMakeLists.txt
@@ -3,7 +3,6 @@
 # Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
-cmake_minimum_required(VERSION 3.5)
 
 include(CheckLibraryExists)
 

--- a/ovs-p4rt/dpdk/CMakeLists.txt
+++ b/ovs-p4rt/dpdk/CMakeLists.txt
@@ -3,8 +3,6 @@
 # Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-cmake_minimum_required(VERSION 3.5)
-
 add_library(ovsp4rt_p4_mapping_o OBJECT
     p4_name_mapping.h
 )

--- a/ovs-p4rt/es2k/CMakeLists.txt
+++ b/ovs-p4rt/es2k/CMakeLists.txt
@@ -3,8 +3,6 @@
 # Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-cmake_minimum_required(VERSION 3.5)
-
 add_library(ovsp4rt_p4_mapping_o OBJECT
     p4_name_mapping.h
 )

--- a/ovs/CMakeLists.txt
+++ b/ovs/CMakeLists.txt
@@ -1,10 +1,11 @@
 # CMake build file for Open vSwitch
 #
-# Copyright 2022 Intel Corporation
+# Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
-cmake_minimum_required(VERSION 3.5)
+# Version 3.15 is the baseline for P4 Control Plane.
+cmake_minimum_required(VERSION 3.15)
 
 project(ovs LANGUAGES C)
 

--- a/setup/CMakeLists.txt
+++ b/setup/CMakeLists.txt
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Version 3.15 is the baseline for P4 Control Plane.
 cmake_minimum_required(VERSION 3.15)
 
-project(dependencies VERSION 1 LANGUAGES C CXX)
+project(stratum-deps VERSION 1 LANGUAGES C CXX)
 
 include(ExternalProject)
 include(CMakePrintHelpers)

--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: Apache 2.0
 #
 
-cmake_minimum_required(VERSION 3.12)
+# Version 3.15 is the baseline for P4 Control Plane.
+cmake_minimum_required(VERSION 3.15)
 
 project(stratum)
 


### PR DESCRIPTION
- Specify `cmake_minimum_required(VERSION 3.15)` in all CMakeLists.txt files that are the root of a project().

- Remove `cmake_minimum_required()` commands from all CMakeLists.txt files that are not the root of a project().