### PR TITLE
Add SDE_INSTALL_DIR and DEPEND_INSTALL_DIR checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,9 @@ set(SDE_INSTALL_DIR "$ENV{SDE_INSTALL}" CACHE PATH
     "SDE install directory")
 
 if(SDE_INSTALL_DIR STREQUAL "")
-    message(FATAL_ERROR "SDE_INSTALL_DIR not defined!")
+    message(FATAL_ERROR "SDE_INSTALL_DIR (SDE_INSTALL) not defined!")
+elseif(DEPEND_INSTALL_DIR STREQUAL "")
+    message(FATAL_ERROR "DEPEND_INSTALL_DIR (DEPEND_INSTALL) not defined!")
 endif()
 
 set(HOST_DEPEND_DIR "" CACHE PATH "Host dependencies install directory")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ set(OVS_SOURCE_DIR "${CMAKE_SOURCE_DIR}/ovs/ovs" CACHE PATH
 set(SDE_INSTALL_DIR "$ENV{SDE_INSTALL}" CACHE PATH
     "SDE install directory")
 
+if(SDE_INSTALL_DIR STREQUAL "")
+    message(FATAL_ERROR "SDE_INSTALL_DIR not defined!")
+endif()
+
 set(HOST_DEPEND_DIR "" CACHE PATH "Host dependencies install directory")
 
 set(PB_OUT_DIR "${CMAKE_BINARY_DIR}/pb.out" CACHE PATH


### PR DESCRIPTION
- Generate fatal error if SDE_INSTALL_DIR is not defined.