### PR TITLE
Add check for missing grpc cpp plugin

### DIFF
--- a/stratum/proto/CMakeLists.txt
+++ b/stratum/proto/CMakeLists.txt
@@ -27,6 +27,9 @@ if(gRPC AND TARGET(gRPC::grpc_cpp_plugin))
 else()
     find_program(GRPC_CPP_PLUGIN "grpc_cpp_plugin" REQUIRED
         NO_CMAKE_FIND_ROOT_PATH)
+    if(NOT GRPC_CPP_PLUGIN)
+        message(FATAL_ERROR "grpc_cpp_plugin not found")
+    endif()
 endif()
 
 cmake_print_variables(PROTOBUF_PROTOC_EXECUTABLE)


### PR DESCRIPTION
- It turns out that find_program() gained support for the REQUIRED parameter in cmake 3.18. Add an explicit check to ensure that the build fails if we are unable to find grpc_cpp_plugin in an earlier version of cmake.