### PR TITLE
Revise Installing ACC SDK guide

### DIFF
--- a/docs/guides/es2k/installing-acc-sdk.md
+++ b/docs/guides/es2k/installing-acc-sdk.md
@@ -4,18 +4,15 @@ The ACC Software Development Kit (SDK) allows you to use an x86 host
 computer to build P4 Control Plane for the ARM Compute Complex (ACC) of the
 Intel&reg; IPU E2100.
 
-## 1. Contents
+## SDK Contents
 
-The SDK includes the following:
+The ACC SDK includes the following:
 
-1. GCC C/C++ toolchain. Runs on an x86-64 Linux host and generates binary
-   executables and libraries for an AArch64 processor running Rocky Linux.
-2. Target directory tree (sysroot). Provides header files and binaries
-   (libraries and executables) for the target system.
-3. ES2K P4SDE. Contains header files and binaries specific to the
-   Intel&reg; IPU E2100.
+1. [GCC C/C++ toolchain](#gcc-toolchain)
+2. [Target directory tree (sysroot)](#target-sysroot)
+3. [ES2K P4SDE](#es2k-sde)
 
-## 2. Obtain the ACC-RL SDK
+## Obtain the ACC-RL SDK
 
 You will need to obtain the software packages for the Intel&reg; IPU E2100
 from the manufacturer.
@@ -23,13 +20,13 @@ from the manufacturer.
 The ACC-RL SDK package is a tarball whose name ends in `acc-rl-sdk`, such
 as `mev-hw-b0-ci-ts.release.3921-acc-rl-sdk.tgz`.
 
-## 3. Choose an Install Location
+## Choose an Install Location
 
 You will need to choose a location for the SDK on your development computer.
 The examples in this document assume you are logged in as user `peabody` and
 that you plan to install the SDK in your home directory.
 
-## 4. Unpack the ACC-RL SDK
+## Unpack the ACC-RL SDK
 
 ```bash
 $ tar xzf mev-hw-b0-ci-ts.release.3921-acc-rl-sdk.tgz
@@ -44,9 +41,9 @@ Each time you wish to use the SDK in a new shell session, you need to source the
 $ popd
 ```
 
-## 5. Key Components
+## Key Components
 
-### 5.1 Layout
+### SDK Layout
 
 The  ACC-RL SDK is laid out as follows:
 
@@ -63,11 +60,17 @@ acc-sdk/
 `-- environment-setup-aarch64-intel-linux-gnu
 ```
 
-### 5.2 Toolchain
+### GCC Toolchain
+
+The GCC C/C++ toolchain executes on an x86-64 Linux host and generates binary
+executables and libraries for an AArch64 processor running Rocky Linux.
 
 The cross-compiler suite is in the `aarch64-intel-linux-gnu/bin` directory.
 
-### 5.3 Sysroot
+### Target Sysroot
+
+The Target directory tree (sysroot) provides header files and binaries
+(libraries and executables) for the target system.
 
 The `sysroot` directory is in the inner `aarch64-intel-linux-gnu` directory:
 
@@ -81,9 +84,38 @@ aarch64-intel-linux-gnu/aarch64-intel-linux-gnu/
 └── sysroot
 ```
 
-### 5.4 P4SDE
+It is laid out as follows:
 
-The ES2K P4SDE is in the `sysroot/opt/p4` directory:
+```text
+sysroot
+├── bin -> usr/bin
+├── boot
+├── dev
+├── etc
+├── home
+├── include
+├── lib -> usr/lib
+├── lib64 -> usr/lib64
+├── media
+├── mnt
+├── opt
+├── proc
+├── root
+├── run
+├── sbin -> usr/sbin
+├── srv
+├── sys
+├── tmp
+├── usr
+└── var
+```
+
+### ES2K SDE
+
+The ES2K SDE contains header files and binaries specific to the
+Intel&reg; IPU E2100.
+
+The SDE is in the `sysroot/opt/p4` directory:
 
 ```text
 sysroot/opt

--- a/docs/guides/es2k/installing-acc-sdk.md
+++ b/docs/guides/es2k/installing-acc-sdk.md
@@ -4,7 +4,7 @@ The ACC Software Development Kit (SDK) allows you to use an x86 host
 computer to build P4 Control Plane for the ARM Compute Complex (ACC) of the
 Intel&reg; IPU E2100.
 
-## SDK Contents
+## SDK contents
 
 The ACC SDK includes the following:
 
@@ -20,7 +20,7 @@ from the manufacturer.
 The ACC-RL SDK package is a tarball whose name ends in `acc-rl-sdk`, such
 as `mev-hw-b0-ci-ts.release.3921-acc-rl-sdk.tgz`.
 
-## Choose an Install Location
+## Choose an install location
 
 You will need to choose a location for the SDK on your development computer.
 The examples in this document assume you are logged in as user `peabody` and
@@ -41,9 +41,9 @@ Each time you wish to use the SDK in a new shell session, you need to source the
 $ popd
 ```
 
-## Key Components
+## Key components
 
-### SDK Layout
+### SDK layout
 
 The  ACC-RL SDK is laid out as follows:
 
@@ -60,14 +60,14 @@ acc-sdk/
 `-- environment-setup-aarch64-intel-linux-gnu
 ```
 
-### GCC Toolchain
+### GCC toolchain
 
 The GCC C/C++ toolchain executes on an x86-64 Linux host and generates binary
 executables and libraries for an AArch64 processor running Rocky Linux.
 
 The cross-compiler suite is in the `aarch64-intel-linux-gnu/bin` directory.
 
-### Target Sysroot
+### Target sysroot
 
 The Target directory tree (sysroot) provides header files and binaries
 (libraries and executables) for the target system.


### PR DESCRIPTION
- Reword some section headings and remove numbering, to improve their appearance in Sphinx.

- Move component descriptions from the list in the SDK Contents section to the Key Components section.

- Add a tree showing the layout of the sysroot directory.