### PR TITLE
Restore support for Tofino infrap4d build

### DIFF
--- a/infrap4d/CMakeLists.txt
+++ b/infrap4d/CMakeLists.txt
@@ -9,6 +9,11 @@ add_subdirectory(daemon)
 if(WITH_KRNLMON)
     add_executable(infrap4d infrap4d_main.cc)
     target_include_directories(infrap4d PRIVATE ${KRNLMON_SOURCE_DIR})
+elseif(TOFINO_TARGET)
+    # Tofino does not support the infrap4d interface, so we just
+    # build Stratum and call it infrap4d.
+    add_executable(infrap4d
+        ${STRATUM_SOURCE_DIR}/stratum/hal/bin/tdi/tofino/main.cc)
 else()
     add_executable(infrap4d infrap4d_lite.cc)
 endif()


### PR DESCRIPTION
- tofino_main does not support the infrap4d interface, so it won't build with infrap4d_lite. There's no call for us to implement the interface at this time, and I don't want to add conditionals to infrap4d_lite. Just revert to the old way of building the Tofino target.