### PR TITLE
Formalize support for Stratum dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,20 +53,19 @@ set(PB_OUT_DIR "${CMAKE_BINARY_DIR}/pb.out" CACHE PATH
     "Path to generated Protobuf files")
 file(MAKE_DIRECTORY ${PB_OUT_DIR})
 
-############################
-# Target selection options #
-############################
-
-include(SelectTdiTarget)
-
 ###################
 # Feature toggles #
 ###################
 
 option(SET_RPATH    "Set RPATH in libraries and executables" OFF)
-
 option(WITH_KRNLMON "Enable Kernel Monitor support" ON)
 option(WITH_OVSP4RT "Enable OVS support" ON)
+
+############################
+# Target selection options #
+############################
+
+include(SelectTdiTarget)
 
 if(TOFINO_TARGET)
     set(WITH_KRNLMON OFF)
@@ -75,6 +74,10 @@ endif()
 
 cmake_print_variables(WITH_KRNLMON)
 cmake_print_variables(WITH_OVSP4RT)
+
+if(WITH_OVSP4RT AND OVS_INSTALL_DIR STREQUAL "")
+    message(FATAL_ERROR "OVS_INSTALL_DIR (OVS_INSTALL) not defined!")
+endif()
 
 ###########################
 # Global compiler options #
@@ -140,7 +143,7 @@ cmake_print_variables(CMAKE_PREFIX_PATH)
 # External packages #
 #####################
 
-find_package(absl REQUIRED)
+include(StratumDependencies)
 
 if(DPDK_TARGET)
     include(dpdk-driver)
@@ -151,9 +154,6 @@ elseif(TOFINO_TARGET)
 endif()
 
 if(WITH_OVSP4RT)
-    if(OVS_INSTALL_DIR STREQUAL "")
-        message(FATAL_ERROR "OVS_INSTALL_DIR (OVS_INSTALL) not defined!")
-    endif()
     find_package(OVS)
 endif()
 

--- a/clients/gnmi-ctl/CMakeLists.txt
+++ b/clients/gnmi-ctl/CMakeLists.txt
@@ -19,20 +19,20 @@ set_install_rpath(gnmi-ctl ${EXEC_ELEMENT} ${DEP_ELEMENT})
 target_link_libraries(gnmi-ctl
     PUBLIC
         stratum_static
-        gnmi_proto grpc_proto
-        grpc protobuf gflags grpc++
-        pthread re2
+        gnmi_proto
+        grpc_proto
+        gflags::gflags_shared
+        gRPC::grpc
+        gRPC::grpc++
+        gRPC::re2
+        protobuf::libprotobuf
+        pthread
 )
 
 target_include_directories(gnmi-ctl
     PRIVATE
         ${STRATUM_SOURCE_DIR}
         ${PB_OUT_DIR}
-)
-
-add_dependencies(gnmi-ctl
-    gnmi_proto
-    grpc_proto
 )
 
 if(DPDK_TARGET)

--- a/clients/sgnmi_cli/CMakeLists.txt
+++ b/clients/sgnmi_cli/CMakeLists.txt
@@ -17,9 +17,14 @@ set_install_rpath(sgnmi_cli ${EXEC_ELEMENT} ${DEP_ELEMENT})
 target_link_libraries(sgnmi_cli
     PUBLIC
         stratum_static
-        gnmi_proto grpc_proto
-        grpc protobuf gflags grpc++
-        pthread re2
+        gnmi_proto
+        grpc_proto
+        gflags::gflags_shared
+        gRPC::grpc
+        gRPC::grpc++
+        gRPC::re2
+        protobuf::libprotobuf
+        pthread
 )
 
 if(HAVE_POSIX_AIO)
@@ -30,11 +35,6 @@ target_include_directories(sgnmi_cli
     PRIVATE
         ${STRATUM_SOURCE_DIR}
         ${PB_OUT_DIR}
-)
-
-add_dependencies(sgnmi_cli
-    gnmi_proto
-    grpc_proto
 )
 
 install(TARGETS sgnmi_cli RUNTIME)

