### PR TITLE
Refine config-cross-recipe script

### DIFF
--- a/config-cross-recipe.sh
+++ b/config-cross-recipe.sh
@@ -20,7 +20,10 @@ fi
 
 _SYSROOT=${SDKTARGETSYSROOT}
 
-# Default values
+##################
+# Default values #
+##################
+
 _BLD_DIR=build
 _BLD_TYPE=RelWithDebInfo
 _DEPS_DIR="${DEPEND_INSTALL:-//opt/deps}"
@@ -31,23 +34,29 @@ _PREFIX=install
 _SDE_DIR="${SDE_INSTALL:-//opt/p4sde}"
 _TOOLFILE=${CMAKE_TOOLCHAIN_FILE}
 
-# Displays help text
+##############
+# print_help #
+##############
+
 print_help() {
     echo ""
-    echo "Configure recipe build"
+    echo "Configure P4 Control Plane build"
     echo ""
-    echo "Options:"
+    echo "Paths:"
     echo "  --build=DIR      -B  Build directory path [${_BLD_DIR}]"
     echo "  --deps=DIR*      -D  Target dependencies directory [${_DEPS_DIR}]"
-    echo "  --dry-run        -n  Display cmake parameter values and exit"
-    echo "  --help           -h  Display this help text"
     echo "  --hostdeps=DIR*  -H  Host dependencies directory [${_HOST_DIR}]"
     echo "  --ovs=DIR*       -O  OVS install directory [${_OVS_DIR}]"
-    echo "  --no-krnlmon         Exclude Kernel Monitor"
-    echo "  --no-ovs             Exclude OVS support"
     echo "  --prefix=DIR*    -P  Install directory prefix [${_PREFIX}]"
     echo "  --sde=DIR*       -S  SDE install directory [${_SDE_DIR}]"
+    echo "  --staging=DIR        Staging directory prefix [${_STAGING}]"
     echo "  --toolchain=FILE -T  CMake toolchain file"
+    echo ""
+    echo "Options:"
+    echo "  --dry-run        -n  Display cmake parameter values and exit"
+    echo "  --help           -h  Display this help text"
+    echo "  --no-krnlmon         Exclude Kernel Monitor"
+    echo "  --no-ovs             Exclude OVS support"
     echo ""
     echo "* '//' at the beginning of the directory path will be replaced"
     echo "  with the sysroot directory path."
@@ -62,50 +71,75 @@ print_help() {
     echo ""
 }
 
-# Parse options
-SHORTOPTS=B:D:H:O:P:S:T:hn
-LONGOPTS=build:,deps:,dry-run,help,hostdeps:,ovs:,prefix:,sde:,toolchain:
-LONGOPTS=${LONGOPTS},no-krnlmon,no-ovs,rfs-enable
+######################
+# print_cmake_params #
+######################
 
-eval set -- `getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@"`
+print_cmake_params() {
+    echo ""
+    echo "CMAKE_BUILD_TYPE=${_BLD_TYPE}"
+    echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
+    [ -n "${_STAGING_PREFIX}" ] && echo "${_STAGING_PREFIX:2}"
+    echo "CMAKE_TOOLCHAIN_FILE=${_TOOLFILE}"
+    echo "DEPEND_INSTALL_DIR=${_DEPS_DIR}"
+    echo "HOST_DEPEND_DIR=${_HOST_DIR}"
+    echo "OVS_INSTALL_DIR=${_OVS_DIR}"
+    echo "SDE_INSTALL_DIR=${_SDE_DIR}"
+    [ -n "${_WITH_KRNLMON}" ] && echo "${_WITH_KRNLMON:2}"
+    [ -n "${_WITH_OVSP4RT}" ] && echo "${_WITH_OVSP4RT:2}"
+    echo ""
+}
+
+######################
+# Parse command line #
+######################
+
+SHORTOPTS=B:D:H:O:P:S:T:hn
+LONGOPTS=build:,deps:,hostdeps:,ovs:,prefix:,sde:,staging:,toolchain:
+LONGOPTS=${LONGOPTS},dry-run,help,no-krnlmon,no-ovs
+
+eval set -- $(getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@")
 
 while true ; do
     case "$1" in
+    # Paths
     -B|--build)
-        echo "Build directory: $2"
         _BLD_DIR=$2
         shift 2 ;;
     -D|--deps)
         _DEPS_DIR=$2
         shift 2 ;;
