### PR TITLE
Building dependencies for the ES2K ACC

### DIFF
--- a/setup/building-es2k-stratum-deps.md
+++ b/setup/building-es2k-stratum-deps.md
@@ -31,19 +31,19 @@ between client applications and `infrap4d`.
 There are several things you need to take care of on your development
 system before you can build.
 
-### CMake
+### 2.1 CMake
 
 CMake 3.15 or above must be installed.
 
 Avoid versions 3.24 and 3.25. There is an issue in cmake that causes the
 Protobuf build to fail. The issue was fixed in version 3.26.
 
-### OpenSSL
+### 2.2 OpenSSL
 
 OpenSSL 1.1 must be installed. P4 Control Plane uses OpenSSL instead of
 BoringSSL.
 
-### ACC SDK
+### 2.3 ACC SDK
 
 Install the ACC SDK on your system. See
 [Installing the ACC SDK](../docs/guides/es2k/installing-acc-sdk.md) for
@@ -68,7 +68,7 @@ The build script for the Stratum dependencies is in the `setup` directory.
 
 ## 4. Host Dependencies
 
-### Host install location
+### 4.1 Host install location
 
 You will need to decide where on your system you would like to install the
 Host dependencies. This location (the "install prefix") must be specified
@@ -88,7 +88,7 @@ need to log in as `root` or run from an account that has `sudo` privilege.
 The distribution includes a helper script (`make-host-deps.sh`) that can be
 used to build the Host dependencies.
 
-### Example: non-root build
+### 4.2 Example: non-root build
 
 To install the dependencies in a user directory:
 
@@ -99,7 +99,7 @@ To install the dependencies in a user directory:
 The source files will be download and built, and the results of the build
 will be installed in `/home/peabody/hostdeps`.
 
-### Example: root build
+### 4.3 Example: root build
 
 ```bash
 ./make-host-deps.sh --prefix=/opt/p4cp/x86deps --sudo
@@ -107,7 +107,7 @@ will be installed in `/home/peabody/hostdeps`.
 
 The `--sudo` parameter may be omitted if you are logged in as `root`.
 
-### Example: complete build
+### 4.4 Example: complete build
 
 By default, the helper script does a *minimal* build, consisting only of
 the components that are needed to support cross-compilation. Specify the
@@ -117,7 +117,7 @@ the components that are needed to support cross-compilation. Specify the
 ./make-host-deps.sh --prefix=$HOME/hostdeps --full
 ```
 
-### make-host-deps.sh
+### 4.5 make-host-deps.sh
 
 The helper script supports the following options:
 
@@ -140,23 +140,23 @@ Options:
   --sudo              Use sudo when installing (Default: false)
 ```
 
-## 4. Target Dependencies
+## 5. Target Dependencies
 
-### Target install location
-
-under construction
-
-### Cross-compilation
+### 5.1 Target install location
 
 under construction
 
-### Example: sysroot build
+### 5.2 Cross-compilation
+
+under construction
+
+### 5.3 Example: sysroot build
 
 ```bash
 ./make-cross-deps.sh --host=/opt/x86deps --prefix=//opt/p4cp/deps
 ```
 
-### make-cross-deps.sh
+### 5.4 make-cross-deps.sh
 
 The helper script supports the following options:
 

--- a/setup/building-es2k-stratum-deps.md
+++ b/setup/building-es2k-stratum-deps.md
@@ -123,14 +123,19 @@ to execute it. We recommend removing execute permission from the file
 For example:
 
 ```bash
+# Set by user. Used internally.
 ACC_SDK=<acc-sdk-directory>
 P4CPBASE=<recipe-directory>
-export CMAKE_TOOLCHAIN_FILE=$P4CPBASE/cmake/aarch64-toolchain.cmake
+
+# Used internally.
 AARCH64=$ACC_SDK/aarch64-intel-linux-gnu
 SYSROOT=$AARCH64/aarch64-intel-linux-gnu/sysroot
