### PR TITLE
Format ovs-p4rt source code

### DIFF
--- a/ovs-p4rt/ovs_p4rt.cc
+++ b/ovs-p4rt/ovs_p4rt.cc
@@ -1,11 +1,13 @@
-// Copyright (c) 2022-2023 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 // TODO: ovs-p4rt logging
-#include "ovs_p4rt_session.h"
-#include "ovs_p4rt_tls_credentials.h"
+
 #include <arpa/inet.h>
+
 #include "absl/flags/flag.h"
 #include "openvswitch/ovs-p4rt.h"
+#include "ovs_p4rt_session.h"
+#include "ovs_p4rt_tls_credentials.h"
 
 #if defined(DPDK_TARGET)
   #include "dpdk/p4_name_mapping.h"
@@ -13,16 +15,14 @@
   #include "es2k/p4_name_mapping.h"
 #endif
 
-
-using namespace ovs_p4rt_cpp;
-
 ABSL_FLAG(std::string, grpc_addr, "localhost:9559",
           "P4Runtime server address.");
 ABSL_FLAG(uint64_t, device_id, 1, "P4Runtime device ID.");
 
-using OvsP4rtStream =
-    ::grpc::ClientReaderWriter<p4::v1::StreamMessageRequest,
-                               p4::v1::StreamMessageResponse>;
+namespace ovs_p4rt {
+
+using OvsP4rtStream = ::grpc::ClientReaderWriter<p4::v1::StreamMessageRequest,
+                                                 p4::v1::StreamMessageResponse>;
 
 std::string EncodeByteValue(int arg_count...) {
   std::string byte_value;
@@ -39,88 +39,75 @@ std::string EncodeByteValue(int arg_count...) {
 }
 
 std::string CanonicalizeIp(const uint32_t ipv4addr) {
-  return EncodeByteValue(4, (ipv4addr & 0xff),
-                            ((ipv4addr >> 8) & 0xff),
-                            ((ipv4addr >> 16) & 0xff),
-                            ((ipv4addr >> 24) & 0xff));
+  return EncodeByteValue(4, (ipv4addr & 0xff), ((ipv4addr >> 8) & 0xff),
+                         ((ipv4addr >> 16) & 0xff), ((ipv4addr >> 24) & 0xff));
 }
 
 std::string CanonicalizeIpv6(const struct in6_addr ipv6addr) {
-  return EncodeByteValue(16, ipv6addr.__in6_u.__u6_addr8[0],
-                             ipv6addr.__in6_u.__u6_addr8[1],
-                             ipv6addr.__in6_u.__u6_addr8[2],
-                             ipv6addr.__in6_u.__u6_addr8[3],
-                             ipv6addr.__in6_u.__u6_addr8[4],
-                             ipv6addr.__in6_u.__u6_addr8[5],
-                             ipv6addr.__in6_u.__u6_addr8[6],
-                             ipv6addr.__in6_u.__u6_addr8[7],
-                             ipv6addr.__in6_u.__u6_addr8[8],
-                             ipv6addr.__in6_u.__u6_addr8[9],
-                             ipv6addr.__in6_u.__u6_addr8[10],
-                             ipv6addr.__in6_u.__u6_addr8[11],
-                             ipv6addr.__in6_u.__u6_addr8[12],
-                             ipv6addr.__in6_u.__u6_addr8[13],
-                             ipv6addr.__in6_u.__u6_addr8[14],
-                             ipv6addr.__in6_u.__u6_addr8[15]);
+  return EncodeByteValue(
+      16, ipv6addr.__in6_u.__u6_addr8[0], ipv6addr.__in6_u.__u6_addr8[1],
+      ipv6addr.__in6_u.__u6_addr8[2], ipv6addr.__in6_u.__u6_addr8[3],
+      ipv6addr.__in6_u.__u6_addr8[4], ipv6addr.__in6_u.__u6_addr8[5],
+      ipv6addr.__in6_u.__u6_addr8[6], ipv6addr.__in6_u.__u6_addr8[7],
+      ipv6addr.__in6_u.__u6_addr8[8], ipv6addr.__in6_u.__u6_addr8[9],
+      ipv6addr.__in6_u.__u6_addr8[10], ipv6addr.__in6_u.__u6_addr8[11],
+      ipv6addr.__in6_u.__u6_addr8[12], ipv6addr.__in6_u.__u6_addr8[13],
+      ipv6addr.__in6_u.__u6_addr8[14], ipv6addr.__in6_u.__u6_addr8[15]);
 }
 
 std::string CanonicalizeMac(const uint8_t mac[6]) {
-  return EncodeByteValue(6, (mac[0] & 0xff),
-                            (mac[1] & 0xff),
-                            (mac[2] & 0xff),
-                            (mac[3] & 0xff),
-                            (mac[4] & 0xff),
-                            (mac[5] & 0xff));
+  return EncodeByteValue(6, (mac[0] & 0xff), (mac[1] & 0xff), (mac[2] & 0xff),
+                         (mac[3] & 0xff), (mac[4] & 0xff), (mac[5] & 0xff));
 }
 
-int GetTableId(const ::p4::config::v1::P4Info &p4info,
-                 const std::string &t_name) {
-  for (const auto &table : p4info.tables()) {
-    const auto &pre = table.preamble();
+int GetTableId(const ::p4::config::v1::P4Info& p4info,
+               const std::string& t_name) {
+  for (const auto& table : p4info.tables()) {
+    const auto& pre = table.preamble();
     if (pre.name() == t_name) return pre.id();
   }
   return -1;
 }
 
-int GetActionId(const ::p4::config::v1::P4Info &p4info,
-                  const std::string &a_name) {
-  for (const auto &action : p4info.actions()) {
-    const auto &pre = action.preamble();
+int GetActionId(const ::p4::config::v1::P4Info& p4info,
+                const std::string& a_name) {
+  for (const auto& action : p4info.actions()) {
+    const auto& pre = action.preamble();
     if (pre.name() == a_name) return pre.id();
   }
   return -1;
 }
 
-int GetParamId(const ::p4::config::v1::P4Info &p4info,
-                 const std::string &a_name, const std::string &param_name) {
-  for (const auto &action : p4info.actions()) {
-    const auto &pre = action.preamble();
+int GetParamId(const ::p4::config::v1::P4Info& p4info,
+               const std::string& a_name, const std::string& param_name) {
+  for (const auto& action : p4info.actions()) {
+    const auto& pre = action.preamble();
     if (pre.name() != a_name) continue;
-    for (const auto &param : action.params())
+    for (const auto& param : action.params())
       if (param.name() == param_name) return param.id();
   }
   return -1;
 }
 
-int GetMatchFieldId(const ::p4::config::v1::P4Info &p4info,
-              const std::string &t_name, const std::string &mf_name) {
-  for (const auto &table : p4info.tables()) {
-    const auto &pre = table.preamble();
+int GetMatchFieldId(const ::p4::config::v1::P4Info& p4info,
+                    const std::string& t_name, const std::string& mf_name) {
+  for (const auto& table : p4info.tables()) {
+    const auto& pre = table.preamble();
     if (pre.name() != t_name) continue;
-    for (const auto &mf : table.match_fields())
+    for (const auto& mf : table.match_fields())
       if (mf.name() == mf_name) return mf.id();
   }
   return -1;
 }
 
 void PrepareFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info &learn_info,
-                                const ::p4::config::v1::P4Info &p4info,
+                                const struct mac_learning_info& learn_info,
+                                const ::p4::config::v1::P4Info& p4info,
                                 bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_TABLE));
   auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, L2_FWD_TX_TABLE,
-                                      L2_FWD_TX_TABLE_KEY_DST_MAC));
+  match->set_field_id(
+      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_DST_MAC));
 
   std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
   match->mutable_exact()->set_value(mac_addr);
@@ -128,37 +115,37 @@ void PrepareFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
 #if defined(ES2K_TARGET)
   // Based on p4 program for ES2K, we need to provide a match key Tunnel Flag
   auto match1 = table_entry->add_match();
-  match1->set_field_id(GetMatchFieldId(p4info, L2_FWD_TX_TABLE,
-			              L2_FWD_TX_TABLE_KEY_TUN_FLAG));
+  match1->set_field_id(
+      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_TUN_FLAG));
 
   match1->mutable_exact()->set_value(EncodeByteValue(1, 0));
 #endif
 
   if (insert_entry) {
-      auto table_action = table_entry->mutable_action();
-      auto action = table_action->mutable_action();
-      action->set_action_id(GetActionId(p4info, L2_FWD_TX_TABLE_ACTION_L2_FWD));
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_L2_FWD,
-                            ACTION_L2_FWD_PARAM_PORT));
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(GetActionId(p4info, L2_FWD_TX_TABLE_ACTION_L2_FWD));
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_L2_FWD,
+                                     ACTION_L2_FWD_PARAM_PORT));
 #if defined(DPDK_TARGET)
-	auto port_id = learn_info.vln_info.vlan_id - 1;
+      auto port_id = learn_info.vln_info.vlan_id - 1;
 #elif defined(ES2K_TARGET)
-        auto port_id = learn_info.mac_addr[1] + ES2K_VPORT_ID_OFFSET;
+      auto port_id = learn_info.mac_addr[1] + ES2K_VPORT_ID_OFFSET;
 #else
-	auto port_id = 0;
+      auto port_id = 0;
 #endif
-        param->set_value(EncodeByteValue(1, port_id));
-      }
+      param->set_value(EncodeByteValue(1, port_id));
+    }
   }
   return;
 }
 
 #if defined(ES2K_TARGET)
 void PrepareFdbTxV6VlanTableEntry(p4::v1::TableEntry* table_entry,
-                                  const struct mac_learning_info &learn_info,
-                                  const ::p4::config::v1::P4Info &p4info,
+                                  const struct mac_learning_info& learn_info,
+                                  const ::p4::config::v1::P4Info& p4info,
                                   bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_IPV6_TABLE));
   auto match = table_entry->add_match();
