### PR TITLE
Update setup guides to include DEPEND_INSTALL env var

### DIFF
--- a/docs/guides/setup/dpdk-setup-guide.md
+++ b/docs/guides/setup/dpdk-setup-guide.md
@@ -29,8 +29,10 @@ pip3 install -r requirements.txt
 git clone --recursive https://github.com/ipdk-io/networking-recipe.git ipdk.recipe
 cd ipdk.recipe
 export IPDK_RECIPE=`pwd`
+export DEPEND_INSTALL=<absolute path for installing dependencies>
+export SDE_INSTALL=<absolute path for p4 sde install built in previous step>
 cd $IPDK_RECIPE/setup
-cmake -B build -DCMAKE_INSTALL_PREFIX=<dependency install path> [-DUSE_SUDO=ON]
+cmake -B build -DCMAKE_INSTALL_PREFIX=$DEPEND_INSTALL [-DUSE_SUDO=ON]
 cmake --build build [-j<njobs>]
 ```
 
@@ -38,11 +40,6 @@ cmake --build build [-j<njobs>]
 config.
 
 ### Build Networking Recipe
-
-#### Set environment variables
-
-- export DEPEND_INSTALL=`absolute path for installing dependencies`
-- export SDE_INSTALL=`absolute path for p4 sde install built in previous step`
 
 ```bash
 cd $IPDK_RECIPE

--- a/docs/guides/setup/es2k-setup-guide.md
+++ b/docs/guides/setup/es2k-setup-guide.md
@@ -26,8 +26,10 @@ development system. A common install location is '/opt/p4/p4sde`.
 git clone --recursive https://github.com/ipdk-io/networking-recipe.git ipdk.recipe
 cd ipdk.recipe
 export IPDK_RECIPE=`pwd`
+export DEPEND_INSTALL=<absolute path for installing dependencies>
+export SDE_INSTALL=<absolute path for p4 sde install built in previous step>
 cd $IPDK_RECIPE/setup
-cmake -B build -DCMAKE_INSTALL_PREFIX=<dependency install path> [-DUSE_SUDO=ON]
+cmake -B build -DCMAKE_INSTALL_PREFIX=$DEPEND_INSTALL [-DUSE_SUDO=ON]
 cmake --build build [-j<njobs>]
 ```
 
@@ -35,11 +37,6 @@ cmake --build build [-j<njobs>]
 config.
 
 ### Build P4 Control Plane
-
-#### Set environment variables
-
-- export DEPEND_INSTALL=`absolute path for installing dependencies`
-- export SDE_INSTALL=`absolute path for p4 sde install built in previous step`
 
 ```bash
 cd $IPDK_RECIPE


### PR DESCRIPTION
Setup guides had details setting DEPEND_INSTALL environment variable set after usage in previous section. Updating to re-order to set the DEPEND_INSTALL environment variable, and using it in the cmake command