--- a/cmake/ProtobufCompile.cmake
+++ b/cmake/ProtobufCompile.cmake
@@ -1,0 +1,131 @@
+# Compile .proto files to C++.
+#
+# Copyright 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+
+#-----------------------------------------------------------------------
+# The following variables are defined externally:
+#
+# DOT_PROTO_INSTALL_DIR
+#   Directory in which the input .proto files should be installed
+# HOST_GRPC_CPP_PLUGIN
+#   Path to the host grpc_cpp_plugin executable
+# HOST_PROTOC
+#   Path to the host protobuf compiler
+# PB_HEADER_INSTALL_DIR
+#   Directory in which the generated pb.h files should be installed
+# PB_OUT_DIR
+#   Directory in which the pb.cc and pb.h files should be generated
+# PROTO_IMPORT_PATH
+#   Directory paths to be searched for input Protobuf files
+# STRATUM_SOURCE_DIR
+#   Path to the root Stratum source directory
+#-----------------------------------------------------------------------
+
+option(INSTALL_PROTO_FILES "Install .proto files" OFF)
+
+#-----------------------------------------------------------------------
+# generate_proto_files()
+# Generates C++ files for protobufs.
+#-----------------------------------------------------------------------
+function(generate_proto_files PROTO_FILES SRC_DIR)
+  foreach(_file ${PROTO_FILES})
+    get_filename_component(_path ${_file} DIRECTORY)
+    get_filename_component(_name ${_file} NAME_WE)
+
+    set(_src ${PB_OUT_DIR}/${_path}/${_name}.pb.cc)
+    set(_hdr ${PB_OUT_DIR}/${_path}/${_name}.pb.h)
+
+    set_source_files_properties(${_src} ${_hdr} PROPERTIES GENERATED TRUE)
+
+    add_custom_command(
+      OUTPUT
+        ${_src} ${_hdr}
+      COMMAND
+        ${HOST_PROTOC}
+        --proto_path=${PROTO_IMPORT_PATH}
+        --cpp_out=${PB_OUT_DIR}
+        -I${STRATUM_SOURCE_DIR}
+        ${_file}
+      WORKING_DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}
+      DEPENDS
+        ${SRC_DIR}/${_file}
+      COMMENT
+        "Generating C++ files for ${_file}"
+      VERBATIM
+    )
+
+    # Install .pb.h file in include/.
+    install(
+      FILES
+        ${_hdr}
+      DESTINATION
+        ${PB_HEADER_INSTALL_DIR}/${_path}
+    )
+
+    # Install .proto file in share/.
+    if(INSTALL_PROTO_FILES)
+      install(
+        FILES
+          ${SRC_DIR}/${_file}
+        DESTINATION
+          ${DOT_PROTO_INSTALL_DIR}/${_path}
+      )
+    endif()
+  endforeach()
+endfunction(generate_proto_files)
+
+#-----------------------------------------------------------------------
+# generate_grpc_files()
+# Generates GRPC C++ files for protobufs.
+#-----------------------------------------------------------------------
+function(generate_grpc_files PROTO_FILES SRC_DIR)
+  foreach(_file ${PROTO_FILES})
+    get_filename_component(_path ${_file} DIRECTORY)
+    get_filename_component(_name ${_file} NAME_WE)
+
+    set(_src ${PB_OUT_DIR}/${_path}/${_name}.grpc.pb.cc)
+    set(_hdr ${PB_OUT_DIR}/${_path}/${_name}.grpc.pb.h)
+
+    set_source_files_properties(${_src} ${_hdr} PROPERTIES GENERATED TRUE)
+
+    add_custom_command(
+      OUTPUT
+        ${_src} ${_hdr}
+      COMMAND
+        ${HOST_PROTOC}
+        --proto_path=${PROTO_IMPORT_PATH}
+        --grpc_out=${PB_OUT_DIR}
+        --plugin=protoc-gen-grpc=${HOST_GRPC_CPP_PLUGIN}
+        -I${STRATUM_SOURCE_DIR}
+        ${_file}
+      WORKING_DIRECTORY
+        ${CMAKE_CURRENT_SOURCE_DIR}
+      DEPENDS
+        ${SRC_DIR}/${_file}
+      COMMENT
+        "Generating grpc files for ${_file}"
+      VERBATIM
+    )
+
+    # Install .pb.h file in include/.
+    install(
+      FILES
+        ${_hdr}
+      DESTINATION
+        ${PB_HEADER_INSTALL_DIR}/${_path}
+      )
+
+    # Install .proto file in share/.
+    if(INSTALL_PROTO_FILES)
+      install(
+        FILES
+          ${SRC_DIR}/${_file}
+        DESTINATION
+          ${DOT_PROTO_INSTALL_DIR}/${_path}
+      )
+    endif()
+  endforeach()
+endfunction(generate_grpc_files)

