### PR TITLE
Helper script maintenance

### DIFF
--- a/make-all.sh
+++ b/make-all.sh
@@ -44,7 +44,7 @@ print_help() {
     echo "  --ovs=DIR        -O  OVS install directory [${_OVS_DIR}]"
     echo "  --prefix=DIR     -P  Install directory prefix [${_PREFIX}]"
     echo "  --sde=DIR        -S  SDE install directory [${_SDE_DIR}]"
-    echo "  --staging=DIR        Staging directory prefix [${_STAGING}]"
+#   echo "  --staging=DIR        Staging directory prefix [${_STAGING}]"
     echo "  --toolchain=FILE -T  CMake toolchain file"
     echo ""
     echo "Options:"

--- a/make-all.sh
+++ b/make-all.sh
@@ -25,9 +25,8 @@ _TGT_TYPE="DPDK"
 _TOOLFILE=${CMAKE_TOOLCHAIN_FILE}
 
 _BLD_DIR=build
-_CFG_ONLY=0
+_DO_BUILD=1
 _DRY_RUN=0
-_CFG_ONLY=0
 _OVS_BLD="ovs/build"
 _WITH_OVS=1
 
@@ -49,12 +48,12 @@ print_help() {
     echo "  --toolchain=FILE -T  CMake toolchain file"
     echo ""
     echo "Options:"
-    echo "  --config             Configure without building"
     echo "  --coverage           Instrument build to measure code coverage"
     echo "  --cxx-std=STD        C++ standard (11|14|17) [$_CXX_STD])"
     echo "  --dry-run        -n  Display cmake parameter values and exit"
     echo "  --help           -h  Display this help text"
     echo "  --jobs=NJOBS     -j  Number of build threads [${_NJOBS}]"
+    echo "  --no-build           Configure without building"
     echo "  --no-krnlmon         Exclude Kernel Monitor"
     echo "  --no-ovs             Exclude OVS support"
     echo "  --target=TARGET      Target to build (dpdk|es2k|tofino) [${_TGT_TYPE}]"
@@ -97,7 +96,7 @@ print_cmake_params() {
     [ -n "${_COVERAGE}" ] && echo "${_COVERAGE:2}"
     echo "${_SET_RPATH:2}"
     echo "${_TARGET_TYPE:2}"
-    if [ ${_CFG_ONLY} -ne 0 ]; then
+    if [ ${_DO_BUILD} -eq 0 ]; then
         echo ""
         echo "Configure without building"
         echo ""
@@ -167,10 +166,11 @@ SHORTOPTS=D:H:O:P:S:T:
 SHORTOPTS=${SHORTOPTS}hj:n
 
 LONGOPTS=deps:,hostdeps:,ovs:,prefix:,sde:,toolchain:
-LONGOPTS=${LONGOPTS},cxx-std:,staging:,target:
+LONGOPTS=${LONGOPTS},cxx-std:,jobs:,staging:,target:
 LONGOPTS=${LONGOPTS},debug,release,minsize,reldeb
-LONGOPTS=${LONGOPTS},dry-run,help,jobs:,no-krnlmon,no-ovs
-LONGOPTS=${LONGOPTS},config,coverage,ninja,rpath,no-rpath
+LONGOPTS=${LONGOPTS},dry-run,help
+LONGOPTS=${LONGOPTS},coverage,ninja,rpath
+LONGOPTS=${LONGOPTS},no-build,no-krnlmon,no-ovs,no-rpath
 
 GETOPTS=$(getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@")
 eval set -- "${GETOPTS}"
@@ -214,9 +214,6 @@ while true ; do
         _BLD_TYPE="Release"
         shift ;;
     # Options
-    --config)
-        _CFG_ONLY=1
-        shift ;;
     --coverage)
         _COVERAGE="-DTEST_COVERAGE=ON"
         shift ;;
@@ -235,6 +232,9 @@ while true ; do
     --ninja)
         _GENERATOR="-G Ninja"
         shift 1 ;;
+    --no-build)
+        _DO_BUILD=0
+        shift ;;
     --no-krnlmon)
         _WITH_KRNLMON=FALSE
         shift ;;