@@ -171,22 +158,22 @@ void PrepareFdbTxV6VlanTableEntry(p4::v1::TableEntry* table_entry,
   // Based on p4 program for ES2K, we need to provide a match key Tunnel Flag
   auto match1 = table_entry->add_match();
   match1->set_field_id(GetMatchFieldId(p4info, L2_FWD_TX_TABLE,
-			              L2_FWD_TX_IPV6_TABLE_KEY_TUN_FLAG));
+                                       L2_FWD_TX_IPV6_TABLE_KEY_TUN_FLAG));
 
   match1->mutable_exact()->set_value(EncodeByteValue(1, 0));
 
   if (insert_entry) {
-      auto table_action = table_entry->mutable_action();
-      auto action = table_action->mutable_action();
-      action->set_action_id(GetActionId(p4info,
-                                        L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD));
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info, L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD,
-                                       ACTION_L2_FWD_PARAM_PORT));
-        auto port_id = learn_info.mac_addr[1] + ES2K_VPORT_ID_OFFSET;
-        param->set_value(EncodeByteValue(1, port_id));
-      }
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(
+        GetActionId(p4info, L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD));
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, L2_FWD_TX_IPV6_TABLE_ACTION_L2_FWD,
+                                     ACTION_L2_FWD_PARAM_PORT));
+      auto port_id = learn_info.mac_addr[1] + ES2K_VPORT_ID_OFFSET;
+      param->set_value(EncodeByteValue(1, port_id));
+    }
   }
   return;
 }
@@ -200,62 +187,62 @@ void PrepareFdbTxV6VlanTableEntry(p4::v1::TableEntry* table_entry,
  * Action: VSI ID to which a matching packet need to forwarded.
  */
 void PrepareSemBypassTableEntry(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info &learn_info,
-                                const ::p4::config::v1::P4Info &p4info,
+                                const struct mac_learning_info& learn_info,
+                                const ::p4::config::v1::P4Info& p4info,
                                 bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, SEM_BYPASS_TABLE));
   auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, SEM_BYPASS_TABLE,
-			              SEM_BYPASS_TABLE_KEY_DST_MAC));
+  match->set_field_id(
+      GetMatchFieldId(p4info, SEM_BYPASS_TABLE, SEM_BYPASS_TABLE_KEY_DST_MAC));
 
   std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
   match->mutable_exact()->set_value(mac_addr);
 
   if (insert_entry) {
-      auto table_action = table_entry->mutable_action();
-      auto action = table_action->mutable_action();
-      action->set_action_id(GetActionId(p4info,
-                                        SEM_BYPASS_TABLE_ACTION_SET_DEST));
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info, SEM_BYPASS_TABLE_ACTION_SET_DEST,
-                            ACTION_SET_DEST_PARAM_PORT_ID));
-        auto port_id = learn_info.mac_addr[1] + ES2K_VPORT_ID_OFFSET;
-        param->set_value(EncodeByteValue(1, port_id));
-      }
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(
+        GetActionId(p4info, SEM_BYPASS_TABLE_ACTION_SET_DEST));
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, SEM_BYPASS_TABLE_ACTION_SET_DEST,
+                                     ACTION_SET_DEST_PARAM_PORT_ID));
+      auto port_id = learn_info.mac_addr[1] + ES2K_VPORT_ID_OFFSET;
+      param->set_value(EncodeByteValue(1, port_id));
+    }
   }
   return;
 }
 #endif
 
 void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
-                                const struct mac_learning_info &learn_info,
-                                const ::p4::config::v1::P4Info &p4info,
+                                const struct mac_learning_info& learn_info,
+                                const ::p4::config::v1::P4Info& p4info,
                                 bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_RX_WITH_TUNNEL_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, L2_FWD_RX_WITH_TUNNEL_TABLE,
-                      L2_FWD_TX_TABLE_KEY_DST_MAC));
+                                      L2_FWD_TX_TABLE_KEY_DST_MAC));
   std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
   match->mutable_exact()->set_value(mac_addr);
 
   if (insert_entry) {
-      auto table_action = table_entry->mutable_action();
-      auto action = table_action->mutable_action();
-      action->set_action_id(GetActionId(p4info, L2_FWD_TX_TABLE_ACTION_L2_FWD));
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info, L2_FWD_RX_TABLE_ACTION_L2_FWD,
-                            ACTION_L2_FWD_PARAM_PORT));
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(GetActionId(p4info, L2_FWD_TX_TABLE_ACTION_L2_FWD));
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, L2_FWD_RX_TABLE_ACTION_L2_FWD,
+                                     ACTION_L2_FWD_PARAM_PORT));
 #if defined(DPDK_TARGET)
-	auto port_id = learn_info.vln_info.vlan_id - 1;
+      auto port_id = learn_info.vln_info.vlan_id - 1;
 #elif defined(ES2K_TARGET)
-        auto port_id = learn_info.mac_addr[1] + ES2K_VPORT_ID_OFFSET;
+      auto port_id = learn_info.mac_addr[1] + ES2K_VPORT_ID_OFFSET;
 #else
-	auto port_id = 0;
+      auto port_id = 0;
 #endif
-        param->set_value(EncodeByteValue(1, port_id));
-      }
+      param->set_value(EncodeByteValue(1, port_id));
+    }
   }
 
   return;
@@ -263,30 +250,31 @@ void PrepareFdbRxVlanTableEntry(p4::v1::TableEntry* table_entry,
 
 #if defined(ES2K_TARGET)
 void PrepareFdbRxV6VlanTableEntry(p4::v1::TableEntry* table_entry,
-                                  const struct mac_learning_info &learn_info,
-                                  const ::p4::config::v1::P4Info &p4info,
+                                  const struct mac_learning_info& learn_info,
+                                  const ::p4::config::v1::P4Info& p4info,
                                   bool insert_entry) {
-  table_entry->set_table_id(GetTableId(p4info,
-                                       L2_FWD_RX_IPV6_WITH_TUNNEL_TABLE));
+  table_entry->set_table_id(
+      GetTableId(p4info, L2_FWD_RX_IPV6_WITH_TUNNEL_TABLE));
   auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, L2_FWD_RX_IPV6_WITH_TUNNEL_TABLE,
+  match->set_field_id(
+      GetMatchFieldId(p4info, L2_FWD_RX_IPV6_WITH_TUNNEL_TABLE,
                       L2_FWD_RX_IPV6_WITH_TUNNEL_TABLE_KEY_DST_MAC));
   std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
   match->mutable_exact()->set_value(mac_addr);
 
   if (insert_entry) {
-      auto table_action = table_entry->mutable_action();
-      auto action = table_action->mutable_action();
-      action->set_action_id(GetActionId(p4info,
-                            L2_FWD_RX_IPV6_WITH_TUNNEL_TABLE_ACTION_L2_FWD));
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info,
-                            L2_FWD_RX_IPV6_WITH_TUNNEL_TABLE_ACTION_L2_FWD,
-                            ACTION_L2_FWD_PARAM_PORT));
-        auto port_id = learn_info.mac_addr[1] + ES2K_VPORT_ID_OFFSET;
-        param->set_value(EncodeByteValue(1, port_id));
-      }
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(
+        GetActionId(p4info, L2_FWD_RX_IPV6_WITH_TUNNEL_TABLE_ACTION_L2_FWD));
+    {
+      auto param = action->add_params();
+      param->set_param_id(
+          GetParamId(p4info, L2_FWD_RX_IPV6_WITH_TUNNEL_TABLE_ACTION_L2_FWD,
+                     ACTION_L2_FWD_PARAM_PORT));
+      auto port_id = learn_info.mac_addr[1] + ES2K_VPORT_ID_OFFSET;
+      param->set_value(EncodeByteValue(1, port_id));
+    }
   }
 
   return;
