### PR TITLE
Building P4 Control Plane for ES2K ACC

### DIFF
--- a/docs/guides/es2k/building-p4cp-acc.md
+++ b/docs/guides/es2k/building-p4cp-acc.md
@@ -71,7 +71,7 @@ To build OVS and install it in the sysroot directory under `/opt/ipdk/ovs`:
 
 Options:
 
-* `--prefix=PREFIX` - where to install OVS
+- `--prefix=PREFIX` - where to install OVS
 
 The `//` at the beginning of the prefix path is a shortcut provided by
 the helper script. It will be replaced with the sysroot directory path.

--- a/docs/guides/es2k/building-p4cp-acc.md
+++ b/docs/guides/es2k/building-p4cp-acc.md
@@ -29,7 +29,7 @@ setup file, in order to cross-compile P4 Control Plane for the ACC.
 
 ## Fetch Source Code
 
-If you have not already done so, you will to get a copy of the IPDK
+If you have not already done so, you will need to get a copy of the IPDK
 networking-recipe repository and its submodules:
 
 ```bash
@@ -40,15 +40,28 @@ You may substitute your own local directory name for `ipdk.recipe`.
 
 ## Build with OVS
 
+### Setup
+
+First, change to the source directory:
+
+```bash
+cd ipdk.recipe
+```
+
+If you have not already done so, source the file that the defines the
+[target build environment variables](../../../setup/building-es2k-stratum-deps.md#5-defining-the-target-build-environment).
+For example:
+
+```bash
+source setup/es2k-setup.env
+```
+
 ### Building OVS
 
 The distribution includes a helper script (`make-cross-ovs.sh`) that can be
 used to build OVS for P4 Control Plane.
 
-- The `--help` (`-h`) option lists the parameters the helper script supports
-
-- The `--dry-run` (`-n`) option displays the parameter values without
-  running CMake
+> The `--help` (`-h`) option lists the parameters the helper script supports.
 
 To build OVS and install it in the sysroot directory under `/opt/ipdk/ovs`:
 
@@ -56,17 +69,22 @@ To build OVS and install it in the sysroot directory under `/opt/ipdk/ovs`:
 ./make-cross-ovs.sh --prefix=//opt/ipdk/ovs
 ```
 
+Options:
+
+* `--prefix=PREFIX` - where to install OVS
+
+The `//` at the beginning of the prefix path is a shortcut provided by
+the helper script. It will be replaced with the sysroot directory path.
+
 ### Configuring P4 Control Plane
 
 The distribution includes a helper script (`config-cross-deps.sh`) that
 can be used to configure CMake to build P4 Control Plane.
 
-- The `--help` (`-h`) option lists the parameters the helper script supports
+> The `--help` (`-h`) option lists the parameters the helper script supports.
 
-- The `--dry-run` (`-n`) option displays the parameter values without
-  running CMake
-
-To configure P4 Control Plane to build with OVS:
+To configure CMake to build P4 Control Plane and install it in the sysroot
+directory under `/opt/ipdk/p4cp`:
 
 ```bash
 ./config-cross-recipe.sh \
@@ -75,9 +93,20 @@ To configure P4 Control Plane to build with OVS:
     --prefix=//opt/ipdk/p4cp
 ```
 
+The options are:
+
+- `--host=HOST` - path to the Host dependencies
+- `--deps=DEPS` - path to the Target dependencies
+- `--ovs=OVS` - path to the OVS installation
+- `--sde=SDE` - path to the SDE installation
+- `--prefix=PREFIX` - where to install P4 control plane
+
+The `//` at the beginning of the prefix path is a shortcut provided by
+the helper script. It will be replaced with the sysroot directory path.
+
 ### Building P4 Control Plane
 
-The final step is to use CMake to perform the build:
+Now use CMake to build and install P4 Control Plane:
 
 ```bash
 cmake --build build -j8 --target install
@@ -85,8 +114,7 @@ cmake --build build -j8 --target install
 
 ## Build without OVS
 
-To build without OVS, skip the OVS build step and specify the `--no-ovs`
-option when you configure the P4 Control Plane build:
+To configure CMake to build P4 Control Plane without OVS:
 
 ```bash
 ./config-cross-recipe.sh \
@@ -95,7 +123,9 @@ option when you configure the P4 Control Plane build:
     --prefix=//opt/ipdk/p4cp
 ```
 
-Now use CMake to perform the build:
+The `--no-ovs` option excludes OVS support.
+
+Now perform the build:
 
 ```bash
 cmake --build build -j8 --target install