@@ -296,6 +296,6 @@ if [ ${_WITH_OVS} -ne 0 ]; then
 fi
 
 config_recipe
-if [ ${_CFG_ONLY} -eq 0 ]; then
+if [ ${_DO_BUILD} -ne 0 ]; then
     build_recipe
 fi

--- a/scripts/es2k/config-cross-recipe.sh
+++ b/scripts/es2k/config-cross-recipe.sh
@@ -106,32 +106,32 @@ eval set -- "${GETOPTS}"
 while true ; do
     case "$1" in
     # Paths
-    -B|--build)
+    --build|-B)
         _BLD_DIR=$2
         shift 2 ;;
-    -D|--deps)
+    --deps|-D)
         _DEPS_DIR=$2
         shift 2 ;;
-    -H|--hostdeps)
+    --hostdeps|-H)
         _HOST_DIR=$2
         shift 2 ;;
-    -O|--ovs)
+    --ovs|-O)
         _OVS_DIR=$2
         shift 2 ;;
-    -P|--prefix)
+    --prefix|-P)
         _PREFIX=$2
         shift 2 ;;
-    -S|--sde)
+    --sde|-S)
         _SDE_DIR=$2
         shift 2 ;;
-    -T|--toolchain)
+    --toolchain|-T)
         _TOOLFILE=$2
         shift 2 ;;
     # Options
-    -n|--dry-run)
+    --dry-run|-n)
         _DRY_RUN=1
         shift 1 ;;
-    -h|--help)
+    --help|-h)
         print_help
         exit 99 ;;
     --no-krnlmon)
@@ -176,7 +176,8 @@ fi
 
 rm -fr "${_BLD_DIR}"
 
-cmake -S . -B "${_BLD_DIR}" \
+ # shellcheck disable=SC2086
+ cmake -S . -B "${_BLD_DIR}" \
     -DCMAKE_BUILD_TYPE=${_BLD_TYPE} \
     -DCMAKE_INSTALL_PREFIX="${_PREFIX}" \
     -DCMAKE_TOOLCHAIN_FILE="${_TOOLFILE}" \

--- a/scripts/es2k/make-cross-ovs.sh
+++ b/scripts/es2k/make-cross-ovs.sh
@@ -27,7 +27,8 @@ _SYSROOT=${SDKTARGETSYSROOT}
 
 _BLD_DIR=ovs/build
 _BLD_TYPE=RelWithDebInfo
-_JOBS=8
+_DRY_RUN=0
+_NJOBS=8
 _PREFIX=//opt/ovs
 _TOOLFILE=${CMAKE_TOOLCHAIN_FILE}
 
@@ -39,12 +40,15 @@ print_help() {
     echo ""
     echo "Build and install Open vSwitch"
     echo ""
-    echo "Options:"
+    echo "Paths:"
     echo "  --build=DIR      -B  Build directory path [${_BLD_DIR}]"
-    echo "  --dry-run        -n  Display cmake parameters and exit"
-    echo "  --jobs=NJOBS     -j  Number of build threads (Default: ${_JOBS})"
     echo "  --prefix=DIR*    -P  Install directory prefix [${_PREFIX}]"
     echo "  --toolchain=FILE -T  CMake toolchain file"
+    echo ""
+    echo "Options:"
+    echo "  --dry-run        -n  Display cmake parameters and exit"
+    echo "  --help           -h  Display this help text"
+    echo "  --jobs=NJOBS     -j  Number of build threads [${_NJOBS}]"
     echo ""
     echo "* '//' at the beginning of the directory path will be replaced"
     echo "  with the sysroot directory path."
@@ -64,7 +68,7 @@ print_cmake_params() {
     echo "CMAKE_BUILD_TYPE=${_BLD_TYPE}"
     echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
     echo "CMAKE_TOOLCHAIN_FILE=${_TOOLFILE}"
-    echo "JOBS=${_JOBS}"
+    echo "JOBS=${_NJOBS}"
     echo ""
 }
 
@@ -83,23 +87,25 @@ eval set -- "${GETOPTS}"
 
 while true ; do
     case "$1" in
-    -B|--build)
+    # Paths
+    --build|-B)
         _BLD_DIR=$2
         shift 2 ;;