@@ -294,13 +282,13 @@ void PrepareFdbRxV6VlanTableEntry(p4::v1::TableEntry* table_entry,
 #endif
 
 void PrepareFdbTableEntryforV4Tunnel(p4::v1::TableEntry* table_entry,
-                                     const struct mac_learning_info &learn_info,
-                                     const ::p4::config::v1::P4Info &p4info,
+                                     const struct mac_learning_info& learn_info,
+                                     const ::p4::config::v1::P4Info& p4info,
                                      bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_TABLE));
   auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, L2_FWD_TX_TABLE,
-                                      L2_FWD_TX_TABLE_KEY_DST_MAC));
+  match->set_field_id(
+      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_DST_MAC));
 
   std::string mac_addr = CanonicalizeMac(learn_info.mac_addr);
   match->mutable_exact()->set_value(mac_addr);
@@ -308,58 +296,58 @@ void PrepareFdbTableEntryforV4Tunnel(p4::v1::TableEntry* table_entry,
 #if defined(ES2K_TARGET)
   // Based on p4 program for ES2K, we need to provide a match key Tunnel Flag
   auto match1 = table_entry->add_match();
-  match1->set_field_id(GetMatchFieldId(p4info, L2_FWD_TX_TABLE,
-			              L2_FWD_TX_TABLE_KEY_TUN_FLAG));
+  match1->set_field_id(
+      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_TUN_FLAG));
 
   match1->mutable_exact()->set_value(EncodeByteValue(1, 0));
 #endif
 
 #if defined(DPDK_TARGET)
   if (insert_entry) {
-      auto table_action = table_entry->mutable_action();
-      auto action = table_action->mutable_action();
-      action->set_action_id(GetActionId(p4info,
-                            L2_FWD_TX_TABLE_ACTION_SET_TUNNEL));
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info,
-                            L2_FWD_TX_TABLE_ACTION_SET_TUNNEL,
-                            ACTION_SET_TUNNEL_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
-      }
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(
+        GetActionId(p4info, L2_FWD_TX_TABLE_ACTION_SET_TUNNEL));
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_SET_TUNNEL,
+                                     ACTION_SET_TUNNEL_PARAM_TUNNEL_ID));
+      param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
+    }
 
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info,
-                            L2_FWD_TX_TABLE_ACTION_SET_TUNNEL,
-                            ACTION_SET_TUNNEL_PARAM_DST_ADDR));
-        std::string ip_address = CanonicalizeIp(learn_info.tnl_info.remote_ip.ip.v4addr.s_addr);
-        param->set_value(ip_address);
-      }
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_SET_TUNNEL,
+                                     ACTION_SET_TUNNEL_PARAM_DST_ADDR));
+      std::string ip_address =
+          CanonicalizeIp(learn_info.tnl_info.remote_ip.ip.v4addr.s_addr);
+      param->set_value(ip_address);
+    }
   }
 
 #elif defined(ES2K_TARGET)
   if (insert_entry) {
-      auto table_action = table_entry->mutable_action();
-      auto action = table_action->mutable_action();
-      action->set_action_id(GetActionId(p4info,
-                            L2_FWD_TX_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V4_OVERLAY_V4));
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info,
-                            L2_FWD_TX_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V4_OVERLAY_V4,
-                            ACTION_SET_TUNNEL_UNDERLAY_V4_OVERLAY_V4_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
-      }
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(GetActionId(
+        p4info, L2_FWD_TX_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V4_OVERLAY_V4));
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(
+          p4info, L2_FWD_TX_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V4_OVERLAY_V4,
+          ACTION_SET_TUNNEL_UNDERLAY_V4_OVERLAY_V4_PARAM_TUNNEL_ID));
+      param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
+    }
 
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info,
-                            L2_FWD_TX_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V4_OVERLAY_V4,
-                            ACTION_SET_TUNNEL_UNDERLAY_V4_OVERLAY_V4_PARAM_DST_ADDR));
-        std::string ip_address = CanonicalizeIp(learn_info.tnl_info.remote_ip.ip.v4addr.s_addr);
-        param->set_value(ip_address);
-      }
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(
+          p4info, L2_FWD_TX_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V4_OVERLAY_V4,
+          ACTION_SET_TUNNEL_UNDERLAY_V4_OVERLAY_V4_PARAM_DST_ADDR));
+      std::string ip_address =
+          CanonicalizeIp(learn_info.tnl_info.remote_ip.ip.v4addr.s_addr);
+      param->set_value(ip_address);
+    }
   }
 #endif
   return;
@@ -367,8 +355,8 @@ void PrepareFdbTableEntryforV4Tunnel(p4::v1::TableEntry* table_entry,
 
 #if defined(ES2K_TARGET)
 void PrepareFdbTableEntryforV6Tunnel(p4::v1::TableEntry* table_entry,
-                                     const struct mac_learning_info &learn_info,
-                                     const ::p4::config::v1::P4Info &p4info,
+                                     const struct mac_learning_info& learn_info,
+                                     const ::p4::config::v1::P4Info& p4info,
                                      bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, L2_FWD_TX_IPV6_TABLE));
   auto match = table_entry->add_match();
@@ -380,167 +368,159 @@ void PrepareFdbTableEntryforV6Tunnel(p4::v1::TableEntry* table_entry,
 
   // Based on p4 program for ES2K, we need to provide a match key Tunnel Flag
   auto match1 = table_entry->add_match();
-  match1->set_field_id(GetMatchFieldId(p4info, L2_FWD_TX_TABLE,
-			              L2_FWD_TX_TABLE_KEY_TUN_FLAG));
+  match1->set_field_id(
+      GetMatchFieldId(p4info, L2_FWD_TX_TABLE, L2_FWD_TX_TABLE_KEY_TUN_FLAG));
 
   match1->mutable_exact()->set_value(EncodeByteValue(1, 0));
 
   if (insert_entry) {
-      auto table_action = table_entry->mutable_action();
-      auto action = table_action->mutable_action();
-      action->set_action_id(GetActionId(p4info,
-                            L2_FWD_TX_IPV6_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6));
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info,
-                            L2_FWD_TX_IPV6_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6,
-                            ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
-      }
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(GetActionId(
+        p4info, L2_FWD_TX_IPV6_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6));
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(
+          p4info, L2_FWD_TX_IPV6_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6,
+          ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6_PARAM_TUNNEL_ID));
+      param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
+    }
 
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info,
-                            L2_FWD_TX_IPV6_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6,
-                            ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6_PARAM_IPV6_1));
-        std::string ip_address = CanonicalizeIp(learn_info.tnl_info.remote_ip.ip.v6addr.__in6_u.__u6_addr32[0]);
-        param->set_value(ip_address);
-      }
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(
+          p4info, L2_FWD_TX_IPV6_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6,
+          ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6_PARAM_IPV6_1));
+      std::string ip_address = CanonicalizeIp(
+          learn_info.tnl_info.remote_ip.ip.v6addr.__in6_u.__u6_addr32[0]);
+      param->set_value(ip_address);
+    }
 
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info,
-                            L2_FWD_TX_IPV6_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6,
-                            ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6_PARAM_IPV6_2));
-        std::string ip_address = CanonicalizeIp(learn_info.tnl_info.remote_ip.ip.v6addr.__in6_u.__u6_addr32[1]);
-        param->set_value(ip_address);
-      }
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(
+          p4info, L2_FWD_TX_IPV6_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6,
+          ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6_PARAM_IPV6_2));
+      std::string ip_address = CanonicalizeIp(
+          learn_info.tnl_info.remote_ip.ip.v6addr.__in6_u.__u6_addr32[1]);
+      param->set_value(ip_address);
+    }
 
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info,
-                            L2_FWD_TX_IPV6_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6,
-                            ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6_PARAM_IPV6_3));
-        std::string ip_address = CanonicalizeIp(learn_info.tnl_info.remote_ip.ip.v6addr.__in6_u.__u6_addr32[0]);
-        param->set_value(ip_address);
-      }
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(
+          p4info, L2_FWD_TX_IPV6_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6,
+          ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6_PARAM_IPV6_3));
+      std::string ip_address = CanonicalizeIp(
+          learn_info.tnl_info.remote_ip.ip.v6addr.__in6_u.__u6_addr32[0]);
+      param->set_value(ip_address);
+    }
 
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info,
-                            L2_FWD_TX_IPV6_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6,
-                            ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6_PARAM_IPV6_4));
-        std::string ip_address = CanonicalizeIp(learn_info.tnl_info.remote_ip.ip.v6addr.__in6_u.__u6_addr32[0]);
-        param->set_value(ip_address);
-      }
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(
+          p4info, L2_FWD_TX_IPV6_TABLE_ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6,
+          ACTION_SET_TUNNEL_UNDERLAY_V6_OVERLAY_V6_PARAM_IPV6_4));
+      std::string ip_address = CanonicalizeIp(
+          learn_info.tnl_info.remote_ip.ip.v6addr.__in6_u.__u6_addr32[0]);
+      param->set_value(ip_address);
+    }
   }
   return;
 }
 #endif
 