+    -H|--hostdeps)
+        _HOST_DIR=$2
+        shift 2 ;;
+    -O|--ovs)
+        _OVS_DIR=$2
+        shift 2 ;;
+    -P|--prefix)
+        _PREFIX=$2
+        shift 2 ;;
+    -S|--sde)
+        _SDE_DIR=$2
+        shift 2 ;;
+    --staging)
+        _STAGING=$2
+        shift 2 ;;
+    -T|--toolchain)
+        _TOOLFILE=$2
+        shift 2 ;;
+    # Options
     -n|--dry-run)
         _DRY_RUN=true
         shift 1 ;;
     -h|--help)
         print_help
         exit 99 ;;
-    -H|--hostdeps)
-        _HOST_DIR=$2
-        shift 2 ;;
     --no-krnlmon)
         _WITH_KRNLMON=FALSE
         shift 1 ;;
     --no-ovs)
         _WITH_OVSP4RT=FALSE
         shift 1 ;;
-    -O|--ovs)
-        _OVS_DIR=$2
-        shift 2 ;;
-    -P|--prefix)
-        echo "Install prefix: $2"
-        _PREFIX=$2
-        shift 2 ;;
-    -S|--sde)
-        _SDE_DIR=$2
-        shift 2 ;;
-    -T|--toolchain)
-        _TOOLFILE=$2
-        shift 2 ;;
     --)
         shift
         break ;;
@@ -114,6 +148,19 @@ while true ; do
         exit 1 ;;
     esac
 done
+
+######################
+# Process parameters #
+######################
+
+if [ -z "${_SDE_DIR}" ]; then
+    echo "ERROR: SDE_INSTALL not defined!"
+    exit 1
+fi
+
+if [ -n "${_STAGING}" ]; then
+    _STAGING_PREFIX=-DCMAKE_STAGING_PREFIX=${_STAGING}
+fi
 
 # Substitute ${_SYSROOT}/ for // prefix
 [ "${_DEPS_DIR:0:2}" = "//" ] && _DEPS_DIR=${_SYSROOT}/${_DEPS_DIR:2}
@@ -126,26 +173,22 @@ done
 [ -n "${_WITH_KRNLMON}" ] && _WITH_KRNLMON=-DWITH_KRNLMON=${_WITH_KRNLMON}
 [ -n "${_WITH_OVSP4RT}" ] && _WITH_OVSP4RT=-DWITH_OVSP4RT=${_WITH_OVSP4RT}
 
+# Show parameters if this is a dry run
 if [ "${_DRY_RUN}" = "true" ]; then
-    echo ""
-    echo "CMAKE_BUILD_TYPE=${_BLD_TYPE}"
-    echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
-    echo "CMAKE_TOOLCHAIN_FILE=${_TOOLFILE}"
-    echo "DEPEND_INSTALL_DIR=${_DEPS_DIR}"
-    echo "HOST_DEPEND_DIR=${_HOST_DIR}"
-    echo "OVS_INSTALL_DIR=${_OVS_DIR}"
-    echo "SDE_INSTALL_DIR=${_SDE_DIR}"
-    [ -n "${_WITH_KRNLMON}" ] && echo "${_WITH_KRNLMON:2}"
-    [ -n "${_WITH_OVSP4RT}" ] && echo "${_WITH_OVSP4RT:2}"
-    echo ""
+    print_cmake_params
     exit 0
 fi
+
+####################
+# Configure recipe #
+####################
 
 rm -fr ${_BLD_DIR}
 
 cmake -S . -B ${_BLD_DIR} \
     -DCMAKE_BUILD_TYPE=${_BLD_TYPE} \
     -DCMAKE_INSTALL_PREFIX=${_PREFIX} \
