### PR TITLE
Use find_package() to locate unwind module

### DIFF
--- a/cmake/FindUnbound.cmake
+++ b/cmake/FindUnbound.cmake
@@ -9,7 +9,10 @@
 #-----------------------------------------------------------------------
 find_package(PkgConfig)
 
-pkg_check_modules(UNBOUND QUIET libunbound)
+pkg_check_modules(UNBOUND libunbound)
+if(NOT UNBOUND_FOUND)
+    return()
+endif()
 
 #-----------------------------------------------------------------------
 # Find libraries and include directories.

--- a/cmake/FindUnwind.cmake
+++ b/cmake/FindUnwind.cmake
@@ -1,0 +1,56 @@
+# FindUnwind.cmake - Find libunwind package.
+#
+# Copyright 2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+
+#-----------------------------------------------------------------------
+# Use pkg-config to search for the module.
+#-----------------------------------------------------------------------
+find_package(PkgConfig)
+
+pkg_check_modules(UNWIND QUIET libunwind)
+
+#-----------------------------------------------------------------------
+# Find libraries and include directories.
+#-----------------------------------------------------------------------
+find_path(UNWIND_INCLUDE_DIR
+    NAMES "unwind.h"
+    PATHS ${UNWIND_INCLUDE_DIRS}
+)
+
+find_library(UNWIND_LIBRARY
+    NAMES unwind
+    PATHS ${UNWIND_LIBRARY_DIRS}
+)
+
+#-----------------------------------------------------------------------
+# Get version number
+#-----------------------------------------------------------------------
+if(UNWIND_VERSION)
+    set(UNWIND_VERSION ${UNWIND_VERSION} CACHE STRING "libunwind version")
+endif()
+
+#-----------------------------------------------------------------------
+# Handle REQUIRED and QUIETLY arguments
+#-----------------------------------------------------------------------
+find_package_handle_standard_args(UNWIND
+    REQUIRED_VARS
+        UNWIND_LIBRARY
+        UNWIND_INCLUDE_DIR
+    VERSION_VAR
+        UNWIND_VERSION
+)
+
+mark_as_advanced(UNWIND_INCLUDE_DIR UNWIND_LIBRARY UNWIND_VERSION)
+
+#-----------------------------------------------------------------------
+# Define library target
+#-----------------------------------------------------------------------
+add_library(unwind UNKNOWN IMPORTED)
+
+set_target_properties(unwind PROPERTIES
+    IMPORTED_LOCATION ${UNWIND_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${UNWIND_INCLUDE_DIR}
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+)

--- a/cmake/FindUnwind.cmake
+++ b/cmake/FindUnwind.cmake
@@ -9,7 +9,10 @@
 #-----------------------------------------------------------------------
 find_package(PkgConfig)
 
-pkg_check_modules(UNWIND QUIET libunwind)
+pkg_check_modules(UNWIND libunwind)
+if(NOT UNWIND_FOUND)
+    return()
+endif()
 
 #-----------------------------------------------------------------------
 # Find libraries and include directories.

--- a/cmake/FindUnwind.cmake
+++ b/cmake/FindUnwind.cmake
@@ -32,7 +32,7 @@ if(UNWIND_VERSION)
 endif()
 
 #-----------------------------------------------------------------------
-# Handle REQUIRED and QUIETLY arguments
+# Handle REQUIRED and QUIET arguments
 #-----------------------------------------------------------------------
 find_package_handle_standard_args(UNWIND
     REQUIRED_VARS

--- a/ovs-p4rt/CMakeLists.txt
+++ b/ovs-p4rt/CMakeLists.txt
@@ -85,6 +85,8 @@ add_executable(ovs-vswitchd
     $<TARGET_OBJECTS:ovs_sidecar_o>
 )
 
+set_install_rpath(ovs-vswitchd ${EXEC_ELEMENT} ${DEP_ELEMENT})
+
 target_link_libraries(ovs-vswitchd
     PRIVATE
         -Wl,--whole-archive
@@ -97,8 +99,6 @@ target_link_libraries(ovs-vswitchd
         atomic
         rt m pthread
 )
-
-set_install_rpath(ovs-vswitchd ${EXEC_ELEMENT} ${DEP_ELEMENT})
 
 if(TARGET unbound)
     target_link_libraries(ovs-vswitchd PUBLIC unbound)
@@ -148,13 +148,12 @@ target_link_libraries(ovs-testcontroller
         rt
 )
 
-<<<<<<< HEAD
 if(TARGET unbound)
     target_link_libraries(ovs-testcontroller PUBLIC unbound)
-=======
+endif()
+
 if(TARGET unwind)
     target_link_libraries(ovs-testcontroller PUBLIC unwind)
->>>>>>> Use find_package() to locate unwind module
 endif()
 
 target_link_libraries(ovs-testcontroller PUBLIC

--- a/ovs-p4rt/CMakeLists.txt
+++ b/ovs-p4rt/CMakeLists.txt
@@ -44,13 +44,7 @@ find_library(LIBVSWITCHD vswitchd REQUIRED)
 find_library(LIBTESTCONTROLLER testcontroller REQUIRED)
 
 find_package(Unbound)
-
-# libunwind appears to be missing in the ACC build
-# include it conditionally
-find_library(LIBUNWIND unwind)
-if(LIBUNWIND)
-    set(UNWIND unwind)
-endif()
+find_package(Unwind)
 
 if(DPDK_TARGET)
     add_subdirectory(dpdk)
@@ -101,15 +95,18 @@ target_link_libraries(ovs-vswitchd
         ${SFLOW_LINK_LIBRARIES}
     PUBLIC
         atomic
-        ${UNWIND}
         rt m pthread
 )
+
+set_install_rpath(ovs-vswitchd ${EXEC_ELEMENT} ${DEP_ELEMENT})
 
 if(TARGET unbound)
     target_link_libraries(ovs-vswitchd PUBLIC unbound)
 endif()
 
-set_install_rpath(ovs-vswitchd ${EXEC_ELEMENT} ${DEP_ELEMENT})
+if(TARGET unwind)
+    target_link_libraries(ovs-vswitchd PUBLIC unwind)
+endif()
 
 target_link_libraries(ovs-vswitchd PUBLIC
     absl::strings
@@ -119,7 +116,6 @@ target_link_libraries(ovs-vswitchd PUBLIC
 )
 
 target_link_libraries(ovs-vswitchd PUBLIC stratum_static)
-#add_dependencies(ovs-vswitchd stratum_static)
 
 target_link_libraries(ovs-vswitchd PUBLIC
     stratum_proto
@@ -150,11 +146,15 @@ target_link_libraries(ovs-testcontroller
     PUBLIC
         atomic
         rt
-        ${UNWIND}
 )
 
+<<<<<<< HEAD
 if(TARGET unbound)
     target_link_libraries(ovs-testcontroller PUBLIC unbound)
+=======
+if(TARGET unwind)
+    target_link_libraries(ovs-testcontroller PUBLIC unwind)
+>>>>>>> Use find_package() to locate unwind module
 endif()
 
 target_link_libraries(ovs-testcontroller PUBLIC


### PR DESCRIPTION
- Use find_package() instead of find_library() to find Unwind library.