### PR TITLE
Implement OVS Find-module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.15)
 # CMAKE_BUILD_TYPE must be set before the first project() command.
 set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Type of build to perform")
 
-project(networking-recipe VERSION 23.01 LANGUAGES C CXX)
+project(networking-recipe VERSION 23.07 LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
@@ -30,11 +30,8 @@ cmake_print_variables(CMAKE_STAGING_PREFIX)
 set(DEPEND_INSTALL_DIR "$ENV{DEPEND_INSTALL}" CACHE PATH
     "Dependencies install directory")
 
-set(OVS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}" CACHE PATH
+set(OVS_INSTALL_DIR "$ENV{OVS_INSTALL}" CACHE PATH
     "OVS install directory")
-
-set(OVS_SOURCE_DIR "${CMAKE_SOURCE_DIR}/ovs/ovs" CACHE PATH
-    "OVS source directory")
 
 set(SDE_INSTALL_DIR "$ENV{SDE_INSTALL}" CACHE PATH
     "SDE install directory")
@@ -178,6 +175,13 @@ elseif(ES2K_TARGET)
     include(es2k-driver)
 elseif(TOFINO_TARGET)
     include(tofino-driver)
+endif()
+
+if(WITH_OVSP4RT)
+    if(OVS_INSTALL_DIR STREQUAL "")
+        message(FATAL_ERROR "OVS_INSTALL_DIR not defined!")
+    endif()
+    find_package(OVS)
 endif()
 
 ########################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ endif()
 
 if(WITH_OVSP4RT)
     if(OVS_INSTALL_DIR STREQUAL "")
-        message(FATAL_ERROR "OVS_INSTALL_DIR not defined!")
+        message(FATAL_ERROR "OVS_INSTALL_DIR (OVS_INSTALL) not defined!")
     endif()
     find_package(OVS)
 endif()

--- a/cmake/FindOVS.cmake
+++ b/cmake/FindOVS.cmake
@@ -8,7 +8,7 @@
 # Use pkg-config to search for the modules.
 #-----------------------------------------------------------------------
 find_package(PkgConfig)
-pkg_check_modules(PC_OVS QUIET libopenvswitch)
+pkg_check_modules(PC_OVS libopenvswitch)
 
 #-----------------------------------------------------------------------
 # Find libraries and include directories.
@@ -24,17 +24,17 @@ find_library(OVS_LIBRARY
 )
 
 find_library(OFPROTO_LIBRARY
-    names ofproto
+    NAMES ofproto
     PATHS ${PC_OVS_LIBRARY_DIRS}
 )
 
 find_library(OVSDB_LIBRARY
-    names ovsdb
+    NAMES ovsdb
     PATHS ${PC_OVS_LIBRARY_DIRS}
 )
 
 find_library(SFLOW_LIBRARY
-    names sflow
+    NAMES sflow
     PATHS ${PC_OVS_LIBRARY_DIRS}
 )
 

--- a/cmake/FindOVS.cmake
+++ b/cmake/FindOVS.cmake
@@ -1,0 +1,131 @@
+# FindOVS.cmake - find Open vSwitch package.
+#
+# Copyright 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+
+#-----------------------------------------------------------------------
+# Use pkg-config to search for the modules.
+#-----------------------------------------------------------------------
+find_package(PkgConfig)
+pkg_check_modules(PC_OVS QUIET libopenvswitch)
+
+#-----------------------------------------------------------------------
+# Find libraries and include directories.
+#-----------------------------------------------------------------------
+find_path(OVS_INCLUDE_DIR
+    NAMES "openvswitch/version.h"
+    PATHS ${PC_OVS_INCLUDE_DIRS}
+)
+
+find_library(OVS_LIBRARY
+    NAMES openvswitch
+    PATHS ${PC_OVS_LIBRARY_DIRS}
+)
+
+find_library(OFPROTO_LIBRARY
+    names ofproto
+    PATHS ${PC_OVS_LIBRARY_DIRS}
+)
+
+find_library(OVSDB_LIBRARY
+    names ovsdb
+    PATHS ${PC_OVS_LIBRARY_DIRS}
+)
+
+find_library(SFLOW_LIBRARY
+    names sflow
+    PATHS ${PC_OVS_LIBRARY_DIRS}
+)
+
+find_library(LIBVSWITCHD
+    NAMES vswitchd
+    PATHS ${PC_OVS_LIBRARY_DIRS}
+)
+
+find_library(LIBTESTCONTROLLER
+    NAMES testcontroller
+    PATHS ${PC_OVS_LIBRARY_DIRS}
+)
+
+#-----------------------------------------------------------------------
+# Get version number
+#-----------------------------------------------------------------------
+if(PC_OVS_VERSION)
+    set(OVS_VERSION ${PC_OVS_VERSION} CACHE STRING "OVS version")
+elseif(EXISTS "${OVS_INCLUDE_DIR}/openvswitch/version.h")
+    # Extract version string from version.h file.
+    file(STRINGS
+        "${OVS_INCLUDE_DIR}/openvswitch/version.h"
+        _version_string REGEX "OVS_PACKAGE_VERSION")
+    string(REGEX REPLACE
+        "[^0-9.]+([0-9.]+).*" "\\1" OVS_VERSION ${_version_string})
+    set(OVS_VERSION ${PC_OVS_VERSION} CACHE STRING "OVS version")
+    unset(_version_string)
+endif()
+
+#-----------------------------------------------------------------------
+# Handle REQUIRED and QUIET arguments
+#-----------------------------------------------------------------------
+find_package_handle_standard_args(OVS
+    REQUIRED_VARS
+        OVS_LIBRARY
+        OVS_INCLUDE_DIR
+        OFPROTO_LIBRARY
+        SFLOW_LIBRARY
+    VERSION_VAR
+        OVS_VERSION
+)
+
+mark_as_advanced(OVS_INCLUDE_DIR)
+mark_as_advanced(OVS_LIBRARY OVSDB_LIBRARY OFPROTO_LIBRARY SFLOW_LIBRARY)
+mark_as_advanced(LIBVSWITCHD LIBTESTCONTROLLER)
+
+#-----------------------------------------------------------------------
+# Define library targets
+#-----------------------------------------------------------------------
+add_library(ovs::openvswitch UNKNOWN IMPORTED)
+set_target_properties(ovs::openvswitch PROPERTIES
+    IMPORTED_LOCATION ${OVS_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${OVS_INCLUDE_DIR}
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+)
+
+add_library(ovs::ovsdb UNKNOWN IMPORTED)
+set_target_properties(ovs::ovsdb PROPERTIES
+    IMPORTED_LOCATION ${OVSDB_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${OVS_INCLUDE_DIR}
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+)
+
+add_library(ovs::ofproto UNKNOWN IMPORTED)
+set_target_properties(ovs::ofproto PROPERTIES
+    IMPORTED_LOCATION ${OFPROTO_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${OVS_INCLUDE_DIR}
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+)
+
+add_library(ovs::sflow UNKNOWN IMPORTED)
+set_target_properties(ovs::sflow PROPERTIES
+    IMPORTED_LOCATION ${SFLOW_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${OVS_INCLUDE_DIR}
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+)
+
+if(LIBVSWITCHD)
+    add_library(ovs::vswitchd UNKNOWN IMPORTED)
+    set_target_properties(ovs::vswitchd PROPERTIES
+        IMPORTED_LOCATION ${LIBVSWITCHD}
+        INTERFACE_INCLUDE_DIRECTORIES ${OVS_INCLUDE_DIR}
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+    )
+endif()
+
+if(LIBTESTCONTROLLER)
+    add_library(ovs::testcontroller UNKNOWN IMPORTED)
+    set_target_properties(ovs::testcontroller PROPERTIES
+        IMPORTED_LOCATION ${LIBTESTCONTROLLER}
+        INTERFACE_INCLUDE_DIRECTORIES ${OVS_INCLUDE_DIR}
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+    )
+endif()

--- a/ovs-p4rt/CMakeLists.txt
+++ b/ovs-p4rt/CMakeLists.txt
@@ -28,21 +28,6 @@ check_binutils_avx512(HAVE_LD_AVX512_GOOD)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.h.in"
                "${CMAKE_CURRENT_BINARY_DIR}/config.h")
 
-# Update pkg-config search path.
-set(_save_CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH})
-list(PREPEND CMAKE_PREFIX_PATH ${OVS_INSTALL_DIR})
-set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH TRUE)
-
-pkg_check_modules(LIBOVS REQUIRED libopenvswitch)
-pkg_check_modules(OFPROTO REQUIRED libofproto)
-pkg_check_modules(SFLOW REQUIRED libsflow)
-
-set(CMAKE_PREFIX_PATH ${_save_CMAKE_PREFIX_PATH})
-unset(_save_CMAKE_PREFIX_PATH)
-
-find_library(LIBVSWITCHD vswitchd REQUIRED)
-find_library(LIBTESTCONTROLLER testcontroller REQUIRED)
-
 find_package(Unbound)
 find_package(Unwind)
 
@@ -90,11 +75,11 @@ set_install_rpath(ovs-vswitchd ${EXEC_ELEMENT} ${DEP_ELEMENT})
 target_link_libraries(ovs-vswitchd
     PRIVATE
         -Wl,--whole-archive
-        ${LIBVSWITCHD}
+        ovs::vswitchd
         -Wl,--no-whole-archive
-        ${OFPROTO_LINK_LIBRARIES}
-        ${LIBOVS_LINK_LIBRARIES}
-        ${SFLOW_LINK_LIBRARIES}
+        ovs::ofproto
+        ovs::openvswitch
+        ovs::sflow
     PUBLIC
         atomic
         rt m pthread
@@ -137,12 +122,12 @@ set_install_rpath(ovs-testcontroller ${EXEC_ELEMENT} ${DEP_ELEMENT})
 target_link_libraries(ovs-testcontroller
     PRIVATE
         -Wl,--whole-archive
-        ${LIBTESTCONTROLLER}
+        ovs::testcontroller
         -Wl,--no-whole-archive
-        ${OFPROTO_LINK_LIBRARIES}
-        ${LIBOVS_LINK_LIBRARIES}
-        ${SFLOW_LINK_LIBRARIES}
-        ${LIBVSWITCHD}
+        ovs::ofproto
+        ovs::openvswitch
+        ovs::sflow
+        ovs::vswitchd
     PUBLIC
         atomic
         rt

--- a/setup/prune.sh
+++ b/setup/prune.sh
@@ -3,14 +3,18 @@
 # Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
-# Removes duplicate copies of third-party packages.
+# Removes unnecessary third-party packages.
 #
 
+# duplicate packages
 rm -fr grpc/third_party/abseil-cpp
 rm -fr grpc/third_party/bloaty/abseil-cpp
+rm -fr grpc/third_party/bloaty/third_party/abseil-cpp
 rm -fr grpc/third_party/bloaty/third_party/protobuf
 rm -fr grpc/third_party/bloaty/third_party/zlib
-rm -fr grpc/third_party/boring-ssl-with-bazel
 rm -fr grpc/third_party/cares
 rm -fr grpc/third_party/protobuf
 rm -fr grpc/third_party/zlib
+
+# unused packages
+rm -fr grpc/third_party/boringssl-with-bazel


### PR DESCRIPTION
- Reimplement the OVS library interface logic as a cmake Find Module. In keeping with modern practice, define a target for each library.

- Change default value of the OVS_INSTALL_DIR variable from ${CMAKE_INSTALL_PREFIX} to $ENV{OVS_INSTALL}. The OVS install tree is an input to the P4 Control Plane build, not an output.

- Delete the OVS_SOURCE_DIR variable. The P4 Control Plane build uses the OVS install tree, not its source tree.

- Fix a couple of issues in the setup/prune.sh script.