--- a/docs/guides/es2k/building-p4cp-acc.md
+++ b/docs/guides/es2k/building-p4cp-acc.md
@@ -1,0 +1,69 @@
+# Building P4 Control Plane for the ACC
+
+This document explains how to build P4 Control Plane for the ARM Compute
+Complex (ACC) of the Intel&reg; IPU E2100.
+
+## Prepare the System
+
+There are several things to do before you can build P4 Control Plane.
+
+- Install CMake 3.15 or above
+
+  Avoid versions 3.24 and 3.25. They cause the dependencies build to fail.
+
+- Install OpenSSL 1.1
+
+  Note that P4 Control Plane is not compatible with BoringSSL.
+
+- Install the ACC SDK
+
+  See [Installing the ACC SDK](installing-acc-sdk.md) for instructions.
+
+## Install the Stratum Dependencies
+
+See [Building ES2K Dependencies for the ACC](../../../setup/building-es2k-stratum-deps.md)
+for instructions.
+
+You will need the Host depencies, Target dependencies, and Build environment
+setup file, in order to cross-compile P4 Control Plane for the ACC.
+
+## Fetch the Source Code
+
+If you have not already done so, you will to get a copy of the IPDK
+networking-recipe repository and its submodules:
+
+```bash
+git clone --recursive https://github.com/ipdk-io/networking-recipe.git ipdk.recipe
+```
+
+You may substitute your own local directory name for `ipdk.recipe`.
+
+## Build P4 Control Plane
+
+### Build with OVS
+
+```bash
+./make-cross-ovs.sh --prefix=//opt/ipdk/ovs
+```
+
+```bash
+./config-cross-recipe.sh --host=../hostdeps \
+    --deps=//opt/ipdk/deps --ovs=//opt/ipdk/ovs --prefix=//opt/ipdk/p4cp \
+    --sde=//opt/p4/p4sde
+```
+
+```bash
+cmake --build build -j8 --target install
+```
+
+### Build without OVS
+
+```bash
+./config-cross-recipe.sh --host=../hostdeps \
+    --deps=//opt/ipdk/deps --no-ovs --prefix=//opt/ipdk/p4cp \
+    --sde=//opt/p4/p4sde
+```
+
+```bash
+cmake --build build -j8 --target install
+```

--- a/docs/guides/es2k/building-p4cp-acc.md
+++ b/docs/guides/es2k/building-p4cp-acc.md
@@ -38,9 +38,7 @@ git clone --recursive https://github.com/ipdk-io/networking-recipe.git ipdk.reci
 
 You may substitute your own local directory name for `ipdk.recipe`.
 
-## Build with OVS
-
-### Setup
+## Define the Environment
 
 First, change to the source directory:
 
@@ -48,7 +46,7 @@ First, change to the source directory:
 cd ipdk.recipe
 ```
 
-If you have not already done so, source the file that defines the
+Source the file that defines the
 [target build environment variables](../../../setup/building-es2k-stratum-deps.md#5-defining-the-target-build-environment).
 For example:
 
@@ -58,6 +56,8 @@ source SETUPFILE
 
 where `SETUPFILE` is the path to the file you created when you built the
 Stratum dependencies (for example, `setup/es2k-setup.env`).
+
+## Build with OVS
 
 ### Building OVS
 

--- a/docs/guides/es2k/building-p4cp-acc.md
+++ b/docs/guides/es2k/building-p4cp-acc.md
@@ -125,19 +125,28 @@ cmake --build build -j8 --target install
 
 ## Build without OVS
 
-To configure CMake to build P4 Control Plane without OVS:
+To build P4 Control Plane without OVS:
 
 ```bash
 ./scripts/es2k/config-cross-recipe.sh \
     --host=../hostdeps --deps=//opt/ipdk/deps \
     --no-ovs --sde=//opt/p4/p4sde \
     --prefix=//opt/ipdk/p4cp
+
+cmake --build build -j8 --target install
 ```
 
 The `--no-ovs` option excludes OVS support.
 
-Now perform the build:
+## Build with Stratum Only
+
+To build P4 Control Plane without OVS or the Kernel Monitor:
 
 ```bash