-absl::Status ConfigFdbTxVlanTableEntry(ovs_p4rt_cpp::OvsP4rtSession* session,
-                                       const struct mac_learning_info &learn_info,
-                                       const ::p4::config::v1::P4Info &p4info,
-                                       bool insert_entry) {
+absl::Status ConfigFdbTxVlanTableEntry(
+    ovs_p4rt::OvsP4rtSession* session,
+    const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   if (insert_entry) {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToInsert(session,
-                                      &write_request);
+    table_entry = ovs_p4rt::SetupTableEntryToInsert(session, &write_request);
   } else {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToDelete(session,
-                                      &write_request);
-  }  
+    table_entry = ovs_p4rt::SetupTableEntryToDelete(session, &write_request);
+  }
   PrepareFdbTxVlanTableEntry(table_entry, learn_info, p4info, insert_entry);
-  return ovs_p4rt_cpp::SendWriteRequest(session, write_request);
+  return ovs_p4rt::SendWriteRequest(session, write_request);
 }
 
 #if defined(ES2K_TARGET)
-absl::Status ConfigFdbTxV6VlanTableEntry(ovs_p4rt_cpp::OvsP4rtSession* session,
-                                         const struct mac_learning_info &learn_info,
-                                         const ::p4::config::v1::P4Info &p4info,
-                                         bool insert_entry) {
+absl::Status ConfigFdbTxV6VlanTableEntry(
+    ovs_p4rt::OvsP4rtSession* session,
+    const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   if (insert_entry) {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToInsert(session,
-                                      &write_request);
+    table_entry = ovs_p4rt::SetupTableEntryToInsert(session, &write_request);
   } else {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToDelete(session,
-                                      &write_request);
-  }  
+    table_entry = ovs_p4rt::SetupTableEntryToDelete(session, &write_request);
+  }
   PrepareFdbTxV6VlanTableEntry(table_entry, learn_info, p4info, insert_entry);
-  return ovs_p4rt_cpp::SendWriteRequest(session, write_request);
+  return ovs_p4rt::SendWriteRequest(session, write_request);
 }
 #endif
 
 #if defined(ES2K_TARGET)
-absl::Status ConfigSemBypassTableEntry(ovs_p4rt_cpp::OvsP4rtSession* session,
-                                       const struct mac_learning_info &learn_info,
-                                       const ::p4::config::v1::P4Info &p4info,
-                                       bool insert_entry) {
+absl::Status ConfigSemBypassTableEntry(
+    ovs_p4rt::OvsP4rtSession* session,
+    const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   if (insert_entry) {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToInsert(session,
-                                      &write_request);
+    table_entry = ovs_p4rt::SetupTableEntryToInsert(session, &write_request);
   } else {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToDelete(session,
-                                      &write_request);
+    table_entry = ovs_p4rt::SetupTableEntryToDelete(session, &write_request);
   }
   PrepareSemBypassTableEntry(table_entry, learn_info, p4info, insert_entry);
-  return ovs_p4rt_cpp::SendWriteRequest(session, write_request);
+  return ovs_p4rt::SendWriteRequest(session, write_request);
 }
 #endif
 
 #if defined(ES2K_TARGET)
-absl::Status ConfigFdbRxV6VlanTableEntry(ovs_p4rt_cpp::OvsP4rtSession* session,
-                                         const struct mac_learning_info &learn_info,
-                                         const ::p4::config::v1::P4Info &p4info,
-                                         bool insert_entry) {
+absl::Status ConfigFdbRxV6VlanTableEntry(
+    ovs_p4rt::OvsP4rtSession* session,
+    const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   if (insert_entry) {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToInsert(session,
-                                      &write_request);
+    table_entry = ovs_p4rt::SetupTableEntryToInsert(session, &write_request);
   } else {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToDelete(session,
-                                      &write_request);
+    table_entry = ovs_p4rt::SetupTableEntryToDelete(session, &write_request);
   }
   PrepareFdbRxV6VlanTableEntry(table_entry, learn_info, p4info, insert_entry);
-  return ovs_p4rt_cpp::SendWriteRequest(session, write_request);
+  return ovs_p4rt::SendWriteRequest(session, write_request);
 }
 #endif
 
-absl::Status ConfigFdbRxVlanTableEntry(ovs_p4rt_cpp::OvsP4rtSession* session,
-                                       const struct mac_learning_info &learn_info,
-                                       const ::p4::config::v1::P4Info &p4info,
-                                       bool insert_entry) {
-  ::p4::v1::WriteRequest write_request;
-  ::p4::v1::TableEntry* table_entry;  
-  if (insert_entry) {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToInsert(session,
-                                      &write_request);
-  } else {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToDelete(session,
-                                      &write_request);
-  }
-  PrepareFdbRxVlanTableEntry(table_entry, learn_info, p4info, insert_entry);
-  return ovs_p4rt_cpp::SendWriteRequest(session, write_request);
-}
-
-absl::Status ConfigFdbTunnelTableEntry(ovs_p4rt_cpp::OvsP4rtSession* session,
-                                       const struct mac_learning_info &learn_info,
-                                       const ::p4::config::v1::P4Info &p4info,
-                                       bool insert_entry) {
+absl::Status ConfigFdbRxVlanTableEntry(
+    ovs_p4rt::OvsP4rtSession* session,
+    const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   if (insert_entry) {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToInsert(session,
-                                      &write_request);
+    table_entry = ovs_p4rt::SetupTableEntryToInsert(session, &write_request);
   } else {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToDelete(session,
-                                      &write_request);
+    table_entry = ovs_p4rt::SetupTableEntryToDelete(session, &write_request);
+  }
+  PrepareFdbRxVlanTableEntry(table_entry, learn_info, p4info, insert_entry);
+  return ovs_p4rt::SendWriteRequest(session, write_request);
+}
+
+absl::Status ConfigFdbTunnelTableEntry(
+    ovs_p4rt::OvsP4rtSession* session,
+    const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
+  ::p4::v1::WriteRequest write_request;
+  ::p4::v1::TableEntry* table_entry;
+  if (insert_entry) {
+    table_entry = ovs_p4rt::SetupTableEntryToInsert(session, &write_request);
+  } else {
+    table_entry = ovs_p4rt::SetupTableEntryToDelete(session, &write_request);
   }
 
 #if defined(DPDK_TARGET)
@@ -549,123 +529,71 @@ absl::Status ConfigFdbTunnelTableEntry(ovs_p4rt_cpp::OvsP4rtSession* session,
 #elif defined(ES2K_TARGET)
   if (learn_info.tnl_info.local_ip.family == AF_INET6 &&
       learn_info.tnl_info.remote_ip.family == AF_INET6) {
-      PrepareFdbTableEntryforV6Tunnel(table_entry, learn_info, p4info,
-                                      insert_entry);
+    PrepareFdbTableEntryforV6Tunnel(table_entry, learn_info, p4info,
+                                    insert_entry);
   } else {
-      PrepareFdbTableEntryforV4Tunnel(table_entry, learn_info, p4info,
-                                      insert_entry);
+    PrepareFdbTableEntryforV4Tunnel(table_entry, learn_info, p4info,
+                                    insert_entry);
   }
 #else
   return absl::UnknownError("Unsupported platform")
 #endif
-  return ovs_p4rt_cpp::SendWriteRequest(session, write_request);
-}
-
-void ConfigFdbTableEntry(struct mac_learning_info learn_info, bool insert_entry) {
-    // Start a new client session.
-    auto status_or_session = ovs_p4rt_cpp::OvsP4rtSession::Create(
-      absl::GetFlag(FLAGS_grpc_addr),
-      GenerateClientCredentials(),
-      absl::GetFlag(FLAGS_device_id));
-    if (!status_or_session.ok()) {
-        return;
-    }
-
-    // Unwrap the session from the StatusOr object.
-    std::unique_ptr<ovs_p4rt_cpp::OvsP4rtSession> session =
-      std::move(status_or_session).value();
-    ::p4::config::v1::P4Info p4info;
-    ::absl::Status status = ovs_p4rt_cpp::GetForwardingPipelineConfig(session.get(),
-		            &p4info);
-    if (!status.ok())
-        return;    
-
-    if (learn_info.is_tunnel) {
-        status = ConfigFdbTunnelTableEntry(session.get(), learn_info,
-                                           p4info, insert_entry);
-    } else if (learn_info.is_vlan) {
-        status = ConfigFdbTxVlanTableEntry(session.get(), learn_info,
-                                           p4info, insert_entry);
-        if(!status.ok())
-            return;
-
-        status = ConfigFdbRxVlanTableEntry(session.get(), learn_info,
-                                           p4info, insert_entry);
-        if(!status.ok())
-            return;
-
-#if defined(ES2K_TARGET)
-	status = ConfigFdbTxV6VlanTableEntry(session.get(), learn_info,
-                                             p4info, insert_entry);
-        if(!status.ok())
-            return;
-	status = ConfigSemBypassTableEntry(session.get(), learn_info,
-                                           p4info, insert_entry);
-        if(!status.ok())
-            return;
-
-	status = ConfigFdbRxV6VlanTableEntry(session.get(), learn_info,
-                                             p4info, insert_entry);
-#endif
-    }
-    if (!status.ok())
-        return;
-
-  return;
+  return ovs_p4rt::SendWriteRequest(session, write_request);
 }
 
 void PrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
-                            const struct tunnel_info &tunnel_info,
-                            const ::p4::config::v1::P4Info &p4info,
+                            const struct tunnel_info& tunnel_info,
+                            const ::p4::config::v1::P4Info& p4info,
                             bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_MOD_TABLE));
   auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, VXLAN_ENCAP_MOD_TABLE, 
+  match->set_field_id(
+      GetMatchFieldId(p4info, VXLAN_ENCAP_MOD_TABLE,
                       VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
   match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
 
   if (insert_entry) {
-     auto table_action = table_entry->mutable_action();
-     auto action = table_action->mutable_action();
-     action->set_action_id(GetActionId(p4info, ACTION_VXLAN_ENCAP));
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP,
-                                        ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR));
-       param->set_value(CanonicalizeIp(tunnel_info.local_ip.ip.v4addr.s_addr));
-     }
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP,
-                           ACTION_VXLAN_ENCAP_PARAM_DST_ADDR));
-       param->set_value(CanonicalizeIp(tunnel_info.remote_ip.ip.v4addr.s_addr));
-     }
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(GetActionId(p4info, ACTION_VXLAN_ENCAP));
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP,
+                                     ACTION_VXLAN_ENCAP_PARAM_SRC_ADDR));
+      param->set_value(CanonicalizeIp(tunnel_info.local_ip.ip.v4addr.s_addr));
+    }
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP,
+                                     ACTION_VXLAN_ENCAP_PARAM_DST_ADDR));
+      param->set_value(CanonicalizeIp(tunnel_info.remote_ip.ip.v4addr.s_addr));
+    }
 #if defined(ES2K_TARGET)
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP,
-                                        ACTION_VXLAN_ENCAP_PARAM_SRC_PORT));
-       uint16_t dst_port = htons(tunnel_info.dst_port);
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP,
+                                     ACTION_VXLAN_ENCAP_PARAM_SRC_PORT));
+      uint16_t dst_port = htons(tunnel_info.dst_port);
 