--- a/cmake/StratumDependencies.cmake
+++ b/cmake/StratumDependencies.cmake
@@ -1,0 +1,84 @@
+# Import Stratum dependencies.
+#
+# Copyright 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+
+include_guard(GLOBAL)
+
+#-----------------------------------------------------------------------
+# Google C++ libraries (Abseil).
+#-----------------------------------------------------------------------
+find_package(absl CONFIG REQUIRED)
+mark_as_advanced(absl_DIR)
+
+message(STATUS "Found Abseil version ${absl_VERSION}")
+
+if(absl_VERSION VERSION_GREATER_EQUAL "20230125")
+  add_compile_definitions(ABSL_LEGACY_THREAD_ANNOTATIONS)
+endif()
+
+#-----------------------------------------------------------------------
+# Google command-line flags library (gflags).
+#-----------------------------------------------------------------------
+# By default, gflags does not namespace its targets.
+set(GFLAGS_USE_TARGET_NAMESPACE TRUE)
+
+find_package(gflags CONFIG REQUIRED)
+mark_as_advanced(gflags_DIR)
+
+#-----------------------------------------------------------------------
+# Google logging library (glog).
+#-----------------------------------------------------------------------
+find_package(glog CONFIG REQUIRED)
+mark_as_advanced(glog_DIR)
+
+#-----------------------------------------------------------------------
+# Google Protocol Buffers (protobuf).
+# We must import the Protobuf package before gRPC.
+#-----------------------------------------------------------------------
+find_package(Protobuf CONFIG REQUIRED)
+mark_as_advanced(Protobuf_DIR)
+
+#-----------------------------------------------------------------------
+# Google RPC (gRPC).
+#-----------------------------------------------------------------------
+find_package(gRPC CONFIG REQUIRED)
+mark_as_advanced(gRPC_DIR)
+mark_as_advanced(c-ares_DIR)
+
+message(STATUS "Found gRPC version ${gRPC_VERSION}")
+
+#-----------------------------------------------------------------------
+# Protobuf compiler.
+# Runs on the development system.
+#-----------------------------------------------------------------------
+find_program(HOST_PROTOC "protoc")
+mark_as_advanced(HOST_PROTOC)
+
+if(HOST_PROTOC)
+  message(STATUS "Found protoc: ${HOST_PROTOC}")
+else()
+  message(FATAL_ERROR "protoc not found")
+endif()
+
+#-----------------------------------------------------------------------
+# gRPC plugin for Protobuf compiler.
+# Runs on the development system.
+#-----------------------------------------------------------------------
+find_program(HOST_GRPC_CPP_PLUGIN "grpc_cpp_plugin")
+mark_as_advanced(HOST_GRPC_CPP_PLUGIN)
+
+if(HOST_GRPC_CPP_PLUGIN)
+  message(STATUS "Found grpc_cpp_plugin: ${HOST_GRPC_CPP_PLUGIN}")
+else()
+  message(FATAL_ERROR "grpc_cpp_plugin not found")
+endif()
+
+#-----------------------------------------------------------------------
+# SSL/TLS library (OpenSSL).
+#-----------------------------------------------------------------------
+find_package(OpenSSL REQUIRED)
+mark_as_advanced(OpenSSL_DIR)
+
+set(WITH_OPENSSL TRUE)

--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -27,7 +27,7 @@ set(STRATUM_SOURCE_DIR
 mark_as_advanced(STRATUM_SOURCE_DIR)
 
 set(PB_OUT_DIR "${CMAKE_BINARY_DIR}/pb.out" CACHE PATH
-    "Path to generated Protobuf files")
+    "Path to directory for generated Protobuf files")
 mark_as_advanced(PB_OUT_DIR)
 file(MAKE_DIRECTORY ${PB_OUT_DIR})
 