-    -n|--dry-run)
-        _DRY_RUN=true
-        shift 1 ;;
-    -h|--help)
-        print_help
-        exit 99 ;;
-    -j|--jobs)
-        _JOBS=$2
-        shift 2 ;;
-    -P|--prefix)
+    --prefix|-P)
         _PREFIX=$2
         shift 2 ;;
-    -T|--toolchain)
+    --toolchain|-T)
         _TOOLFILE=$2
+        shift 2 ;;
+    # Options
+    --dry-run|-n)
+        _DRY_RUN=1
+        shift 1 ;;
+    --help|-h)
+        print_help
+        exit 99 ;;
+    --jobs|-j)
+        _NJOBS=$2
         shift 2 ;;
     --)
         shift
@@ -117,7 +123,8 @@ done
 # Substitute ${_SYSROOT}/ for '//' prefix
 [ "${_PREFIX:0:2}" = "//" ] && _PREFIX=${_SYSROOT}/${_PREFIX:2}
 
-if [ "${_DRY_RUN}" = "true" ]; then
+# Show parameters if this is a dry run
+if [ ${_DRY_RUN} -ne 0 ]; then
     print_cmake_params
     exit 0
 fi
@@ -138,4 +145,4 @@ cmake -S ovs -B "${_BLD_DIR}" \
 # Build OVS #
 #############
 
-cmake --build "${_BLD_DIR}" "-j${_JOBS}" -- V=0
+cmake --build "${_BLD_DIR}" "-j${_NJOBS}" -- V=0

--- a/setup/make-cross-deps.sh
+++ b/setup/make-cross-deps.sh
@@ -27,8 +27,9 @@ _SYSROOT=${SDKTARGETSYSROOT}
 ##################
 
 _BLD_DIR=build
+_DO_BUILD=true
 _DRY_RUN=false
-_JOBS=8
+_NJOBS=8
 _PREFIX=//opt/deps
 _TOOLFILE=${CMAKE_TOOLCHAIN_FILE}
 
@@ -40,17 +41,21 @@ print_help() {
     echo ""
     echo "Build target dependency libraries"
     echo ""
-    echo "Options:"
+    echo "Paths:"
     echo "  --build=DIR      -B  Build directory path [${_BLD_DIR}]"
+    echo "  --host=DIR       -H  Host dependencies directory [${_HOST_DIR}]"
+    echo "  --prefix=DIR*    -P  Install directory prefix [${_PREFIX}]"
+    echo "  --toolchain=FILE -T  CMake toolchain file"
+    echo ""
+    echo "Options:"
     echo "  --cxx=VERSION        CXX_STANDARD to build dependencies (Default: empty)"
     echo "  --dry-run        -n  Display cmake parameters and exit"
     echo "  --force          -f  Specify -f when patching (Default: false)"
-    echo "  --host=DIR       -H  Host dependencies directory [${_HOST_DIR}]"
-    echo "  --jobs=NJOBS     -j  Number of build threads (Default: ${_JOBS})"
+    echo "  --help           -h  Display this help text"
+    echo "  --jobs=NJOBS     -j  Number of build threads (Default: ${_NJOBS})"
+    echo "  --no-build           Configure without building"
     echo "  --no-download        Do not download repositories (Default: false)"
-    echo "  --prefix=DIR*    -P  Install directory prefix [${_PREFIX}]"
     echo "  --sudo               Use sudo when installing (Default: false)"
-    echo "  --toolchain=FILE -T  CMake toolchain file"
     echo ""
     echo "* '//' at the beginning of the directory path will be replaced"
     echo "  with the sysroot directory path."
@@ -67,7 +72,7 @@ print_help() {
 
 SHORTOPTS=B:H:P:T:fhj:n
 LONGOPTS=build:,cxx:,hostdeps:,jobs:,prefix:,toolchain:
-LONGOPTS=${LONGOPTS},dry-run,force,help,no-download,sudo
+LONGOPTS=${LONGOPTS},dry-run,force,help,no-build,no-download,sudo
 
 eval set -- `getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@"`
 
@@ -97,11 +102,14 @@ while true ; do
         print_help
         exit 99 ;;
     -j|--jobs)
-        _JOBS=$2
+        _NJOBS=$2
         shift 2 ;;
     -n|--dry-run)
         _DRY_RUN=true
         shift 1 ;;