-       param->set_value(EncodeByteValue(2, (((dst_port*2) >> 8) & 0xff),
-                                        ((dst_port*2) & 0xff)));
-     }
+      param->set_value(EncodeByteValue(2, (((dst_port * 2) >> 8) & 0xff),
+                                       ((dst_port * 2) & 0xff)));
+    }
 #endif
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP,
-                                        ACTION_VXLAN_ENCAP_PARAM_DST_PORT));
-       uint16_t dst_port = htons(tunnel_info.dst_port);
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP,
+                                     ACTION_VXLAN_ENCAP_PARAM_DST_PORT));
+      uint16_t dst_port = htons(tunnel_info.dst_port);
 
-       param->set_value(EncodeByteValue(2, ((dst_port >> 8) & 0xff),
-                                        (dst_port & 0xff)));
-     }
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP, 
-                                        ACTION_VXLAN_ENCAP_PARAM_VNI));
-       param->set_value(EncodeByteValue(1, tunnel_info.vni));
-     }
+      param->set_value(
+          EncodeByteValue(2, ((dst_port >> 8) & 0xff), (dst_port & 0xff)));
+    }
+    {
+      auto param = action->add_params();
+      param->set_param_id(
+          GetParamId(p4info, ACTION_VXLAN_ENCAP, ACTION_VXLAN_ENCAP_PARAM_VNI));
+      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+    }
   }
 
   return;
@@ -673,55 +601,56 @@ void PrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
 
 #if defined(ES2K_TARGET)
 void PrepareV6EncapTableEntry(p4::v1::TableEntry* table_entry,
-                              const struct tunnel_info &tunnel_info,
-                              const ::p4::config::v1::P4Info &p4info,
+                              const struct tunnel_info& tunnel_info,
+                              const ::p4::config::v1::P4Info& p4info,
                               bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, VXLAN_ENCAP_V6_MOD_TABLE));
   auto match = table_entry->add_match();
-  match->set_field_id(GetMatchFieldId(p4info, VXLAN_ENCAP_V6_MOD_TABLE, 
+  match->set_field_id(
+      GetMatchFieldId(p4info, VXLAN_ENCAP_V6_MOD_TABLE,
                       VXLAN_ENCAP_V6_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
   match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
 
   if (insert_entry) {
-     auto table_action = table_entry->mutable_action();
-     auto action = table_action->mutable_action();
-     action->set_action_id(GetActionId(p4info, ACTION_VXLAN_ENCAP_V6));
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
-                                        ACTION_VXLAN_ENCAP_V6_PARAM_SRC_ADDR));
-       param->set_value(CanonicalizeIpv6(tunnel_info.local_ip.ip.v6addr));
-     }
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
-                           ACTION_VXLAN_ENCAP_V6_PARAM_DST_ADDR));
-       param->set_value(CanonicalizeIpv6(tunnel_info.remote_ip.ip.v6addr));
-     }
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
-                                        ACTION_VXLAN_ENCAP_V6_PARAM_SRC_PORT));
-       uint16_t dst_port = htons(tunnel_info.dst_port);
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(GetActionId(p4info, ACTION_VXLAN_ENCAP_V6));
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
+                                     ACTION_VXLAN_ENCAP_V6_PARAM_SRC_ADDR));
+      param->set_value(CanonicalizeIpv6(tunnel_info.local_ip.ip.v6addr));
+    }
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
+                                     ACTION_VXLAN_ENCAP_V6_PARAM_DST_ADDR));
+      param->set_value(CanonicalizeIpv6(tunnel_info.remote_ip.ip.v6addr));
+    }
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
+                                     ACTION_VXLAN_ENCAP_V6_PARAM_SRC_PORT));
+      uint16_t dst_port = htons(tunnel_info.dst_port);
 
