### PR TITLE
Address a couple of user guide issues

### DIFF
--- a/docs/clients/clients-index.rst
+++ b/docs/clients/clients-index.rst
@@ -1,0 +1,9 @@
+.. Copyright 2023 Intel Corporation
+   SPDX-License-Identifier: Apache-2.0
+
+.. toctree::
+   :maxdepth: 1
+
+   gnmi-ctl
+   p4rt-ctl
+   sgnmi_cli

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,4 +29,4 @@ myst_heading_anchors = 3
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
+#html_static_path = ['_static']

--- a/docs/features/features-index.rst
+++ b/docs/features/features-index.rst
@@ -1,0 +1,8 @@
+.. Copyright 2023 Intel Corporation
+   SPDX-License-Identifier: Apache-2.0
+
+.. toctree::
+   :maxdepth: 1
+
+   ipsec-offload
+.. linux-networking-index

--- a/docs/features/ipsec-offload.md
+++ b/docs/features/ipsec-offload.md
@@ -73,7 +73,7 @@ certificate location, IPs, lifetime thresholds, etc.
 ### Start IPsec
 
 With the strongSwan application configured, starting IPsec
-(see [ipsec-recipe](https://github.com/ipdk-io/ipsec-recipe) for details) will 
+(see [ipsec-recipe](https://github.com/ipdk-io/ipsec-recipe) for details) will
 initiate the pipeline, program the SPD rules as per the P4 program, and
 configure/re-configure SAD entries based on negotiated encryption parameters
 between local and peer system.
@@ -86,7 +86,7 @@ details encoded.
 
 ### Config SAD message
 
-The P4 Control Plane provides SET and DELETE service to the 
+The P4 Control Plane provides SET and DELETE service to the
 IPsec-offload [Config SAD message](https://github.com/ipdk-io/openconfig-public/blob/master/release/models/ipsec/openconfig-ipsec-offload.yang#L39-L185)
 at `/ipsec-offload/sad/sad-entry[offload-id=x][direction=y]/config`.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,6 @@
+.. Copyright 2023 Intel Corporation
+   SPDX-License-Identifier: Apache-2.0
+
 .. P4 Control Plane documentation master file, created by
    sphinx-quickstart on Fri Jul 28 18:19:43 2023.
    You can adapt this file completely to your liking, but it should at least
@@ -38,15 +41,13 @@ P4 Control Plane User Guide
    :maxdepth: 1
    :caption: Clients
 
-   clients/gnmi-ctl
-   clients/p4rt-ctl
-   clients/sgnmi_cli
+   clients/clients-index
 
 .. toctree::
    :maxdepth: 1
    :caption: Features
 
-   features/ipsec-offload
+   features/features-index
 
 .. toctree::
    :maxdepth: 1
@@ -59,10 +60,4 @@ P4 Control Plane User Guide
    :maxdepth: 1
    :caption: Updates
 
-   updates/development-update-23.21
-   updates/development-update-22.50
-   updates/development-update-22.44
-   updates/changes-from-p4-ovs
-
-
-
+   updates/updates-index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ P4 Control Plane User Guide
    clients/sgnmi_cli
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Features
 
    features/ipsec-offload

--- a/docs/updates/updates-index.rst
+++ b/docs/updates/updates-index.rst
@@ -1,0 +1,10 @@
+.. Copyright 2023 Intel Corporation
+   SPDX-License-Identifier: Apache-2.0
+
+.. toctree::
+   :maxdepth: 1
+
+   development-update-23.21
+   development-update-22.50
+   development-update-22.44
+   changes-from-p4-ovs


### PR DESCRIPTION
- Correct 'maxdepth' on Functions division to 1, to conform to standard practice. We currently display one level in the main window and let the user expand the list by clicking on the entry in the sidebar.

- Disable html_static_path definition in Sphinx configuration file to fix warning.

- Create sub-indexes for the Clients, Features, and Updates sections.

- Remove trailing blanks from markdown file to address lint issue.