### PR TITLE
Mark cache variables as advanced

### DIFF
--- a/clients/p4rt-ctl/CMakeLists.txt
+++ b/clients/p4rt-ctl/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.5)
 
 # Define PYTHON3 variable.
 find_program(PYTHON3 python3)
+mark_as_advanced(PYTHON3)
 if(NOT PYTHON3)
     include(FindPython)
     find_package(Python COMPONENTS Interpreter)

--- a/cmake/FindOVS.cmake
+++ b/cmake/FindOVS.cmake
@@ -17,47 +17,56 @@ find_path(OVS_INCLUDE_DIR
     NAMES "openvswitch/version.h"
     PATHS ${PC_OVS_INCLUDE_DIRS}
 )
+mark_as_advanced(OVS_INCLUDE_DIR)
 
 find_library(OVS_LIBRARY
     NAMES openvswitch
     PATHS ${PC_OVS_LIBRARY_DIRS}
 )
+mark_as_advanced(OVS_LIBRARY)
 
 find_library(OVS_LIBAVX512
     NAMES openvswitchavx512
     PATHS ${PC_OVS_LIBRARY_DIRS}
 )
+mark_as_advanced(OVS_LIBAVX512)
 
 find_library(OFPROTO_LIBRARY
     NAMES ofproto
     PATHS ${PC_OVS_LIBRARY_DIRS}
 )
+mark_as_advanced(OFPROTO_LIBRARY)
 
 find_library(OVSDB_LIBRARY
     NAMES ovsdb
     PATHS ${PC_OVS_LIBRARY_DIRS}
 )
+mark_as_advanced(OVSDB_LIBRARY)
 
 find_library(SFLOW_LIBRARY
     NAMES sflow
     PATHS ${PC_OVS_LIBRARY_DIRS}
 )
+mark_as_advanced(SFLOW_LIBRARY)
 
 find_library(LIBVSWITCHD
     NAMES vswitchd
     PATHS ${PC_OVS_LIBRARY_DIRS}
 )
+mark_as_advanced(LIBVSWITCHD)
 
 find_library(LIBTESTCONTROLLER
     NAMES testcontroller
     PATHS ${PC_OVS_LIBRARY_DIRS}
 )
+mark_as_advanced(LIBTESTCONTROLLER)
 
 #-----------------------------------------------------------------------
 # Get version number
 #-----------------------------------------------------------------------
 if(PC_OVS_VERSION)
     set(OVS_VERSION ${PC_OVS_VERSION} CACHE STRING "OVS version")
+    mark_as_advanced(OVS_VERSION)
 elseif(EXISTS "${OVS_INCLUDE_DIR}/openvswitch/version.h")
     # Extract version string from version.h file.
     file(STRINGS
@@ -66,6 +75,7 @@ elseif(EXISTS "${OVS_INCLUDE_DIR}/openvswitch/version.h")
     string(REGEX REPLACE
         "[^0-9.]+([0-9.]+).*" "\\1" OVS_VERSION ${_version_string})
     set(OVS_VERSION ${PC_OVS_VERSION} CACHE STRING "OVS version")
+    mark_as_advanced(OVS_VERSION)
     unset(_version_string)
 endif()
 
@@ -81,10 +91,6 @@ find_package_handle_standard_args(OVS
     VERSION_VAR
         OVS_VERSION
 )
-
-mark_as_advanced(OVS_INCLUDE_DIR)
-mark_as_advanced(OVS_LIBRARY OVSDB_LIBRARY OFPROTO_LIBRARY SFLOW_LIBRARY)
-mark_as_advanced(LIBVSWITCHD LIBTESTCONTROLLER)
 
 #-----------------------------------------------------------------------
 # Define library targets

--- a/cmake/SelectTdiTarget.cmake
+++ b/cmake/SelectTdiTarget.cmake
@@ -131,6 +131,8 @@ function(_select_tdi_target_type)
     # Set cache variables.
     set(TARGETFLAG "${target_flag}" CACHE STRING "TDI target conditional" FORCE)
     set(TARGETTYPE "${target_type}" CACHE STRING "TDI target type" FORCE)
+    mark_as_advanced(TARGETFLAG)
+    mark_as_advanced(TARGETTYPE)
 
     message(NOTICE "${target_action} ${target_flag}")
 endfunction()

--- a/krnlmon/CMakeLists.txt
+++ b/krnlmon/CMakeLists.txt
@@ -7,10 +7,12 @@
 # Path to SAI source directory (for krnlmon)
 set(SAI_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/SAI" CACHE PATH
     "Path to SAI source directory")
+mark_as_advanced(SAI_SOURCE_DIR)
 
 # Path to KRNLMON source directory (for infrap4d)
 set(KRNLMON_SOURCE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/krnlmon" CACHE PATH
     "Path to kernel monitor source directory")
+mark_as_advanced(KRNLMON_SOURCE_DIR)
 
 add_subdirectory(krnlmon)

--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -14,17 +14,21 @@ cmake_minimum_required(VERSION 3.15)
 set(GOOGLEAPIS_SOURCE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/googleapis" CACHE PATH
     "Path to Google APIs source directory")
+mark_as_advanced(GOOGLEAPIS_SOURCE_DIR)
 
 set(P4RUNTIME_SOURCE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/p4runtime" CACHE PATH
     "Path to P4Runtime source directory")
+mark_as_advanced(P4RUNTIME_SOURCE_DIR)
 
 set(STRATUM_SOURCE_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/stratum" CACHE PATH
     "Path to Stratum source directory")
+mark_as_advanced(STRATUM_SOURCE_DIR)
 
 set(PB_OUT_DIR "${CMAKE_BINARY_DIR}/pb.out" CACHE PATH
     "Path to generated Protobuf files")
+mark_as_advanced(PB_OUT_DIR)
 file(MAKE_DIRECTORY ${PB_OUT_DIR})
 
 set(STRATUM_INCLUDES

--- a/stratum/proto/CMakeLists.txt
+++ b/stratum/proto/CMakeLists.txt
@@ -27,6 +27,7 @@ if(gRPC AND TARGET(gRPC::grpc_cpp_plugin))
 else()
     find_program(GRPC_CPP_PLUGIN "grpc_cpp_plugin" REQUIRED
         NO_CMAKE_FIND_ROOT_PATH)
+    mark_as_advanced(GRPC_CPP_PLUGIN)
     if(NOT GRPC_CPP_PLUGIN)
         message(FATAL_ERROR "grpc_cpp_plugin not found")
     endif()


### PR DESCRIPTION
- Set the ADVANCED attribute on cache variables that should not normally be displayed in cmake GUIs.