-       param->set_value(EncodeByteValue(2, ((dst_port*2) >> 8) & 0xff,
-                                        (dst_port*2) & 0xff));
-     }
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
-                                        ACTION_VXLAN_ENCAP_V6_PARAM_DST_PORT));
-       uint16_t dst_port = htons(tunnel_info.dst_port);
+      param->set_value(EncodeByteValue(2, ((dst_port * 2) >> 8) & 0xff,
+                                       (dst_port * 2) & 0xff));
+    }
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
+                                     ACTION_VXLAN_ENCAP_V6_PARAM_DST_PORT));
+      uint16_t dst_port = htons(tunnel_info.dst_port);
 
-       param->set_value(EncodeByteValue(2, (dst_port >> 8) & 0xff,
-                                        dst_port & 0xff));
-     }
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6, 
-                                        ACTION_VXLAN_ENCAP_V6_PARAM_VNI));
-       param->set_value(EncodeByteValue(1, tunnel_info.vni));
-     }
+      param->set_value(
+          EncodeByteValue(2, (dst_port >> 8) & 0xff, dst_port & 0xff));
+    }
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
+                                     ACTION_VXLAN_ENCAP_V6_PARAM_VNI));
+      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+    }
   }
 
   return;
@@ -729,51 +658,51 @@ void PrepareV6EncapTableEntry(p4::v1::TableEntry* table_entry,
 #endif
 
 void PrepareDecapTableEntry(p4::v1::TableEntry* table_entry,
-                            const struct tunnel_info &tunnel_info,
-                            const ::p4::config::v1::P4Info &p4info,
+                            const struct tunnel_info& tunnel_info,
+                            const ::p4::config::v1::P4Info& p4info,
                             bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, IPV4_TUNNEL_TERM_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
-                      IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE));
+                                      IPV4_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE));
   match->mutable_exact()->set_value(EncodeByteValue(1, TUNNEL_TYPE_VXLAN));
 
   auto match1 = table_entry->add_match();
   match1->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
-                      IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC));
-  match1->mutable_exact()->set_value(CanonicalizeIp(tunnel_info.remote_ip.ip.v4addr.s_addr));
+                                       IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_SRC));
+  match1->mutable_exact()->set_value(
+      CanonicalizeIp(tunnel_info.remote_ip.ip.v4addr.s_addr));
 
   auto match2 = table_entry->add_match();
   match2->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
-                       IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST));
-  match2->mutable_exact()->set_value(CanonicalizeIp(tunnel_info.local_ip.ip.v4addr.s_addr));
+                                       IPV4_TUNNEL_TERM_TABLE_KEY_IPV4_DST));
+  match2->mutable_exact()->set_value(
+      CanonicalizeIp(tunnel_info.local_ip.ip.v4addr.s_addr));
 
 #if defined(DPDK_TARGET)
   if (insert_entry) {
-     auto table_action = table_entry->mutable_action();
-     auto action = table_action->mutable_action();
-     action->set_action_id(GetActionId(p4info, ACTION_DECAP_OUTER_IPV4));
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_DECAP_OUTER_IPV4,
-                           ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID));
-       param->set_value(EncodeByteValue(1, tunnel_info.vni));
-
-     }
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(GetActionId(p4info, ACTION_DECAP_OUTER_IPV4));
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, ACTION_DECAP_OUTER_IPV4,
+                                     ACTION_DECAP_OUTER_IPV4_PARAM_TUNNEL_ID));
+      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+    }
   }
 
 #elif defined(ES2K_TARGET)
   if (insert_entry) {
-     auto table_action = table_entry->mutable_action();
-     auto action = table_action->mutable_action();
-     action->set_action_id(GetActionId(p4info, ACTION_DECAP_OUTER_HDR));
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_DECAP_OUTER_HDR,
-                           ACTION_DECAP_OUTER_HDR_PARAM_TUNNEL_ID));
-       param->set_value(EncodeByteValue(1, tunnel_info.vni));
-
-     }
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(GetActionId(p4info, ACTION_DECAP_OUTER_HDR));
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, ACTION_DECAP_OUTER_HDR,
+                                     ACTION_DECAP_OUTER_HDR_PARAM_TUNNEL_ID));
+      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+    }
   }
 #endif
 
@@ -782,54 +711,53 @@ void PrepareDecapTableEntry(p4::v1::TableEntry* table_entry,
 
 #if defined(ES2K_TARGET)
 void PrepareV6DecapTableEntry(p4::v1::TableEntry* table_entry,
-                              const struct tunnel_info &tunnel_info,
-                              const ::p4::config::v1::P4Info &p4info,
+                              const struct tunnel_info& tunnel_info,
+                              const ::p4::config::v1::P4Info& p4info,
                               bool insert_entry) {
   table_entry->set_table_id(GetTableId(p4info, IPV6_TUNNEL_TERM_TABLE));
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
-                      IPV6_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE));
+                                      IPV6_TUNNEL_TERM_TABLE_KEY_TUNNEL_TYPE));
   match->mutable_exact()->set_value(EncodeByteValue(1, TUNNEL_TYPE_VXLAN));
 
   auto match1 = table_entry->add_match();
   match1->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
-                      IPV6_TUNNEL_TERM_TABLE_KEY_IPV6_SRC));
-  match1->mutable_exact()->set_value(CanonicalizeIpv6(tunnel_info.remote_ip.ip.v6addr));
+                                       IPV6_TUNNEL_TERM_TABLE_KEY_IPV6_SRC));
+  match1->mutable_exact()->set_value(
+      CanonicalizeIpv6(tunnel_info.remote_ip.ip.v6addr));
 
   auto match2 = table_entry->add_match();
   match2->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
-                       IPV6_TUNNEL_TERM_TABLE_KEY_IPV6_DST));
-  match2->mutable_exact()->set_value(CanonicalizeIpv6(tunnel_info.local_ip.ip.v6addr));
+                                       IPV6_TUNNEL_TERM_TABLE_KEY_IPV6_DST));
+  match2->mutable_exact()->set_value(
+      CanonicalizeIpv6(tunnel_info.local_ip.ip.v6addr));
 
   if (insert_entry) {
-     auto table_action = table_entry->mutable_action();
-     auto action = table_action->mutable_action();
-     action->set_action_id(GetActionId(p4info, ACTION_DECAP_OUTER_HDR));
-     {
-       auto param = action->add_params();
-       param->set_param_id(GetParamId(p4info, ACTION_DECAP_OUTER_HDR,
-                           ACTION_DECAP_OUTER_HDR_PARAM_TUNNEL_ID));
-       param->set_value(EncodeByteValue(1, tunnel_info.vni));
-
-     }
+    auto table_action = table_entry->mutable_action();
+    auto action = table_action->mutable_action();
+    action->set_action_id(GetActionId(p4info, ACTION_DECAP_OUTER_HDR));
+    {
+      auto param = action->add_params();
+      param->set_param_id(GetParamId(p4info, ACTION_DECAP_OUTER_HDR,
+                                     ACTION_DECAP_OUTER_HDR_PARAM_TUNNEL_ID));
+      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+    }
   }
   return;
 }
 #endif
 