+    ${_STAGING_PREFIX} \
     -DCMAKE_TOOLCHAIN_FILE=${_TOOLFILE} \
     -DDEPEND_INSTALL_DIR=${_DEPS_DIR} \
     -DHOST_DEPEND_DIR=${_HOST_DIR} \

--- a/make-all.sh
+++ b/make-all.sh
@@ -80,8 +80,8 @@ print_cmake_params() {
     echo ""
     echo "CMAKE_BUILD_TYPE=${_BLD_TYPE}"
     echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
-    [ -n "${_CMAKE_STAGING_PREFIX}" ] && echo "${_CMAKE_STAGING_PREFIX:2}"
-    [ -n "${_CMAKE_TOOLCHAIN_FILE}" ] && echo "${_CMAKE_TOOLCHAIN_FILE:2}"
+    [ -n "${_STAGING_PREFIX}" ] && echo "${_STAGING_PREFIX:2}"
+    [ -n "${_TOOLCHAIN_FILE}" ] && echo "${_TOOLCHAIN_FILE:2}"
     echo "DEPEND_INSTALL_DIR=${_DEPS_DIR}"
     [ -n "${_HOST_DEPEND_DIR}" ] && echo "${_HOST_DEPEND_DIR:2}"
     echo "OVS_INSTALL_DIR=${_OVS_DIR}"
@@ -103,7 +103,7 @@ config_ovs() {
     cmake -S ovs -B ${_OVS_BLD} \
         -DCMAKE_BUILD_TYPE=${_BLD_TYPE} \
         -DCMAKE_INSTALL_PREFIX=${_OVS_DIR} \
-        ${_CMAKE_TOOLCHAIN_FILE} \
+        ${_TOOLCHAIN_FILE} \
         -DP4OVS=ON
 }
 
@@ -123,8 +123,8 @@ config_recipe() {
     cmake -S . -B ${_BLD_DIR} \
         -DCMAKE_BUILD_TYPE=${_BLD_TYPE} \
         -DCMAKE_INSTALL_PREFIX=${_PREFIX} \
-        ${_CMAKE_STAGING_PREFIX} \
-        ${_CMAKE_TOOLCHAIN_FILE} \
+        ${_STAGING_PREFIX} \
+        ${_TOOLCHAIN_FILE} \
         -DDEPEND_INSTALL_DIR=${_DEPS_DIR} \
         ${_HOST_DEPEND_DIR} \
         -DOVS_INSTALL_DIR=${_OVS_DIR} \
@@ -155,7 +155,7 @@ LONGOPTS=${LONGOPTS},debug,release,minsize,reldeb
 LONGOPTS=${LONGOPTS},dry-run,help,jobs:,no-krnlmon,no-ovs
 LONGOPTS=${LONGOPTS},coverage,rpath,no-rpath
 
-GETOPTS=`getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@"`
+GETOPTS=$(getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@")
 eval set -- "${GETOPTS}"
 
 # Process command-line options.
@@ -230,7 +230,7 @@ while true ; do
         shift
         break ;;
     *)
-        echo "Internal error!"
+        echo "Invalid parameter: $1"
         exit 1 ;;
     esac
 done
@@ -245,7 +245,7 @@ if [ -z "${_SDE_DIR}" ]; then
 fi
 
 if [ -n "${_STAGING}" ]; then
-    _CMAKE_STAGING_PREFIX=-DCMAKE_STAGING_PREFIX=${_STAGING}
+    _STAGING_PREFIX=-DCMAKE_STAGING_PREFIX=${_STAGING}
 fi
 
 # --host and --toolfile are only used when cross-compiling
@@ -254,7 +254,7 @@ if [ -n "${_HOST_DIR}" ]; then
 fi
 
 if [ -n "${_TOOLFILE}" ]; then
-    _CMAKE_TOOLCHAIN_FILE=-DCMAKE_TOOLCHAIN_FILE=${_TOOLFILE}
+    _TOOLCHAIN_FILE=-DCMAKE_TOOLCHAIN_FILE=${_TOOLFILE}
 fi
 
 _SET_RPATH=-DSET_RPATH=${_RPATH}

--- a/make-cross-ovs.sh
+++ b/make-cross-ovs.sh
@@ -38,6 +38,7 @@ print_help() {
     echo "  --dry-run        -n  Display cmake parameters and exit"
     echo "  --jobs=NJOBS     -j  Number of build threads (Default: ${_JOBS})"
     echo "  --prefix=DIR*    -P  Install directory prefix [${_PREFIX}]"
+    echo "  --staging=DIR        Staging directory prefix [${_STAGING}]"
     echo "  --toolchain=FILE -T  CMake toolchain file"
     echo ""
     echo "* '//' at the beginning of the directory path will be replaced"
@@ -51,9 +52,9 @@ print_help() {
 
 # Parse options
 SHORTOPTS=B:P:T:hj:n
-LONGOPTS=build:,dry-run,help,jobs:,prefix:,toolchain:
+LONGOPTS=build:,dry-run,help,jobs:,prefix:,staging:,toolchain:
 
-eval set -- `getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@"`
+eval set -- $(getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@")
 
 while true ; do
     case "$1" in
@@ -72,6 +73,9 @@ while true ; do
     -P|--prefix)
         _PREFIX=$2
         shift 2 ;;
+    --staging)
+        _STAGING=$2
+        shift 2 ;;
     -T|--toolchain)
         _TOOLFILE=$2
         shift 2 ;;
@@ -84,6 +88,10 @@ while true ; do
     esac
 done
 
+if [ -n "${_STAGING}" ]; then
+    _STAGING_PREFIX=-DCMAKE_STAGING_PREFIX=${_STAGING}
+fi
+
 # Substitute ${_SYSROOT}/ for '//' prefix
 [ "${_PREFIX:0:2}" = "//" ] && _PREFIX=${_SYSROOT}/${_PREFIX:2}
 
@@ -91,6 +99,7 @@ if [ "${_DRY_RUN}" = "true" ]; then
     echo ""
     echo "CMAKE_BUILD_TYPE=${_BLD_TYPE}"
     echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
+    [ -n "${_STAGING_PREFIX}" ] && echo "${_STAGING_PREFIX:2}"
     echo "CMAKE_TOOLCHAIN_FILE=${_TOOLFILE}"
     echo "JOBS=${_JOBS}"
     echo ""
@@ -102,6 +111,7 @@ rm -fr ${_BLD_DIR}
 cmake -S ovs -B ${_BLD_DIR} \
     -DCMAKE_BUILD_TYPE=${_BLD_TYPE} \
     -DCMAKE_INSTALL_PREFIX=${_PREFIX} \
+    ${_STAGING_PREFIX} \
     -DCMAKE_TOOLCHAIN_FILE=${_TOOLFILE} \
     -DP4OVS=TRUE
 

--- a/ovs/CMakeLists.txt
+++ b/ovs/CMakeLists.txt
@@ -140,6 +140,10 @@ if(CMAKE_TOOLCHAIN_FILE AND NOT CMAKE_TOOLCHAIN_FILE STREQUAL "")
    # print_crosscompile_variables()
 endif()
 
+if(CMAKE_STAGING_PREFIX AND NOT CMAKE_STAGING_PREFIX STREQUAL "")
+    set(DESTDIR DESTDIR=${CMAKE_STAGING_PREFIX})
+endif()
+
 ######################
 # Build Open vSwitch #
 ######################
@@ -173,5 +177,5 @@ ExternalProject_Add(ovs
     # on ovs, so CMake won't continue until the ovs build completes.
     $(MAKE)
   INSTALL_COMMAND
-    ${CMAKE_MAKE_PROGRAM} install
+    ${CMAKE_MAKE_PROGRAM} install ${DESTDIR}
 )


### PR DESCRIPTION
- Modify config-cross-recipe.sh to accept a --staging=DIR parameter to specify the staging directory prefix.

- Modify ovs/CMakeLists.txt to translate CMAKE_STAGING_PREFIX to autotools DESTDIR parameter.

- Divide command-line help into Paths and Options sections.

- Move dry-run display logic into print_cmake_params() function.