--- a/stratum/proto/CMakeLists.txt
+++ b/stratum/proto/CMakeLists.txt
@@ -4,38 +4,6 @@
 # SPDX-License-Identifier: Apache 2.0
 #
 
-include(FindProtobuf)
-
-option(INSTALL_PROTO_FILES "Install .proto files" OFF)
-
-#############################
-# Find Protobuf executables #
-#############################
-
-# The Protobuf compiler and gRPC plugin are host tools, even if we're
-# cross-compiling. NO_CMAKE_FIND_ROOT_PATH ensures that we do not
-# search the cross-compiled binaries for the Protobuf executables.
-
-find_package(Protobuf REQUIRED NO_CMAKE_FIND_ROOT_PATH)
-
-find_package(gRPC NO_CMAKE_FIND_ROOT_PATH)
-
-if(gRPC AND TARGET(gRPC::grpc_cpp_plugin))
-    get_property(GRPC_CPP_PLUGIN
-        TARGET gRPC::grpc_cpp_plugin
-        PROPERTY IMPORTED_LOCATION_NOCONFIG)
-else()
-    find_program(GRPC_CPP_PLUGIN "grpc_cpp_plugin" REQUIRED
-        NO_CMAKE_FIND_ROOT_PATH)
-    mark_as_advanced(GRPC_CPP_PLUGIN)
-    if(NOT GRPC_CPP_PLUGIN)
-        message(FATAL_ERROR "grpc_cpp_plugin not found")
-    endif()
-endif()
-
-cmake_print_variables(PROTOBUF_PROTOC_EXECUTABLE)
-cmake_print_variables(GRPC_CPP_PLUGIN)
-
 ##########################
 # Compile protobuf files #
 ##########################
@@ -54,112 +22,7 @@ string(JOIN ":" PROTO_IMPORT_PATH
 set(PB_HEADER_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/stratum/pb)
 set(DOT_PROTO_INSTALL_DIR ${CMAKE_INSTALL_DATAROOTDIR}/stratum/proto)
 
-########################
-# generate_proto_files #
-########################
-
-# Generates C++ files for protobufs.
-function(generate_proto_files PROTO_FILES SRC_DIR)
-    foreach(_file ${PROTO_FILES})
-        get_filename_component(_path ${_file} DIRECTORY)
-        get_filename_component(_name ${_file} NAME_WE)
-
-        set(_src ${PB_OUT_DIR}/${_path}/${_name}.pb.cc)
-        set(_hdr ${PB_OUT_DIR}/${_path}/${_name}.pb.h)
-
-        set_source_files_properties(${_src} ${_hdr} PROPERTIES GENERATED TRUE)
-
-        add_custom_command(
-            OUTPUT
-                ${_src} ${_hdr}
-            COMMAND
-                ${PROTOBUF_PROTOC_EXECUTABLE}
-                --proto_path=${PROTO_IMPORT_PATH}
-                --cpp_out=${PB_OUT_DIR}
-                -I${STRATUM_SOURCE_DIR}
-                ${_file}
-            WORKING_DIRECTORY
-                ${CMAKE_CURRENT_SOURCE_DIR}
-            DEPENDS
-                ${SRC_DIR}/${_file}
-            COMMENT
-                "Generating C++ files for ${_file}"
-            VERBATIM
-        )
-
-        # Install .pb.h file in include/.
-        install(
-            FILES
-                ${_hdr}
-            DESTINATION
-                ${PB_HEADER_INSTALL_DIR}/${_path}
-        )
-
-        # Install .proto file in share/.
-        if(INSTALL_PROTO_FILES)
-            install(
-                FILES
-                    ${SRC_DIR}/${_file}
-                DESTINATION
-                    ${DOT_PROTO_INSTALL_DIR}/${_path}
-            )
-        endif()
-    endforeach()
-endfunction(generate_proto_files)
-
-#######################
-# generate_grpc_files #
-#######################
-
-# Generates GRPC C++ files for protobufs.
-function(generate_grpc_files PROTO_FILES SRC_DIR)
-    foreach(_file ${PROTO_FILES})
-        get_filename_component(_path ${_file} DIRECTORY)
-        get_filename_component(_name ${_file} NAME_WE)
-
-        set(_src ${PB_OUT_DIR}/${_path}/${_name}.grpc.pb.cc)
-        set(_hdr ${PB_OUT_DIR}/${_path}/${_name}.grpc.pb.h)
-
-        set_source_files_properties(${_src} ${_hdr} PROPERTIES GENERATED TRUE)
-
-        add_custom_command(
-            OUTPUT
-                ${_src} ${_hdr}
-            COMMAND
-                ${PROTOBUF_PROTOC_EXECUTABLE}
-                --proto_path=${PROTO_IMPORT_PATH}
-                --grpc_out=${PB_OUT_DIR}
-                --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN}
-                -I${STRATUM_SOURCE_DIR}
-                ${_file}
-            WORKING_DIRECTORY
-                ${CMAKE_CURRENT_SOURCE_DIR}
-            DEPENDS
-                ${SRC_DIR}/${_file}
-            COMMENT
-                "Generating grpc files for ${_file}"
-            VERBATIM
-        )
-
-        # Install .pb.h file in include/.
-        install(
-            FILES
-                ${_hdr}
-            DESTINATION
-                ${PB_HEADER_INSTALL_DIR}/${_path}
-            )
-
-        # Install .proto file in share/.
-        if(INSTALL_PROTO_FILES)
-            install(
-                FILES
-                    ${SRC_DIR}/${_file}
-                DESTINATION
-                    ${DOT_PROTO_INSTALL_DIR}/${_path}
-            )
-        endif()
-    endforeach()
-endfunction(generate_grpc_files)
+include(ProtobufCompile)
 
 #######################
 # Build libgrpc_proto #
