### PR TITLE
Add support for libopenvswitchax512

### DIFF
--- a/cmake/FindOVS.cmake
+++ b/cmake/FindOVS.cmake
@@ -23,6 +23,11 @@ find_library(OVS_LIBRARY
     PATHS ${PC_OVS_LIBRARY_DIRS}
 )
 
+find_library(OVS_LIBAVX512
+    NAMES openvswitchavx512
+    PATHS ${PC_OVS_LIBRARY_DIRS}
+)
+
 find_library(OFPROTO_LIBRARY
     NAMES ofproto
     PATHS ${PC_OVS_LIBRARY_DIRS}
@@ -125,6 +130,15 @@ if(LIBTESTCONTROLLER)
     add_library(ovs::testcontroller UNKNOWN IMPORTED)
     set_target_properties(ovs::testcontroller PROPERTIES
         IMPORTED_LOCATION ${LIBTESTCONTROLLER}
+        INTERFACE_INCLUDE_DIRECTORIES ${OVS_INCLUDE_DIR}
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+    )
+endif()
+
+if(OVS_LIBAVX512)
+    add_library(ovs::avx512 UNKNOWN IMPORTED)
+    set_target_properties(ovs::avx512 PROPERTIES
+        IMPORTED_LOCATION ${OVS_LIBAVX512}
         INTERFACE_INCLUDE_DIRECTORIES ${OVS_INCLUDE_DIR}
         IMPORTED_LINK_INTERFACE_LANGUAGES "C"
     )

--- a/ovs-p4rt/CMakeLists.txt
+++ b/ovs-p4rt/CMakeLists.txt
@@ -85,6 +85,10 @@ target_link_libraries(ovs-vswitchd
         rt m pthread
 )
 
+if(TARGET ovs::avx512)
+    target_link_libraries(ovs-vswitchd PUBLIC ovs::avx512)
+endif()
+
 if(TARGET unbound)
     target_link_libraries(ovs-vswitchd PUBLIC unbound)
 endif()
@@ -132,6 +136,10 @@ target_link_libraries(ovs-testcontroller
         atomic
         rt
 )
+
+if(TARGET ovs::avx512)
+    target_link_libraries(ovs-testcontroller PUBLIC ovs::avx512)
+endif()
 
 if(TARGET unbound)
     target_link_libraries(ovs-testcontroller PUBLIC unbound)


### PR DESCRIPTION
- Add conditional support for the openvswitchax512 library when linking ovs-vswitchd and ovs-testcontroller. This should address a build issue in Rocky Linux 9.1.