### PR TITLE
Remove symlinks to es2k scripts

### DIFF
--- a/config-cross-recipe.sh
+++ b/config-cross-recipe.sh
@@ -1,1 +1,0 @@
-scripts/es2k/config-cross-recipe.sh

--- a/make-cross-ovs.sh
+++ b/make-cross-ovs.sh
@@ -1,1 +1,0 @@
-scripts/es2k/make-cross-ovs.sh


### PR DESCRIPTION
- Remove the symlinks to the helper scripts in the scripts/es2k directory.