### PR TITLE
Address issues in os_ver_details.sh

### DIFF
--- a/scripts/common/os_ver_details.sh
+++ b/scripts/common/os_ver_details.sh
@@ -29,10 +29,10 @@ get_os_ver_details()
   else
       # Fall back to uname, e.g. "Linux <version>", also works for BSD, etc.
       OS=$(uname -s)
-      export OS
       VER=$(uname -r)
-      export VER
   fi
+  export OS
+  export VER
 }
 
 #
@@ -67,4 +67,6 @@ get_num_cores()
         NUM_CORES=1
         NUM_THREADS=-j1
     fi
+    export NUM_CORES
+    export NUM_THREADS
 }


### PR DESCRIPTION
- Export OS and VER from `get_os_ver_details` in all cases. (It currently does so in only one case.)
- Export NUM_CORES and NUM_THREADS from `get_num_cores`.