### PR TITLE
Fix commands for CPT installation and usage

### DIFF
--- a/docs/guides/es2k/compiling-p4-programs.md
+++ b/docs/guides/es2k/compiling-p4-programs.md
@@ -19,7 +19,7 @@ from RPMs in the release tarball.
   cd host/packages/x86_64/
 
   # Install RPMs on server
-  dnf localinstall cpt*.rpm --allowerasing
+  rpm -i cpt-<version>-ci.ts.release.<xxxx>.ehb0.5.15.fc37.x86_64.rpm
   dnf localinstall p4c*.rpm --allowerasing
   dnf localinstall p4-sde*.rpm --allowerasing
   ```
@@ -127,7 +127,7 @@ These files are called _P4 artifacts_.
 Use `cpt` to prepare the P4 artifacts for deployment:
 
 ```bash
-cpt --npic --device idpf --format csr --pbd  -o simple_l3_l4_pna.pkg \
+cpt --npic --format csr --pbd  -o simple_l3_l4_pna.pkg \
     cpt_ver.s simple_l3_l4_pna.s
 ```
 


### PR DESCRIPTION
Latest CPT tool requires installation of only cpt rpm and device parameter shouldn't be specificed when using cpt tool to build a package