-absl::Status ConfigEncapTableEntry(ovs_p4rt_cpp::OvsP4rtSession* session,
-                                   const struct tunnel_info &tunnel_info,
-                                   const ::p4::config::v1::P4Info &p4info,
+absl::Status ConfigEncapTableEntry(ovs_p4rt::OvsP4rtSession* session,
+                                   const struct tunnel_info& tunnel_info,
+                                   const ::p4::config::v1::P4Info& p4info,
                                    bool insert_entry) {
   p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
   if (insert_entry) {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToInsert(session,
-                                      &write_request);
+    table_entry = ovs_p4rt::SetupTableEntryToInsert(session, &write_request);
   } else {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToDelete(session,
-                                      &write_request);
+    table_entry = ovs_p4rt::SetupTableEntryToDelete(session, &write_request);
   }
 
 #if defined(DPDK_TARGET)
@@ -838,31 +766,29 @@ absl::Status ConfigEncapTableEntry(ovs_p4rt_cpp::OvsP4rtSession* session,
 #elif defined(ES2K_TARGET)
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
-      PrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    PrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else if (tunnel_info.local_ip.family == AF_INET6 &&
              tunnel_info.remote_ip.family == AF_INET6) {
-      PrepareV6EncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    PrepareV6EncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   }
 #else
   return absl::UnknownError("Unsupported platform")
 #endif
 
-  return ovs_p4rt_cpp::SendWriteRequest(session, write_request);
+  return ovs_p4rt::SendWriteRequest(session, write_request);
 }
 
-absl::Status ConfigDecapTableEntry(ovs_p4rt_cpp::OvsP4rtSession* session,
-                                   const struct tunnel_info &tunnel_info,
-                                   const ::p4::config::v1::P4Info &p4info,
+absl::Status ConfigDecapTableEntry(ovs_p4rt::OvsP4rtSession* session,
+                                   const struct tunnel_info& tunnel_info,
+                                   const ::p4::config::v1::P4Info& p4info,
                                    bool insert_entry) {
   p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
   if (insert_entry) {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToInsert(session,
-                                      &write_request);
+    table_entry = ovs_p4rt::SetupTableEntryToInsert(session, &write_request);
   } else {
-      table_entry = ovs_p4rt_cpp::SetupTableEntryToDelete(session,
-                                      &write_request);
+    table_entry = ovs_p4rt::SetupTableEntryToDelete(session, &write_request);
   }
 #if defined(DPDK_TARGET)
   PrepareDecapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
@@ -870,45 +796,94 @@ absl::Status ConfigDecapTableEntry(ovs_p4rt_cpp::OvsP4rtSession* session,
 #elif defined(ES2K_TARGET)
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
-      PrepareDecapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    PrepareDecapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   } else if (tunnel_info.local_ip.family == AF_INET6 &&
              tunnel_info.remote_ip.family == AF_INET6) {
-      PrepareV6DecapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
+    PrepareV6DecapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   }
 #else
   return absl::UnknownError("Unsupported platform")
 #endif
 
-  return ovs_p4rt_cpp::SendWriteRequest(session, write_request);
+  return ovs_p4rt::SendWriteRequest(session, write_request);
 }
 
-void ConfigTunnelTableEntry(struct tunnel_info tunnel_info,
-                            bool insert_entry) {
-    // Start a new client session.
-    auto status_or_session = ovs_p4rt_cpp::OvsP4rtSession::Create(
-      absl::GetFlag(FLAGS_grpc_addr),
-      GenerateClientCredentials(),
+}  // namespace ovs_p4rt
+
+//----------------------------------------------------------------------
+// Functions with C interfaces
+//----------------------------------------------------------------------
+
+void ConfigFdbTableEntry(struct mac_learning_info learn_info,
+                         bool insert_entry) {
+  using namespace ovs_p4rt;
+
+  // Start a new client session.
+  auto status_or_session = ovs_p4rt::OvsP4rtSession::Create(
+      absl::GetFlag(FLAGS_grpc_addr), GenerateClientCredentials(),
       absl::GetFlag(FLAGS_device_id));
-    if (!status_or_session.ok()) {
-       return;
-    }
+  if (!status_or_session.ok()) {
+    return;
+  }
 
-    // Unwrap the session from the StatusOr object.
-    std::unique_ptr<ovs_p4rt_cpp::OvsP4rtSession> session =
+  // Unwrap the session from the StatusOr object.
+  std::unique_ptr<ovs_p4rt::OvsP4rtSession> session =
       std::move(status_or_session).value();
-    ::p4::config::v1::P4Info p4info;
-    ::absl::Status status = ovs_p4rt_cpp::GetForwardingPipelineConfig(session.get(),
-		            &p4info);
-    if(!status.ok())
-       return;
-    status = ConfigEncapTableEntry(session.get(), tunnel_info,
-                                   p4info, insert_entry);
-    if(!status.ok())
-       return;
-    status = ConfigDecapTableEntry(session.get(), tunnel_info,
-                                   p4info, insert_entry);
-    if(!status.ok())
-       return;
+  ::p4::config::v1::P4Info p4info;
+  ::absl::Status status =
+      ovs_p4rt::GetForwardingPipelineConfig(session.get(), &p4info);
+  if (!status.ok()) return;
 
+  if (learn_info.is_tunnel) {
+    status = ConfigFdbTunnelTableEntry(session.get(), learn_info, p4info,
+                                       insert_entry);
+  } else if (learn_info.is_vlan) {
+    status = ConfigFdbTxVlanTableEntry(session.get(), learn_info, p4info,
+                                       insert_entry);
+    if (!status.ok()) return;
+
+    status = ConfigFdbRxVlanTableEntry(session.get(), learn_info, p4info,
+                                       insert_entry);
+    if (!status.ok()) return;
+
+#if defined(ES2K_TARGET)
+    status = ConfigFdbTxV6VlanTableEntry(session.get(), learn_info, p4info,
+                                         insert_entry);
+    if (!status.ok()) return;
+    status = ConfigSemBypassTableEntry(session.get(), learn_info, p4info,
+                                       insert_entry);
+    if (!status.ok()) return;
+
+    status = ConfigFdbRxV6VlanTableEntry(session.get(), learn_info, p4info,
+                                         insert_entry);
+#endif
+  }
+  if (!status.ok()) return;
+  return;
+}
+
+void ConfigTunnelTableEntry(struct tunnel_info tunnel_info, bool insert_entry) {
+  using namespace ovs_p4rt;
+
+  // Start a new client session.
+  auto status_or_session = OvsP4rtSession::Create(
+      absl::GetFlag(FLAGS_grpc_addr), GenerateClientCredentials(),
+      absl::GetFlag(FLAGS_device_id));
+  if (!status_or_session.ok()) {
+    return;
+  }
+
+  // Unwrap the session from the StatusOr object.
+  std::unique_ptr<OvsP4rtSession> session =
+      std::move(status_or_session).value();
+  ::p4::config::v1::P4Info p4info;
+  ::absl::Status status = GetForwardingPipelineConfig(session.get(), &p4info);
+  if (!status.ok()) return;
+  status =
+      ConfigEncapTableEntry(session.get(), tunnel_info, p4info, insert_entry);
+  if (!status.ok()) return;
+  status =
+      ConfigDecapTableEntry(session.get(), tunnel_info, p4info, insert_entry);
+  if (!status.ok()) return;
   return;
 }

--- a/ovs-p4rt/ovs_p4rt_session.h
+++ b/ovs-p4rt/ovs_p4rt_session.h
@@ -1,16 +1,17 @@
 // Copyright 2020 Google LLC
 // Copyright 2021-present Open Networking Foundation
-// Copyright (c) 2022-2023 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef OVSP4RT_SESSION_H_
 #define OVSP4RT_SESSION_H_
 
+#include <grpcpp/grpcpp.h>
+
 #include <fstream>
 #include <memory>
 #include <sstream>
 #include <string>
-#include <grpcpp/grpcpp.h>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -19,30 +20,31 @@
 #include "p4/v1/p4runtime.grpc.pb.h"
 #include "p4/v1/p4runtime.pb.h"
 
-namespace ovs_p4rt_cpp {
+namespace ovs_p4rt {
+
 // Generates an election id that increases monotonically over time.
 // Specifically, the upper 64 bits are the unix timestamp in seconds, and the
 // lower 64 bits are 0. This is compatible with election systems that use the
 // same epoch-based election IDs, and in that case, this election ID will be
 // guaranteed to be higher than any previous election ID, allowing the user
 // to switch between ovs-p4rt and p4rt-ctl as master controller.
-inline absl::uint128 TimeBasedElectionId() {
-  return absl::MakeUint128(absl::ToUnixSeconds(absl::Now()), 0);
+inline ::absl::uint128 TimeBasedElectionId() {
+  return ::absl::MakeUint128(::absl::ToUnixSeconds(::absl::Now()), 0);
 }
 
 class OvsP4rtSession {
  public:
   // Create the session with given P4runtime stub and device id
-  static absl::StatusOr<std::unique_ptr<OvsP4rtSession>> Create(
+  static ::absl::StatusOr<std::unique_ptr<OvsP4rtSession>> Create(
       std::unique_ptr<p4::v1::P4Runtime::Stub> stub, uint32_t device_id,
-      absl::uint128 election_id = TimeBasedElectionId());
+      ::absl::uint128 election_id = TimeBasedElectionId());
 
   // Create the session with given grpc address, channel credentials
   // and device id
-  static absl::StatusOr<std::unique_ptr<OvsP4rtSession>> Create(
+  static ::absl::StatusOr<std::unique_ptr<OvsP4rtSession>> Create(
       const std::string& address,
       const std::shared_ptr<grpc::ChannelCredentials>& credentials,
-      uint32_t device_id, absl::uint128 election_id = TimeBasedElectionId());
+      uint32_t device_id, ::absl::uint128 election_id = TimeBasedElectionId());
 
   // Disable copy semantics.
   OvsP4rtSession(const OvsP4rtSession&) = delete;
@@ -60,14 +62,14 @@ class OvsP4rtSession {
 
  private:
   OvsP4rtSession(uint32_t device_id,
-                   std::unique_ptr<p4::v1::P4Runtime::Stub> stub,
-                   absl::uint128 election_id)
+                 std::unique_ptr<p4::v1::P4Runtime::Stub> stub,
+                 ::absl::uint128 election_id)
       : device_id_(device_id),
         stub_(std::move(stub)),
-        stream_channel_context_(absl::make_unique<grpc::ClientContext>()),
+        stream_channel_context_(::absl::make_unique<grpc::ClientContext>()),
         stream_channel_(stub_->StreamChannel(stream_channel_context_.get())) {
-    election_id_.set_high(absl::Uint128High64(election_id));
-    election_id_.set_low(absl::Uint128Low64(election_id));
+    election_id_.set_high(::absl::Uint128High64(election_id));
+    election_id_.set_low(::absl::Uint128Low64(election_id));
   }
 
   uint32_t device_id_;
@@ -79,7 +81,8 @@ class OvsP4rtSession {
   std::unique_ptr<grpc::ClientContext> stream_channel_context_;
 
   std::unique_ptr<grpc::ClientReaderWriter<p4::v1::StreamMessageRequest,
-                                           p4::v1::StreamMessageResponse>> stream_channel_;
+                                           p4::v1::StreamMessageResponse>>
+      stream_channel_;
 };
 
 std::unique_ptr<p4::v1::P4Runtime::Stub> CreateP4RuntimeStub(
@@ -88,25 +91,24 @@ std::unique_ptr<p4::v1::P4Runtime::Stub> CreateP4RuntimeStub(
 
 // Functions that operate on a OvsP4rtSession.
 
-absl::StatusOr<p4::v1::ReadResponse> SendReadRequest(
+::absl::StatusOr<p4::v1::ReadResponse> SendReadRequest(
     OvsP4rtSession* session, const p4::v1::ReadRequest& read_request);
 
-absl::Status SendWriteRequest(OvsP4rtSession* session,
+::absl::Status SendWriteRequest(OvsP4rtSession* session,
                               const p4::v1::WriteRequest& write_request);
 
-absl::Status GetForwardingPipelineConfig(OvsP4rtSession* session,
+::absl::Status GetForwardingPipelineConfig(OvsP4rtSession* session,
                                          p4::config::v1::P4Info* p4info);
 
 ::p4::v1::TableEntry* SetupTableEntryToInsert(OvsP4rtSession* session,
-                             ::p4::v1::WriteRequest* req);
+                                              ::p4::v1::WriteRequest* req);
 
 ::p4::v1::TableEntry* SetupTableEntryToModify(OvsP4rtSession* session,
-                             ::p4::v1::WriteRequest* req);
+                                              ::p4::v1::WriteRequest* req);
 
 ::p4::v1::TableEntry* SetupTableEntryToDelete(OvsP4rtSession* session,
-                             ::p4::v1::WriteRequest* req);
+                                              ::p4::v1::WriteRequest* req);
 
-}  // namespace ovs_p4rt_cpp
+}  // namespace ovs_p4rt
 
 #endif  // OVS_P4RT_SESSION_H_
-

--- a/ovs-p4rt/ovs_p4rt_tls_credentials.cc
+++ b/ovs-p4rt/ovs_p4rt_tls_credentials.cc
@@ -4,12 +4,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ovs_p4rt_tls_credentials.h"
-#include <string>
-#include <iostream>
 
 #include <sys/stat.h>
 
-namespace ovs_p4rt_cpp {
+#include <iostream>
+#include <string>
+
+namespace ovs_p4rt {
 
 using ::grpc::experimental::FileWatcherCertificateProvider;
 using ::grpc::experimental::TlsChannelCredentialsOptions;
@@ -17,7 +18,7 @@ using ::grpc::experimental::TlsChannelCredentialsOptions;
 bool IsRegularFile(const std::string& filename) {
   struct stat buf;
   int rc = lstat(filename.c_str(), &buf);
-  return (rc==0 && S_ISREG(buf.st_mode));
+  return (rc == 0 && S_ISREG(buf.st_mode));
 }
 
 std::shared_ptr<::grpc::ChannelCredentials> GenerateClientCredentials() {
@@ -25,20 +26,19 @@ std::shared_ptr<::grpc::ChannelCredentials> GenerateClientCredentials() {
   // If files are not present or not accesible, load insecure credentials
   std::shared_ptr<::grpc::ChannelCredentials> client_credentials_;
 
-  if (IsRegularFile(ca_cert_file) &&
-      IsRegularFile(client_cert_file) &&
+  if (IsRegularFile(ca_cert_file) && IsRegularFile(client_cert_file) &&
       IsRegularFile(client_key_file)) {
-        auto certificate_provider =
-              std::make_shared<FileWatcherCertificateProvider>(
-                  client_key_file, client_cert_file, ca_cert_file,
-                  kFileRefreshIntervalSeconds);
-        auto tls_opts = std::make_shared<TlsChannelCredentialsOptions>();
-        tls_opts->set_certificate_provider(certificate_provider);
-        tls_opts->watch_root_certs();
-        if (!ca_cert_file.empty() && !client_key_file.empty()) {
-          tls_opts->watch_identity_key_cert_pairs();
-        }
-        client_credentials_ = ::grpc::experimental::TlsCredentials(*tls_opts);
+    auto certificate_provider =
+        std::make_shared<FileWatcherCertificateProvider>(
+            client_key_file, client_cert_file, ca_cert_file,
+            kFileRefreshIntervalSeconds);
+    auto tls_opts = std::make_shared<TlsChannelCredentialsOptions>();
+    tls_opts->set_certificate_provider(certificate_provider);
+    tls_opts->watch_root_certs();
+    if (!ca_cert_file.empty() && !client_key_file.empty()) {
+      tls_opts->watch_identity_key_cert_pairs();
+    }
+    client_credentials_ = ::grpc::experimental::TlsCredentials(*tls_opts);
   } else {
     client_credentials_ = ::grpc::InsecureChannelCredentials();
     printf("Using insecure client credentials!\n");
@@ -46,4 +46,4 @@ std::shared_ptr<::grpc::ChannelCredentials> GenerateClientCredentials() {
   return client_credentials_;
 }
 
-}  // namespace ovs_p4rt_cpp
+}  // namespace ovs_p4rt

--- a/ovs-p4rt/ovs_p4rt_tls_credentials.h
+++ b/ovs-p4rt/ovs_p4rt_tls_credentials.h
@@ -6,8 +6,10 @@
 #ifndef OVSP4RT_TLS_CREDENTIALS_H_
 #define OVSP4RT_TLS_CREDENTIALS_H_
 
-#include <string>
 #include <grpcpp/grpcpp.h>
+
+#include <string>
+
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "grpcpp/grpcpp.h"
@@ -16,7 +18,7 @@
 
 #define DEFAULT_CERTS_DIR "/usr/share/stratum/certs/"
 
-namespace ovs_p4rt_cpp {
+namespace ovs_p4rt {
 
 static std::string ca_cert_file = DEFAULT_CERTS_DIR "ca.crt";
 static std::string client_key_file = DEFAULT_CERTS_DIR "client.key";
@@ -25,10 +27,10 @@ static std::string client_cert_file = DEFAULT_CERTS_DIR "client.crt";
 static constexpr unsigned int kFileRefreshIntervalSeconds = 1;
 
 // Checks whether filename is a regular file and not a symlink
-static bool IsRegularFile(const std::string& filename);
+bool IsRegularFile(const std::string& filename);
 
 std::shared_ptr<::grpc::ChannelCredentials> GenerateClientCredentials();
 
-}  // namespace ovs_p4rt_cpp
+}  // namespace ovs_p4rt
 
 #endif  // OVSP4RT_TLS_CREDENTIALS_H_


### PR DESCRIPTION
- Use clang-format to ensure that ovs-p4rt source code is in canonical form.

- Change namespace from ovs_p4rt_cpp to ovs_p4rt.

- Move the bulk of ovs_p4rt.cpp into the ovs_p4rt namespace. The C interfaces remain outside the namespace.