@@ -182,7 +45,7 @@ add_library(grpc_proto SHARED
 
 target_include_directories(grpc_proto PRIVATE ${PB_OUT_DIR})
 
-target_link_libraries(grpc_proto PUBLIC protobuf)
+target_link_libraries(grpc_proto PUBLIC protobuf::libprotobuf)
 
 set_install_rpath(grpc_proto ${DEP_ELEMENT})
 
@@ -223,7 +86,8 @@ target_include_directories(p4runtime_proto PRIVATE ${PB_OUT_DIR})
 target_link_libraries(p4runtime_proto
     PUBLIC
         grpc_proto
-        absl::synchronization               
+        protobuf::libprotobuf
+        absl::synchronization
 )
 
 set_install_rpath(p4runtime_proto $ORIGIN ${DEP_ELEMENT})
@@ -309,5 +173,7 @@ add_library(stratum_proto SHARED
     $<TARGET_OBJECTS:stratum_proto1_o>
     $<TARGET_OBJECTS:stratum_proto2_o>
 )
+
+target_link_libraries(stratum_proto PUBLIC protobuf::libprotobuf)
 
 install(TARGETS stratum_proto LIBRARY)

--- a/stratum/proto/gnmi/CMakeLists.txt
+++ b/stratum/proto/gnmi/CMakeLists.txt
@@ -37,6 +37,7 @@ target_include_directories(gnmi_proto PRIVATE ${PB_OUT_DIR})
 target_link_libraries(gnmi_proto
     PUBLIC
         grpc_proto
+        protobuf::libprotobuf
         absl::hash
         absl::strings
         absl::synchronization

--- a/stratum/proto/openconfig/CMakeLists.txt
+++ b/stratum/proto/openconfig/CMakeLists.txt
@@ -85,4 +85,6 @@ add_library(openconfig_proto SHARED
     $<TARGET_OBJECTS:openconfig_goog_bcm_proto_o>
 )
 
+target_link_libraries(openconfig_proto PUBLIC protobuf::libprotobuf)
+
 install(TARGETS openconfig_proto LIBRARY)


### PR DESCRIPTION
- Consolidate the find_package() commands for the packages
  used by Stratum into StratumDependencies.cmake, and include
  the latter from the top-level cmake listfile.

- Replace library names with namespaced library targets.

- Define WITH_OPENSSL variable to indicate whether to link against
  OpenSSL.

- Display Abseil and gRPC package versions.

- Rework logic to find the paths to the host protobuf compiler
  and the gRPC C++ plugin.

- Extract functions to compile Protobuf files and move them to
  ProtobufCompile.cmake.