+    --no-build)
+        _DO_BUILD=false
+        shift ;;
     --no-download)
         _DOWNLOAD="-DDOWNLOAD=FALSE"
         shift 1 ;;
@@ -132,12 +140,18 @@ if [ "${_DRY_RUN}" = "true" ]; then
     echo ""
     echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
     echo "CMAKE_TOOLCHAIN_FILE=${_TOOLFILE}"
-    echo "JOBS=${_JOBS}"
+    echo "JOBS=${_NJOBS}"
     [ -n "${_CXX_STANDARD_OPTION}" ] && echo "${_CXX_STANDARD_OPTION:2}"
     [ -n "${_DOWNLOAD}" ] && echo "${_DOWNLOAD:2}"
     [ -n "${_HOST_DEPEND_DIR}" ] && echo "${_HOST_DEPEND_DIR:2}"
     [ -n "${_FORCE_PATCH}" ] && echo "${_FORCE_PATCH:2}"
     [ -n "${_USE_SUDO}" ] && echo "${_USE_SUDO:2}"
+
+    if [ "${_DO_BUILD}" = "false" ]; then
+	echo ""
+        echo "Configure without building"
+    fi
+
     echo ""
     exit 0
 fi
@@ -155,4 +169,6 @@ cmake -S . -B ${_BLD_DIR} \
     ${_CXX_STANDARD_OPTION} \
     ${_DOWNLOAD} ${_FORCE_PATCH} ${_USE_SUDO}
 
-cmake --build ${_BLD_DIR} -j${_JOBS}
+if [ "${_DO_BUILD}" = "true" ]; then
+    cmake --build ${_BLD_DIR} -j${_NJOBS}
+fi

--- a/setup/make-host-deps.sh
+++ b/setup/make-host-deps.sh
@@ -66,7 +66,6 @@ while true ; do
         _BLD_DIR=$2
         shift 2 ;;
     -P|--prefix)
-        echo "Install directory: $2"
         _PREFIX=$2
         shift 2 ;;
     # Options

--- a/setup/make-host-deps.sh
+++ b/setup/make-host-deps.sh
@@ -25,7 +25,7 @@ fi
 
 # Default values
 _BLD_DIR=build
-_CFG_ONLY=false
+_DO_BUILD=true
 _DRY_RUN=false
 _PREFIX=./host-deps
 _NJOBS=8
@@ -35,17 +35,19 @@ print_help() {
     echo ""
     echo "Build host dependency libraries"
     echo ""
-    echo "Options:"
+    echo "Paths:"
     echo "  --build=DIR     -B  Build directory path (Default: ${_BLD_DIR})"
-    echo "  --config            Only perform configuration step (Default: ${_CFG_ONLY})"
+    echo "  --prefix=DIR    -P  Install directory path (Default: ${_PREFIX})"
+    echo ""
+    echo "Options:"
     echo "  --cxx=VERSION       CXX_STANDARD to build dependencies (Default: empty)"
     echo "  --dry-run       -n  Display cmake parameters and exit (Default: false)"
     echo "  --force         -f  Specify -f when patching (Default: false)"
     echo "  --full              Build all dependency libraries (Default: ${_SCOPE})"
     echo "  --jobs=NJOBS    -j  Number of build threads (Default: ${_NJOBS})"
     echo "  --minimal           Build required host dependencies only (Default: ${_SCOPE})"
+    echo "  --no-build          Configure without building"
     echo "  --no-download       Do not download repositories (Default: false)"
-    echo "  --prefix=DIR    -P  Install directory path (Default: ${_PREFIX})"
     echo "  --sudo              Use sudo when installing (Default: false)"
     echo ""
 }
