### PR TITLE
Update list of Stratum DPDK unit tests

### DIFF
--- a/.github/dpdk-tests.txt
+++ b/.github/dpdk-tests.txt
@@ -9,5 +9,5 @@
 //stratum/hal/lib/tdi:tdi_pre_manager_test
 //stratum/hal/lib/tdi:tdi_table_manager_test
 //stratum/hal/lib/tdi:utils_test
-//stratum/hal/lib/tdi/dpdk:dpdk_chassis_manager_test
+//stratum/hal/lib/tdi/dpdk:all
 //stratum/hal/lib/yang/...


### PR DESCRIPTION
- Run all unit tests in //stratum/hal/lib/tdi/dpdk.

This PR adds three Stratum unit tests to the CI DPDK test suite.

Note that the PR cannot be merged until https://github.com/ipdk-io/stratum-dev/pull/89 has been approved and merged. The Stratum reference point will also need to be updated.