+./scripts/es2k/config-cross-recipe.sh \
+    --host=../hostdeps --deps=//opt/ipdk/deps \
+    --no-ovs --no-krnlmon --sde=//opt/p4/p4sde \
+    --prefix=//opt/ipdk/p4cp
+
 cmake --build build -j8 --target install
 ```

--- a/docs/guides/es2k/building-p4cp-acc.md
+++ b/docs/guides/es2k/building-p4cp-acc.md
@@ -21,7 +21,7 @@ There are several things to do before you can build P4 Control Plane.
 
 ## Install the Stratum Dependencies
 
-See [Building Stratum Dependencies for the ACC](../../../setup/building-es2k-stratum-deps.md)
+See [Building Stratum Dependencies for the ACC](/setup/building-es2k-stratum-deps.md)
 for instructions.
 
 You will need the Host dependencies, Target dependencies, and Build environment
@@ -47,7 +47,7 @@ cd ipdk.recipe
 ```
 
 Source the file that defines the
-[target build environment variables](../../../setup/building-es2k-stratum-deps.md#5-defining-the-target-build-environment).
+[target build environment variables](/setup/building-es2k-stratum-deps.md#5-defining-the-target-build-environment).
 For example:
 
 ```bash

--- a/docs/guides/es2k/building-p4cp-acc.md
+++ b/docs/guides/es2k/building-p4cp-acc.md
@@ -66,7 +66,7 @@ used to build OVS for P4 Control Plane.
 To build OVS and install it in the sysroot directory under `/opt/ipdk/ovs`:
 
 ```bash
-./make-cross-ovs.sh --prefix=//opt/ipdk/ovs
+./scripts/es2k/make-cross-ovs.sh --prefix=//opt/ipdk/ovs
 ```
 
 Options:
@@ -87,7 +87,7 @@ To configure CMake to build P4 Control Plane and install it in the sysroot
 directory under `/opt/ipdk/p4cp`:
 
 ```bash
-./config-cross-recipe.sh \
+./scripts/es2k/config-cross-recipe.sh \
     --host=../hostdeps --deps=//opt/ipdk/deps \
     --ovs=//opt/ipdk/ovs --sde=//opt/p4/p4sde \
     --prefix=//opt/ipdk/p4cp
@@ -117,7 +117,7 @@ cmake --build build -j8 --target install
 To configure CMake to build P4 Control Plane without OVS:
 
 ```bash
-./config-cross-recipe.sh \
+./scripts/es2k/config-cross-recipe.sh \
     --host=../hostdeps --deps=//opt/ipdk/deps \
     --no-ovs --sde=//opt/p4/p4sde \
     --prefix=//opt/ipdk/p4cp

--- a/docs/guides/es2k/building-p4cp-acc.md
+++ b/docs/guides/es2k/building-p4cp-acc.md
@@ -19,7 +19,7 @@ There are several things to do before you can build P4 Control Plane.
 
   See [Installing the ACC SDK](installing-acc-sdk.md) for instructions.
 
-## Install Stratum Dependencies
+## Install the Stratum Dependencies
 
 See [Building Stratum Dependencies for the ACC](../../../setup/building-es2k-stratum-deps.md)
 for instructions.
@@ -27,7 +27,7 @@ for instructions.
 You will need the Host depencies, Target dependencies, and Build environment
 setup file, in order to cross-compile P4 Control Plane for the ACC.
 
-## Fetch Source Code
+## Fetch the Source Code
 
 If you have not already done so, you will need to get a copy of the IPDK
 networking-recipe repository and its submodules:
@@ -48,13 +48,16 @@ First, change to the source directory:
 cd ipdk.recipe
 ```
 
-If you have not already done so, source the file that the defines the
+If you have not already done so, source the file that defines the
 [target build environment variables](../../../setup/building-es2k-stratum-deps.md#5-defining-the-target-build-environment).
 For example:
 
 ```bash
-source setup/es2k-setup.env
+source SETUPFILE
 ```
+
+where `SETUPFILE` is the path to the file you created when you built the
+Stratum dependencies (for example, `setup/es2k-setup.env`).
 
 ### Building OVS
 
@@ -76,6 +79,10 @@ Options:
 The `//` at the beginning of the prefix path is a shortcut provided by
 the helper script. It will be replaced with the sysroot directory path.
 
+To do a clean build, issue the command `rm -fr ovs/build` before running
+`make-cross-ovs.sh`. You may also want to remove the installation
+directory from the previous build.
+
 ### Configuring P4 Control Plane
 
 The distribution includes a helper script (`config-cross-deps.sh`) that
@@ -93,7 +100,7 @@ directory under `/opt/ipdk/p4cp`:
     --prefix=//opt/ipdk/p4cp
 ```
 
-The options are:
+Options:
 
 - `--host=HOST` - path to the Host dependencies
 - `--deps=DEPS` - path to the Target dependencies
@@ -103,6 +110,10 @@ The options are:
 
 The `//` at the beginning of the prefix path is a shortcut provided by
 the helper script. It will be replaced with the sysroot directory path.
+
+To do a clean build, issue the command `rm -fr build` before running
+`config-cross-recipe.sh`. You may also want to remove the installation
+directory from the previous build.
 
 ### Building P4 Control Plane
 

--- a/docs/guides/es2k/building-p4cp-acc.md
+++ b/docs/guides/es2k/building-p4cp-acc.md
@@ -19,15 +19,15 @@ There are several things to do before you can build P4 Control Plane.
 
   See [Installing the ACC SDK](installing-acc-sdk.md) for instructions.
 
-## Install the Stratum Dependencies
+## Install Stratum Dependencies
 
-See [Building ES2K Dependencies for the ACC](../../../setup/building-es2k-stratum-deps.md)
+See [Building Stratum Dependencies for the ACC](../../../setup/building-es2k-stratum-deps.md)
 for instructions.
 
 You will need the Host depencies, Target dependencies, and Build environment
 setup file, in order to cross-compile P4 Control Plane for the ACC.
 
-## Fetch the Source Code
+## Fetch Source Code
 
 If you have not already done so, you will to get a copy of the IPDK
 networking-recipe repository and its submodules:
@@ -38,31 +38,64 @@ git clone --recursive https://github.com/ipdk-io/networking-recipe.git ipdk.reci
 
 You may substitute your own local directory name for `ipdk.recipe`.
 
-## Build P4 Control Plane
+## Build with OVS
 
-### Build with OVS
+### Building OVS
+
+The distribution includes a helper script (`make-cross-ovs.sh`) that can be
+used to build OVS for P4 Control Plane.
+
+- The `--help` (`-h`) option lists the parameters the helper script supports
+
+- The `--dry-run` (`-n`) option displays the parameter values without
+  running CMake
+
+To build OVS and install it in the sysroot directory under `/opt/ipdk/ovs`:
 
 ```bash
 ./make-cross-ovs.sh --prefix=//opt/ipdk/ovs
 ```
 
+### Configuring P4 Control Plane
+
+The distribution includes a helper script (`config-cross-deps.sh`) that
+can be used to configure CMake to build P4 Control Plane.
+
+- The `--help` (`-h`) option lists the parameters the helper script supports
+
+- The `--dry-run` (`-n`) option displays the parameter values without
+  running CMake
+
+To configure P4 Control Plane to build with OVS:
+
 ```bash
-./config-cross-recipe.sh --host=../hostdeps \
-    --deps=//opt/ipdk/deps --ovs=//opt/ipdk/ovs --prefix=//opt/ipdk/p4cp \
-    --sde=//opt/p4/p4sde
+./config-cross-recipe.sh \
+    --host=../hostdeps --deps=//opt/ipdk/deps \
+    --ovs=//opt/ipdk/ovs --sde=//opt/p4/p4sde \
+    --prefix=//opt/ipdk/p4cp
 ```
+
+### Building P4 Control Plane
+
+The final step is to use CMake to perform the build:
 
 ```bash
 cmake --build build -j8 --target install
 ```
 
-### Build without OVS
+## Build without OVS
+
+To build without OVS, skip the OVS build step and specify the `--no-ovs`
+option when you configure the P4 Control Plane build:
 
 ```bash
-./config-cross-recipe.sh --host=../hostdeps \
-    --deps=//opt/ipdk/deps --no-ovs --prefix=//opt/ipdk/p4cp \
-    --sde=//opt/p4/p4sde
+./config-cross-recipe.sh \
+    --host=../hostdeps --deps=//opt/ipdk/deps \
+    --no-ovs --sde=//opt/p4/p4sde \
+    --prefix=//opt/ipdk/p4cp
 ```
+
+Now use CMake to perform the build:
 
 ```bash
 cmake --build build -j8 --target install

--- a/docs/guides/es2k/building-p4cp-acc.md
+++ b/docs/guides/es2k/building-p4cp-acc.md
@@ -24,7 +24,7 @@ There are several things to do before you can build P4 Control Plane.
 See [Building Stratum Dependencies for the ACC](../../../setup/building-es2k-stratum-deps.md)
 for instructions.
 
-You will need the Host depencies, Target dependencies, and Build environment
+You will need the Host dependencies, Target dependencies, and Build environment
 setup file, in order to cross-compile P4 Control Plane for the ACC.
 
 ## Fetch the Source Code


### PR DESCRIPTION
How to build P4 Control Plane for the ARM Compute Complex (ACC) of the Intel&reg; IPU E2100.