### PR TITLE
Add support for libunbound

### DIFF
--- a/cmake/FindUnbound.cmake
+++ b/cmake/FindUnbound.cmake
@@ -32,7 +32,7 @@ if(UNBOUND_VERSION)
 endif()
 
 #-----------------------------------------------------------------------
-# Handle REQUIRED and QUIETLY arguments
+# Handle REQUIRED and QUIET arguments
 #-----------------------------------------------------------------------
 find_package_handle_standard_args(UNBOUND
     REQUIRED_VARS

--- a/cmake/FindUnbound.cmake
+++ b/cmake/FindUnbound.cmake
@@ -1,0 +1,56 @@
+# FindUnbound.cmake - Find libunbound package.
+#
+# Copyright 2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+
+#-----------------------------------------------------------------------
+# Use pkg-config to search for the module.
+#-----------------------------------------------------------------------
+find_package(PkgConfig)
+
+pkg_check_modules(UNBOUND QUIET libunbound)
+
+#-----------------------------------------------------------------------
+# Find libraries and include directories.
+#-----------------------------------------------------------------------
+find_path(UNBOUND_INCLUDE_DIR
+    NAMES "unbound.h"
+    PATHS ${UNBOUND_INCLUDE_DIRS}
+)
+
+find_library(UNBOUND_LIBRARY
+    NAMES unbound
+    PATHS ${UNBOUND_LIBRARY_DIRS}
+)
+
+#-----------------------------------------------------------------------
+# Get version number
+#-----------------------------------------------------------------------
+if(UNBOUND_VERSION)
+    set(UNBOUND_VERSION ${UNBOUND_VERSION} CACHE STRING "libunbound version")
+endif()
+
+#-----------------------------------------------------------------------
+# Handle REQUIRED and QUIETLY arguments
+#-----------------------------------------------------------------------
+find_package_handle_standard_args(UNBOUND
+    REQUIRED_VARS
+        UNBOUND_LIBRARY
+        UNBOUND_INCLUDE_DIR
+    VERSION_VAR
+        UNBOUND_VERSION
+)
+
+mark_as_advanced(UNBOUND_INCLUDE_DIR UNBOUND_LIBRARY UNBOUND_VERSION)
+
+#-----------------------------------------------------------------------
+# Define library target
+#-----------------------------------------------------------------------
+add_library(unbound UNKNOWN IMPORTED)
+
+set_target_properties(unbound PROPERTIES
+    IMPORTED_LOCATION ${UNBOUND_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${UNBOUND_INCLUDE_DIR}
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+)

--- a/ovs-p4rt/CMakeLists.txt
+++ b/ovs-p4rt/CMakeLists.txt
@@ -43,6 +43,8 @@ unset(_save_CMAKE_PREFIX_PATH)
 find_library(LIBVSWITCHD vswitchd REQUIRED)
 find_library(LIBTESTCONTROLLER testcontroller REQUIRED)
 
+find_package(Unbound)
+
 # libunwind appears to be missing in the ACC build
 # include it conditionally
 find_library(LIBUNWIND unwind)
@@ -103,6 +105,10 @@ target_link_libraries(ovs-vswitchd
         rt m pthread
 )
 
+if(TARGET unbound)
+    target_link_libraries(ovs-vswitchd PUBLIC unbound)
+endif()
+
 set_install_rpath(ovs-vswitchd ${EXEC_ELEMENT} ${DEP_ELEMENT})
 
 target_link_libraries(ovs-vswitchd PUBLIC
@@ -146,6 +152,10 @@ target_link_libraries(ovs-testcontroller
         rt
         ${UNWIND}
 )
+
+if(TARGET unbound)
+    target_link_libraries(ovs-testcontroller PUBLIC unbound)
+endif()
 
 target_link_libraries(ovs-testcontroller PUBLIC
     absl::strings


### PR DESCRIPTION
- Implement Find module for libunbound package.

- Include Unbound library when linking ovs-vswitchd and ovs-testcontroller if package is installed.