### PR TITLE
Edit setup guides for Sphinx

### DIFF
--- a/docs/guides/dpdk-guide.md
+++ b/docs/guides/dpdk-guide.md
@@ -1,4 +1,4 @@
-# DPDK Setup Guide for P4 Control Plane
+# DPDK Setup Guide
 
 ## Overview
 

--- a/docs/guides/es2k-guide.md
+++ b/docs/guides/es2k-guide.md
@@ -1,4 +1,4 @@
-# ES2K Setup Guide for P4 Control Plane
+# ES2K Setup Guide
 
 ## Overview
 
@@ -169,7 +169,7 @@ p4c-pna-xxp -I/usr/lib -I/usr/share/p4c/p4include -I/usr/share/p4c/idpf-lib \
 
 - Create a dummy tofino.bin file, which is needed by tdi_pipeline_builder.
 
-```bask
+```bash
 touch tofino.bin
 ```
 

--- a/docs/guides/tofino-guide.md
+++ b/docs/guides/tofino-guide.md
@@ -1,4 +1,4 @@
-# Tofino Setup Guide for P4 Control Plane
+# Tofino Setup Guide
 
 ## Overview
 


### PR DESCRIPTION
- Initial edits for Sphinx compatibility.
- Remove "for P4 Control Plane" from document titles.
- Correct a typo in a code block type.