### PR TITLE
Edit security guides for Sphinx

### DIFF
--- a/docs/guides/installing-tls-certificates.md
+++ b/docs/guides/installing-tls-certificates.md
@@ -1,44 +1,43 @@
-# Generating and installing TLS certificates
-
-## 1. Overview
+# Working with TLS Certificates
 
 This document provides information about generating and installing TLS certificates
-for running infrap4d in secure mode
+for running infrap4d in secure mode.
 
-## 2. Generating TLS Certificates
+## Generating certificates
 
-Note: Here target name can be `dpdk` or `es2k`
+Note: Here target name can be `dpdk` or `es2k`.
 
 Review the files `ca.conf` and `grpc-client.conf` available under
 `/usr/share/stratum/<target_name>` to verify that the configuration settings are
-as desired
+as desired.
 
-Run the `generate-certs.sh` available under `/usr/share/stratum/<target_name>`
+Run the `generate-certs.sh` available under `/usr/share/stratum/<target_name>`.
 
 Note: Here `IP` is the IP address of gRPC server.
-For example, `IP` can be `127.0.0.1`, `5.5.5.5` or `localhost`
+For example, `IP` can be `127.0.0.1`, `5.5.5.5` or `localhost`.
 
 ```bash
 cd /usr/share/stratum/<target_name>/
+
 COMMON_NAME=<IP> ./generate-certs.sh
 ```
 
 The system relies on mTLS (mutual TLS) for authentication.
 
-## 3. Installing TLS Certificates
+## Installing certificates
 
 `infrap4d` will check for server certificates in the default location
-`/usr/share/stratum/certs/`
+`/usr/share/stratum/certs/`.
 
-### 3.1 Install to default location
+### Default location
 
 Copy the generated `ca.crt`, `stratum.crt`, and `stratum.key` in the
-default location `/usr/share/stratum/certs/` to the server running infrap4d
+default location `/usr/share/stratum/certs/` to the server running infrap4d.
 
 Copy the generated `ca.crt`, `client.crt`, and `client.key` in the
-default location `/usr/share/stratum/certs/` to the client machine
+default location `/usr/share/stratum/certs/` to the client machine.
 
-### 3.2 Install to non-default location
+### Non-default location
 
 If you would like to use a different location for the server certificates,
 copy the certifactes to the location and specify the following options on
@@ -50,7 +49,7 @@ Option                 | Description
 -server_cert_file=PATH | Server certificate file
 -server_key_file=PATH  | Server private key file
 
-For example, start infrap4d with certificates in `/tmp/certs`
+For example, start infrap4d with certificates in `/tmp/certs`:
 
 ```bash
 $P4CP_INSTALL/sbin/infrap4d \

--- a/docs/guides/security-guide.md
+++ b/docs/guides/security-guide.md
@@ -10,7 +10,7 @@ configuration files are available to assist in generating certificates and
 keys using OpenSSL. You may use other tools if you wish.
 
 The [reference files](https://github.com/ipdk-io/stratum-dev/tree/split-arch/tools/tls)
-uses a simple PKI where a self-signed key and certificate.
+use a simple PKI where a self-signed key and certificate.
 The root level Certificate Authority (CA) is used to generate server-side
 key and cert files, and client-side key and cert files. This results in a
 1-depth level certificate chain, which will suffice for validation and
@@ -18,7 +18,7 @@ confirmation but may not provide sufficient security for production systems.
 It is highly recommended to use well-known CAs, and generate certificates at
 multiple depth levels in order to conform to higher security standards.
 
-See [Working with TLS Certificates](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/install-tls-certificates.md)
+See [Working with TLS Certificates](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/installing-tls-certificates.md)
 for step by step guide to generate and install TLS certificates
 
 ## Running in secure mode

--- a/docs/guides/security-guide.md
+++ b/docs/guides/security-guide.md
@@ -1,19 +1,9 @@
-# Security Guide for P4 Control Plane
-
-- [1. Overview](#1-overview)
-- [2. Certificate management](#2-certificate-management)
-   - [2.1 Running in secure mode](#21-running-in-secure-mode)
-      - [2.1.1 Requirements for gRPC server](#211-requirements-for-grpc-server)
-      - [2.1.2 Requirements for gRPC clients](#212-requirements-for-grpc-clients)
-      - [2.1.3 Generate and install TLS certificates](#213-generate-and-install-tls-certificates)
-   - [2.2 Running in insecure mode](#22-running-in-insecure-mode)
-
-## 1. Overview
+# Security Guide
 
 This document provides information about secure and insecure
 modes for networking recipe and certificate management.
 
-## 2. Certificate Management
+## TLS Certificates
 
 The gRPC ports are secured using TLS certificates. A script and reference
 configuration files are available to assist in generating certificates and
@@ -28,21 +18,24 @@ confirmation but may not provide sufficient security for production systems.
 It is highly recommended to use well-known CAs, and generate certificates at
 multiple depth levels in order to conform to higher security standards.
 
-### 2.1 Running in secure mode
+See [Working with TLS Certificates](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/install-tls-certificates.md)
+for step by step guide to generate and install TLS certificates
 
-#### 2.1.1 Requirements for gRPC server
+## Running in secure mode
+
+### Server requirements
 
 The IPDK Networking Recipe uses a secure-by-default model. If you wish to
 open insecure ports, you must do so explicitly. It is strongly recommended
 that you use secure ports in production systems.
 
-infrap4d is launched with following gRPC ports secured via TLS certificates.
+infrap4d is launched with the gRPC ports secured by TLS certificates.
 The port numbers are:
 
 - 9339 - an IANA-registered port for gNMI
 - 9559 - an IANA-registered port for P4RT
 
-#### 2.1.2 Requirements for gRPC clients
+### Client requirements
 
 Under default conditions, the gRPC clients will require the TLS certificates
 to establish communication with infrap4d. The clients will need to use the
@@ -63,12 +56,7 @@ must specify insecure mode for this to work.
     gnmi-ctl (the gNMI client for DPDK) and sgnmi_cli (the secure gNMI client)
 issue requests to port 9339.
 
-#### 2.1.3 Generate and install TLS certificates
-
-See [Install TLS Certificates](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/install-tls-certificates.md)
-for step by step guide to generate and install TLS certificates
-
-### 2.2 Running in insecure mode
+## Running in insecure mode
 
 To launch infrap4d in insecure mode:
 
@@ -82,12 +70,12 @@ For DPDK target:
 
 ```bash
 $IPDK_RECIPE/install/bin/gnmi-ctl set <COMMAND> \
--grpc_use_insecure_mode=true
+    -grpc_use_insecure_mode=true
 ```
 
 For Intel IPU E2100 target:
 
 ```bash
 $IPDK_RECIPE/install/bin/sgnmi_cli set <COMMAND> \
--grpc_use_insecure_mode=true
+    -grpc_use_insecure_mode=true
 ```


### PR DESCRIPTION
- Remove internal table of contents.
- Simplify document titles and section headings.
- Eliminate 'Overview' heading.
- Indent continued lines in bash examples.
- Add periods at end of sentences.