### PR TITLE
Update gRPC to v1.54.2

### DIFF
--- a/setup/cmake/deps.cmake
+++ b/setup/cmake/deps.cmake
@@ -20,7 +20,7 @@ set(GLOG_GIT_URL https://github.com/google/glog.git)
 set(GLOG_GIT_TAG a8e0007e96ff96145022c488e367da10f835c75d) # v0.6.0-rc1
 
 set(GRPC_GIT_URL https://github.com/google/grpc.git)
-set(GRPC_GIT_TAG 90ccf24d22b6fc909a1021ebd89fd8c838467d26) # v1.50.1
+set(GRPC_GIT_TAG 8871dab19b4ab5389e28474d25cfeea61283265c) # v1.54.2
 
 set(GTEST_GIT_URL https://github.com/google/googletest.git)
 set(GTEST_GIT_TAG release-1.11.0)

--- a/setup/cmake/grpc.patch.in
+++ b/setup/cmake/grpc.patch.in
@@ -1,32 +1,32 @@
-# Copyright 2022 Intel Corporation
+# Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+
+# Updated to gRPC v1.54.2
 
 # Patch the gRPC build script to set the RUNPATH of the installed
 # Protobuf compiler plugins to the relative paths of the library
 # directories.
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 824886600..5ba8f9384 100644
+index b67b7aafae..18d837e301 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -11173,6 +11173,10 @@ add_executable(grpc_cpp_plugin
+@@ -12248,6 +12248,9 @@ if(gRPC_BUILD_CODEGEN AND gRPC_BUILD_GRPC_CPP_PLUGIN)
+ add_executable(grpc_cpp_plugin
    src/compiler/cpp_plugin.cc
  )
- 
 +set_target_properties(grpc_cpp_plugin
 +  PROPERTIES INSTALL_RPATH @GRPC_INSTALL_RPATH@
 +)
-+
+ target_compile_features(grpc_cpp_plugin PUBLIC cxx_std_14)
  target_include_directories(grpc_cpp_plugin
    PRIVATE
-     ${CMAKE_CURRENT_SOURCE_DIR}
-@@ -11368,6 +11372,10 @@ add_executable(grpc_python_plugin
+@@ -12507,6 +12510,9 @@ if(gRPC_BUILD_CODEGEN AND gRPC_BUILD_GRPC_PYTHON_PLUGIN)
+ add_executable(grpc_python_plugin
    src/compiler/python_plugin.cc
  )
- 
 +set_target_properties(grpc_python_plugin
 +  PROPERTIES INSTALL_RPATH @GRPC_INSTALL_RPATH@
 +)
-+
+ target_compile_features(grpc_python_plugin PUBLIC cxx_std_14)
  target_include_directories(grpc_python_plugin
    PRIVATE
-     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/setup/cmake/grpc.patch.in
+++ b/setup/cmake/grpc.patch.in
@@ -3,9 +3,12 @@
 
 # Updated to gRPC v1.54.2
 
-# Patch the gRPC build script to set the RUNPATH of the installed
-# Protobuf compiler plugins to the relative paths of the library
-# directories.
+# 1) Patch the gRPC build script to set the RUNPATH of the installed
+#    Protobuf compiler plugins to the relative paths of the library
+#    directories.
+# 2) Fix a bug in the v1.54.2 build script by suppressing installation of
+#    gRPCPluginTargets if gRPC_BUILD_CODEGEN is FALSE. We can't export
+#    the plugin targets if we haven't built them.
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index b67b7aafae..18d837e301 100644
 --- a/CMakeLists.txt
@@ -30,3 +33,20 @@ index b67b7aafae..18d837e301 100644
  target_compile_features(grpc_python_plugin PUBLIC cxx_std_14)
  target_include_directories(grpc_python_plugin
    PRIVATE
+@@ -25968,10 +25974,12 @@ if(gRPC_INSTALL)
+     DESTINATION ${gRPC_INSTALL_CMAKEDIR}
+     NAMESPACE gRPC::
+   )
+-  install(EXPORT gRPCPluginTargets
+-    DESTINATION ${gRPC_INSTALL_CMAKEDIR}
+-    NAMESPACE gRPC::
+-  )
++  if(gRPC_BUILD_CODEGEN)
++    install(EXPORT gRPCPluginTargets
++      DESTINATION ${gRPC_INSTALL_CMAKEDIR}
++      NAMESPACE gRPC::
++    )
++  endif()
+ endif()
+
+ include(CMakePackageConfigHelpers)


### PR DESCRIPTION
- Upgrade gRPC from v1.50.1 to v1.54.2, incorporating fixes for CVE-2023-32731, CVE-2023-32732, and CVE-2023-1428.

- Modify gRPC patch to work with updated source file.

- Fix error when cross-compiling gRPC v1.54.2 for ACC:

     `INSTALL(EXPORT) given unknown export "gRPCPluginTargets"`

  We suppress the gRPC plugin targets when cross-compiling for ACC because we use the HOST compiler to do the build, not the target compiler. This means that there are no gRPC Plugin Targets to be exported.

  We solve the problem by conditionalizing the INSTALL(EXPORT) command with the variable that conditionalizes generation of the plugins.