### PR TITLE
Implement userguide build target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,8 @@ add_custom_target(userguide
     ${USERGUIDE_PREFIX}
 )
 
+message(STATUS "User guide will be written to ${USERGUIDE_PREFIX}")
+
 ##################
 # Subdirectories #
 ##################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,24 @@ function(set_install_rpath TARGET)
     endif()
 endfunction()
 
+##############
+# User guide #
+##############
+
+find_program(SPHINX_BUILD "sphinx-build" REQUIRED)
+if(NOT SPHINX_BUILD)
+    message(FATAL_ERROR "sphinx-build not found")
+endif()
+
+set(USERGUIDE_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/userguide" CACHE PATH
+    "User guide install directory")
+
+add_custom_target(userguide
+    ${SPHINX_BUILD}
+    ${CMAKE_CURRENT_SOURCE_DIR}/docs
+    ${USERGUIDE_PREFIX}
+)
+
 ##################
 # Subdirectories #
 ##################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,9 +251,9 @@ add_custom_target(userguide
     ${SPHINX_BUILD}
     ${CMAKE_CURRENT_SOURCE_DIR}/docs
     ${USERGUIDE_PREFIX}
+    COMMENT "Generating user guide to ${USERGUIDE_PREFIX}"
 )
 
-message(STATUS "User guide will be written to ${USERGUIDE_PREFIX}")
 
 ##################
 # Subdirectories #

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ P4 Control Plane User Guide
    clients/sgnmi_cli
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Features
 
    features/ipsec-offload


### PR DESCRIPTION
- Add 'userguide' CMake target to build the user guide.

- Correct 'maxdepth' on Functions division to 1. We currently display one level in the main window and let the user expand the list by clicking on the entry in the sidebar.