### PR TITLE
Daemonize infrap4d without krnlmon

### DIFF
--- a/infrap4d/CMakeLists.txt
+++ b/infrap4d/CMakeLists.txt
@@ -6,23 +6,17 @@
 
 add_subdirectory(daemon)
 
-set(STRATUM_TDI_BIN_DIR ${STRATUM_SOURCE_DIR}/stratum/hal/bin/tdi)
-
 if(WITH_KRNLMON)
     add_executable(infrap4d infrap4d_main.cc)
-    target_sources(infrap4d PRIVATE $<TARGET_OBJECTS:daemon_o>)
     target_include_directories(infrap4d PRIVATE ${KRNLMON_SOURCE_DIR})
-elseif(DPDK_TARGET)
-    add_executable(infrap4d ${STRATUM_TDI_BIN_DIR}/dpdk/main.cc)
-elseif(ES2K_TARGET)
-    add_executable(infrap4d ${STRATUM_TDI_BIN_DIR}/es2k/main.cc)
-elseif(TOFINO_TARGET)
-    add_executable(infrap4d ${STRATUM_TDI_BIN_DIR}/tofino/main.cc)
+else()
+    add_executable(infrap4d infrap4d_lite.cc)
 endif()
 
-if(NOT TOFINO_TARGET)
-    target_sources(infrap4d PRIVATE ${STRATUM_TDI_BIN_DIR}/main.h)
-endif()
+target_sources(infrap4d PRIVATE
+    $<TARGET_OBJECTS:daemon_o>
+    ${STRATUM_SOURCE_DIR}/stratum/hal/bin/tdi/main.h
+)
 
 target_include_directories(infrap4d PRIVATE ${STRATUM_SOURCE_DIR})
 

--- a/infrap4d/infrap4d_lite.cc
+++ b/infrap4d/infrap4d_lite.cc
@@ -1,0 +1,32 @@
+// infrap4d_main without krnlmon
+
+// Copyright 2022-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gflags/gflags.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/hal/bin/tdi/main.h"
+
+extern "C"  {
+#include "daemon/daemon.h"
+}
+
+DEFINE_bool(detach, true, "Run infrap4d in detached mode");
+
+int main(int argc, char* argv[]) {
+  // Parse infrap4d command line
+  stratum::hal::tdi::ParseCommandLine(argc, argv, true);
+
+  if (FLAGS_detach) {
+      daemonize_start(false);
+      daemonize_complete();
+  }
+
+  auto status = stratum::hal::tdi::Main();
+  if (!status.ok()) {
+     // TODO: Figure out logging for infrap4d
+     return status.error_code();
+   }
+
+  return 0;
+}


### PR DESCRIPTION
- In the original implementation, infrap4d without krnlmon consisted of nothing but Stratum. There was no support for running as a daemon.

  This CL implements a lightweight version of infrap4d_main.cc (infrap4d_lite.cc) that includes support for daemonization.