+
+# Used externally for build.
 export SDKTARGETSYSROOT=$SYSROOT
 export PKG_CONFIG_SYSROOT_DIR=$SYSROOT
 export PKG_CONFIG_PATH=$SYSROOT/usr/lib64/pkgconfig:$SYSROOT/usr/lib/pkgconfig:$SYSROOT/usr/share/pkgconfig
+export CMAKE_TOOLCHAIN_FILE=$P4CPBASE/cmake/aarch64-toolchain.cmake
 [ -z "$ES2K_SAVE_PATH" ] && export ES2K_SAVE_PATH=$PATH
 export PATH=$AARCH64/bin:$ES2K_SAVE_PATH
 ```

--- a/setup/building-es2k-stratum-deps.md
+++ b/setup/building-es2k-stratum-deps.md
@@ -201,8 +201,7 @@ dependencies as well as the install prefix.
 
 ### Target build
 
-Source the file that the defines the [target build environment variables]
-(#5-defining-the-target-build-environment).
+Source the file that the defines the [target build environment variables](#5-defining-the-target-build-environment).
 
 ```bash
 source es2k-setup.env

--- a/setup/building-es2k-stratum-deps.md
+++ b/setup/building-es2k-stratum-deps.md
@@ -67,7 +67,7 @@ First, decide where to install the Host dependencies. This location (the
 
 It is recommended that you *not* install the Host dependencies in `/usr` or
 `/usr/local`. It will be easier to rebuild or update the dependencies if
-their libraries not are mingled with other libraries.
+their libraries are not mingled with other libraries.
 
 The `setup` directory includes a helper script (`make-host-deps.sh`) that
 can be used to build the Host dependencies.

--- a/setup/building-es2k-stratum-deps.md
+++ b/setup/building-es2k-stratum-deps.md
@@ -8,9 +8,9 @@ ARM Compute Complex (ACC) of the Intel&reg; IPU E2100.
 
 ## 1. Introduction
 
-Stratum is the component of `infrap4d` that implements the P4Runtime and gNMI
-(OpenConfig) services. It requires a number of third-party libraries, which
-this package provides.
+Stratum is the component of P4 Control Plane that implements the P4Runtime
+and gNMI (OpenConfig) services. It requires a number of third-party
+libraries, which this package provides.
 
 You will need to build two versions of the libraries:
 
@@ -26,16 +26,15 @@ The Host and Target libraries must be the same version.
 
 There are several things to do before you can build the dependencies.
 
-- Install CMake 3.15 or above.
+- Install CMake 3.15 or above
 
-  Avoid versions 3.24 and 3.25. They cause the build to fail. This issue was
-  fixed in CMake 3.26.
+  Avoid versions 3.24 and 3.25. They cause the dependencies build to fail.
 
-- Install OpenSSL 1.1.
+- Install OpenSSL 1.1
 
   Note that P4 Control Plane is not compatible with BoringSSL.
 
-- Install the ACC SDK.
+- Install the ACC SDK
 
   See [Installing the ACC SDK](../docs/guides/es2k/installing-acc-sdk.md)
   for directions.
@@ -58,8 +57,8 @@ You may substitute your own local directory name for `ipdk.recipe`.
 
 The build script for the Stratum dependencies is in the `setup` directory.
 
-The `setup` directory does not include the source code for the dependencies.
-This will be downloaded by the build script.
+TThe source code for the dependencies is not part of the distribution.
+It is downloaded by the build script.
 
 ## 4. Building the Host Dependencies
 
@@ -68,16 +67,15 @@ First, decide where to install the Host dependencies. This location (the
 
 It is recommended that you *not* install the Host dependencies in `/usr` or
 `/usr/local`. It will be easier to rebuild or update the dependencies if
-their libraries are separate from other libraries.
+their libraries are mingled with other libraries.
 
 The `setup` directory includes a helper script (`make-host-deps.sh`) that
 can be used to build the Host dependencies.
 
-- Use the `--help` or `-h` option to see a list of the parameters the
-  helper script supports.
+- The `--help` (`-h`) option lists the parameters the helper script supports.
 
-- Use the `--dry-run` or `-n` option to see the parameter values that will
-  be passed to CMake. (No other action will be taken.)
+- The `--dry-run` (`-n`) option displays the parameter values without
+  running CMake.
 
 The script normally does a minimal build, containing just the components
 needed for cross-compilation. Specify the `--full` parameter if you want
@@ -85,11 +83,11 @@ to build all the libraries.
 
 > Note that the Host and Target build environments are mutually incompatible.
   You must ensure that the [target build environment variables](#5-defining-the-target-build-environment)
-  are undefined before you run the build script.
+  are undefined before you build the Host dependencies.
 
 ### User build
 
-To install the dependencies in a user directory
+To install the dependencies in a user directory:
 
 ```bash
 ./make-host-deps.sh --prefix=PREFIX
@@ -140,9 +138,9 @@ export PATH=$AARCH64/bin:$ES2K_SAVE_PATH
 In the listing above, you will need to provide values for these variables:
 
 - `ACC_SDK` - install path of the ACC-RL SDK (for example,
-  `$(realpath $HOME/p4cp-dev/acc_sdk)`)
-- `P4CPBASE` - path to the local networking-recipe directory
-  (for example, `$(realpath $HOME/p4cp-dev/ipdk.recipe)`)
+  `$HOME/p4cp-dev/acc_sdk`)
+- `P4CPBASE` - path to the local networking-recipe directory (for example,
+  `$HOME/p4cp-dev/ipdk.recipe`)
 
 From these paths, the setup script derives:
 
@@ -150,6 +148,8 @@ From these paths, the setup script derives:
   cross-compiler suite
 - `SYSROOT` - path to the sysroot directory, which contains AArch64
   header files and binaries
+
+These directories are part of the ACC SDK.
 
 The setup script exports the following variables, which are used by CMake
 and the helper script:
@@ -170,10 +170,10 @@ executables to the system `PATH`.
   the SDK's setup file when building the Stratum dependencies and P4
   Control Plane.
 
-  The SDK setup file is intended for use with Autotools. It makes extensive
-  use of variables that have a blanket effect on the behavior of the tools
-  the build uses. These definitions may interfere with the CMake build in
-  subtle and unpredictable ways.
+  The SDK setup file is intended for use with Autotools. It defines a
+  considerable number of environment variables, which have a blanket
+  effect on the behavior of the build tools. These definitions may
+  interfere with the CMake build in non-obvious ways.
 
   The SDK also provides its own CMake toolchain file. We recommend using
   the toolchain file that is provided as part of the networking recipe,
@@ -183,21 +183,20 @@ executables to the system `PATH`.
 ## 6. Building the Target Dependencies
 
 You will need to pick an install location for the target dependencies.
-This will typically be in the `sysroot` directory structure -- for example,
-under `sysroot/opt`. This will become the root-level `/opt` directory when
-the file structure is transferred to the E2100 file system.
+This will typically be under the sysroot directory structure. For
+example, the `opt` subdirectory will become the root-level `/opt`
+directory when the file structure is copied to the E2100 file system.
 
 The `setup` directory includes a helper script (`make-cross-deps.sh`) that
 can be used to build the Target dependencies.
 
-- Use the `--help` or `-h` option to see a list of the parameters the
-  helper script supports.
+- The `--help` (`-h`) option lists the parameters the helper script supports.
 
-- Use the `--dry-run` or `-n` option to see the parameter values that will
-  be passed to CMake. (No other action will be taken.)
+- The `--dry-run` (`-n`) option displays the parameter values without
+  running CMake.
 
 You will need to provide the helper script with the path to the Host
-dependencies as well as the install prefix.
+dependencies (`--host`) as well as the install prefix (`--prefix`).
 
 ### Target build
 
@@ -224,6 +223,5 @@ Now run the build script:
 `PREFIX` is the install prefix for the Target dependencies. Here, you might
 specify something like `//opt/ipdk/deps`.
 
-`//` at the beginning of the prefix directory path is a shortcut provided by
-the helper script. It will be replaced by the sysroot directory path.
-You can use the `-n` option to review the parameter values.
+The `//` at the beginning of the prefix path is a shortcut provided by
+the helper script. It will be replaced with the sysroot directory path.

--- a/setup/building-es2k-stratum-deps.md
+++ b/setup/building-es2k-stratum-deps.md
@@ -67,7 +67,7 @@ First, decide where to install the Host dependencies. This location (the
 
 It is recommended that you *not* install the Host dependencies in `/usr` or
 `/usr/local`. It will be easier to rebuild or update the dependencies if
-their libraries are mingled with other libraries.
+their libraries not are mingled with other libraries.
 
 The `setup` directory includes a helper script (`make-host-deps.sh`) that
 can be used to build the Host dependencies.

--- a/setup/building-es2k-stratum-deps.md
+++ b/setup/building-es2k-stratum-deps.md
@@ -5,7 +5,7 @@ ARM Compute Complex (ACC) of the Intel&reg; IPU E2100.
 
 > **Note**: If you are building P4 Control Plane to run on an x86 host
 core of the E2100, follow the directions in
-[Building the Stratum Dependencies](../building-stratum-deps.md) and
+[Building the Stratum Dependencies](building-stratum-deps.md) and
 specify `ES2K`` as the TDI target type.
 
 ## 1. Introduction

--- a/setup/building-es2k-stratum-deps.md
+++ b/setup/building-es2k-stratum-deps.md
@@ -164,21 +164,15 @@ and the helper script:
 The setup script also adds the directory containing the cross-compiler
 executables to the system `PATH`.
 
-> Note: The ACC-RL SDK includes a setup file
-  (`environment-setup-aarch64-intel-linux-gnu`) that performs the same
-  function as is described here. We strongly recommend that you *not* use
-  the SDK's setup file when building the Stratum dependencies and P4
-  Control Plane.
-
-  The SDK setup file is intended for use with Autotools. It defines a
-  considerable number of environment variables, which have a blanket
-  effect on the behavior of the build tools. These definitions may
-  interfere with the CMake build in non-obvious ways.
-
-  The SDK also provides its own CMake toolchain file. We recommend using
-  the toolchain file that is provided as part of the networking recipe,
-  not the SDK's toolchain file, when building the Stratum dependencies
-  and P4 Control Plane.
+> **Note:** The ACC-RL SDK includes its own setup file
+> (`environment-setup-aarch64-intel-linux-gnu`). We strongly recommend
+> that you *not* use this setup file when building the Stratum dependencies
+> or P4 Control Plane.
+>
+> The SDK setup file is intended for use with GNU Autotools. Some of
+> the environment variables it defines affect the behavior of the C and
+> C++ compilers and the linker. These definitions may interfere with the
+> CMake build in non-obvious ways.
 
 ## 6. Building the Target Dependencies
 

--- a/setup/building-es2k-stratum-deps.md
+++ b/setup/building-es2k-stratum-deps.md
@@ -57,7 +57,7 @@ You may substitute your own local directory name for `ipdk.recipe`.
 
 The build script for the Stratum dependencies is in the `setup` directory.
 
-TThe source code for the dependencies is not part of the distribution.
+The source code for the dependencies is not part of the distribution.
 It is downloaded by the build script.
 
 ## 4. Building the Host Dependencies

--- a/setup/building-es2k-stratum-deps.md
+++ b/setup/building-es2k-stratum-deps.md
@@ -72,16 +72,16 @@ their libraries are mingled with other libraries.
 The `setup` directory includes a helper script (`make-host-deps.sh`) that
 can be used to build the Host dependencies.
 
-- The `--help` (`-h`) option lists the parameters the helper script supports.
+- The `--help` (`-h`) option lists the parameters the helper script supports
 
 - The `--dry-run` (`-n`) option displays the parameter values without
-  running CMake.
+  running CMake
 
 The script normally does a minimal build, containing just the components
 needed for cross-compilation. Specify the `--full` parameter if you want
 to build all the libraries.
 
-> Note that the Host and Target build environments are mutually incompatible.
+> **Note:** The Host and Target build environments are mutually incompatible.
   You must ensure that the [target build environment variables](#5-defining-the-target-build-environment)
   are undefined before you build the Host dependencies.
 
@@ -166,7 +166,7 @@ executables to the system `PATH`.
 
 > **Note:** The ACC-RL SDK includes its own setup file
 > (`environment-setup-aarch64-intel-linux-gnu`). We strongly recommend
-> that you *not* use this setup file when building the Stratum dependencies
+> that you *not* use this file when building the Stratum dependencies
 > or P4 Control Plane.
 >
 > The SDK setup file is intended for use with GNU Autotools. Some of
@@ -184,10 +184,10 @@ directory when the file structure is copied to the E2100 file system.
 The `setup` directory includes a helper script (`make-cross-deps.sh`) that
 can be used to build the Target dependencies.
 
-- The `--help` (`-h`) option lists the parameters the helper script supports.
+- The `--help` (`-h`) option lists the parameters the helper script supports
 
 - The `--dry-run` (`-n`) option displays the parameter values without
-  running CMake.
+  running CMake
 
 You will need to provide the helper script with the path to the Host
 dependencies (`--host`) as well as the install prefix (`--prefix`).

--- a/setup/building-es2k-stratum-deps.md
+++ b/setup/building-es2k-stratum-deps.md
@@ -1,0 +1,186 @@
+# Building Stratum Dependencies for the ES2K ACC
+
+This document explains how to build the Stratum dependencies for the
+ARM Compute Complex (ACC) of the Intel&reg; IPU E2100.
+
+> **Note**: If you are building P4 Control Plane to run on an x86 host
+core of the E2100, follow the directions in
+[Building the Stratum Dependencies](../building-stratum-deps.md) and
+specify `ES2K`` as the TDI target type.
+
+## 1. Introduction
+
+Stratum is the component of `infrap4d` that implements the P4Runtime and gNMI
+(OpenConfig) services. It requires that a number of third-party libraries
+be built and installed on the system.
+
+You will need to build two versions of the dependency libraries:
+
+- The **Host** libraries, which run on the build system and the x86
+  cores of the E2100. They also provide tools that are used during the
+  build process.
+
+- The **Target** libraries, which run on the ACC. The P4 Control Plane is
+  compiled and linked against these libraries.
+
+The Host and Target libraries versions must match, to ensure compatibility
+between client applications and `infrap4d`.
+
+## 2. Setup
+
+There are several things you need to take care of on your development
+system before you can build.
+
+### CMake
+
+CMake 3.15 or above must be installed.
+
+Avoid versions 3.24 and 3.25. There is an issue in cmake that causes the
+Protobuf build to fail. The issue was fixed in version 3.26.
+
+### OpenSSL
+
+OpenSSL 1.1 must be installed. P4 Control Plane uses OpenSSL instead of
+BoringSSL.
+
+### ACC SDK
+
+Install the ACC SDK on your system. See
+[Installing the ACC SDK](../docs/guides/es2k/installing-acc-sdk.md) for
+instructions. You will be using the Toolchain and Sysroot directories
+to build the Target dependencies.
+
+## 3. Source Code
+
+Download the Open-Source IPDK networking-recipe from GitHub. To clone the
+repository:
+
+```bash
+git clone --recursive https://github.com/ipdk-io/networking-recipe.git ipdk.recipe
+```
+
+You may omit the `--recursive` option if you are only interested in building
+the dependencies.
+
+You may substitute your own local directory name for `ipdk.recipe`.
+
+The build script for the Stratum dependencies is in the `setup` directory.
+
+## 4. Host Dependencies
+
+### Host install location
+
+You will need to decide where on your system you would like to install the
+Host dependencies. This location (the "install prefix") must be specified
+when you configure the build.
+
+It is recommended that you *not* install the Host dependencies in `/usr` or
+`/usr/local`. You will find it easier to update or rebuild the libraries
+if components that are updated at different times are kept separate from
+one another.
+
+The `CMAKE_INSTALL_PREFIX` option is used to specify the directory in which
+the Host dependencies should be installed.
+
+If you plan *do* install the Host dependencies in a system directory, you will
+need to log in as `root` or run from an account that has `sudo` privilege.
+
+The distribution includes a helper script (`make-host-deps.sh`) that can be
+used to build the Host dependencies.
+
+### Example: non-root build
+
+To install the dependencies in a user directory:
+
+```bash
+./make-host-deps.sh --prefix=~/hostdeps
+```
+
+The source files will be download and built, and the results of the build
+will be installed in `/home/peabody/hostdeps`.
+
+### Example: root build
+
+```bash
+./make-host-deps.sh --prefix=/opt/p4cp/x86deps --sudo
+```
+
+The `--sudo` parameter may be omitted if you are logged in as `root`.
+
+### Example: complete build
+
+By default, the helper script does a *minimal* build, consisting only of
+the components that are needed to support cross-compilation. Specify the
+`--full` parameter if you would like to build all the components.
+
+```bash
+./make-host-deps.sh --prefix=$HOME/hostdeps --full
+```
+
+### make-host-deps.sh
+
+The helper script supports the following options:
+
+```text
+peabody@wabac:~/recipe/setup$ ./make-host-deps.sh -h
+
+Build host dependency libraries
+
+Options:
+  --build=DIR     -B  Build directory path (Default: build)
+  --config            Only perform configuration step (Default: false)
+  --cxx=VERSION       CXX_STANDARD to build dependencies (Default: empty)
+  --dry-run       -n  Display cmake parameters and exit (Default: false)
+  --force         -f  Specify -f when patching (Default: false)
+  --full              Build all dependency libraries (Default: minimal)
+  --jobs=NJOBS    -j  Number of build threads (Default: 8)
+  --minimal           Build required host dependencies only (Default: minimal)
+  --no-download       Do not download repositories (Default: false)
+  --prefix=DIR    -P  Install directory path (Default: ./host-deps)
+  --sudo              Use sudo when installing (Default: false)
+```
+
+## 4. Target Dependencies
+
+### Target install location
+
+under construction
+
+### Cross-compilation
+
+under construction
+
+### Example: sysroot build
+
+```bash
+./make-cross-deps.sh --host=/opt/x86deps --prefix=//opt/p4cp/deps
+```
+
+### make-cross-deps.sh
+
+The helper script supports the following options:
+
+```text
+peabody@wabac:~/recipe/setup$ ./make-cross-deps.sh -h
+
+Build target dependency libraries
+
+Options:
+  --build=DIR      -B  Build directory path [build]
+  --cxx=VERSION        CXX_STANDARD to build dependencies (Default: empty)
+  --dry-run        -n  Display cmake parameters and exit
+  --force          -f  Specify -f when patching (Default: false)
+  --host=DIR       -H  Host dependencies directory []
+  --jobs=NJOBS     -j  Number of build threads (Default: 8)
+  --no-download        Do not download repositories (Default: false)
+  --prefix=DIR*    -P  Install directory prefix [//opt/deps]
+  --sudo               Use sudo when installing (Default: false)
+  --toolchain=FILE -T  CMake toolchain file
+
+* '//' at the beginning of the directory path will be replaced
+  with the sysroot directory path.
+
+Environment variables:
+  CMAKE_TOOLCHAIN_FILE - Default toolchain file
+  SDKTARGETSYSROOT - sysroot directory
+```

--- a/setup/building-stratum-deps.md
+++ b/setup/building-stratum-deps.md
@@ -7,7 +7,7 @@ be built and installed on the system.
 This document explains how to build and install the Stratum dependencies.
 
 > **Note**: For the Intel&reg; IPU E2100, see
-[Building Stratum Dependencies for ES2K](building-stratum-deps-es2k.md).
+[Building Stratum Dependencies for the ES2K ACC](building-es2k-stratum-deps.md).
 
 ## 1 Prerequisites
 


### PR DESCRIPTION
How to build the Stratum dependencies for cross-compilation to the ARM Compute Complex (ACC) of the Intel&reg; IPU E2100.