@@ -53,18 +55,21 @@ print_help() {
 # Parse options
 SHORTOPTS=B:P:fhj:n
 LONGOPTS=build:,cxx:,jobs:,prefix:
-LONGOPTS=${LONGOPTS},config,dry-run,force,full,help,minimal,no-download,sudo
+LONGOPTS=${LONGOPTS},dry-run,force,full,help,minimal,no-build,no-download,sudo
 
 eval set -- `getopt -o ${SHORTOPTS} --long ${LONGOPTS} -- "$@"`
 
 while true ; do
     case "$1" in
+    # Paths
     -B|--build)
         _BLD_DIR=$2
         shift 2 ;;
-    --config)
-        _CFG_ONLY=true
-        shift ;;
+    -P|--prefix)
+        echo "Install directory: $2"
+        _PREFIX=$2
+        shift 2 ;;
+    # Options
     --cxx)
         _CXX_STANDARD_OPTION="-DCXX_STANDARD=$2"
         shift 2 ;;
@@ -86,13 +91,12 @@ while true ; do
     --minimal)
         _SCOPE=minimal
         shift ;;
+    --no-build)
+        _DO_BUILD=false
+        shift ;;
     --no-download)
         _DOWNLOAD="-DDOWNLOAD=FALSE"
         shift ;;
-    -P|--prefix)
-        echo "Install directory: $2"
-        _PREFIX=$2
-        shift 2 ;;
     --sudo)
 	_USE_SUDO="-DUSE_SUDO=TRUE"
 	shift ;;
@@ -120,7 +124,7 @@ if [ "${_DRY_RUN}" = "true" ]; then
     [ -n "${_ON_DEMAND}" ] && echo "  ${_ON_DEMAND:2}"
     [ -n "${_USE_SUDO}" ] && echo "  ${_USE_SUDO:2}"
     echo ""
-    if [ "${_CFG_ONLY}" = "true" ]; then
+    if [ "${_DO_BUILD}" = "false" ]; then
         echo "Configure only (${_SCOPE} build)"
     else
         echo "Build options:"
@@ -140,6 +144,6 @@ cmake -S . -B ${_BLD_DIR} \
     ${_CXX_STANDARD_OPTION} \
     ${_ON_DEMAND} ${_DOWNLOAD} ${_FORCE_PATCH} ${_USE_SUDO}
 
-if [ "${_CFG_ONLY}" = "false" ]; then
+if [ "${_DO_BUILD}" = "true" ]; then
     cmake --build ${_BLD_DIR} -j${_NJOBS} ${_TARGET}
 fi


### PR DESCRIPTION
make_all.sh
-----------

- Rename --config option to --no-build.

- Remove --staging option from help text. It is experimental and should not be advertised.

config-cross-recipe.sh
----------------------

- Swap short and long option names in switch statement to make it clearer that the names are alphabetized by long name.

- Address shellcheck issue.

make-cross-ovs.sh
-----------------

- Divide help text into Paths and Options sections.

- Make _DRY_RUN a numeric variable, and rename _JOBS to _NJOBS, for consistency with other helper scripts.

make-cross-deps.sh
------------------

- Divide help text into Paths and Options sections.

- Implement --no-build option.

- Rename _JOBS variable to _NJOBS.

make-host-deps.sh
-----------------

- Divide help text into Paths and Options sections.

- Rename --config option to --no-build.