### PR TITLE
Fix force-patch omission in make-cross-deps.sh

### DIFF
--- a/setup/make-cross-deps.sh
+++ b/setup/make-cross-deps.sh
@@ -65,7 +65,7 @@ print_help() {
 # Parse command line #
 ######################
 
-SHORTOPTS=B:H:P:T:hj:n
+SHORTOPTS=B:H:P:T:fhj:n
 LONGOPTS=build:,cxx:,hostdeps:,jobs:,prefix:,toolchain:
 LONGOPTS=${LONGOPTS},dry-run,force,help,no-download,sudo
 


### PR DESCRIPTION
- Supply missing definition of -f short option.