### PR TITLE
Update TLS generate-certs default destination location

### DIFF
--- a/docs/guides/security/using-tls-certificates.md
+++ b/docs/guides/security/using-tls-certificates.md
@@ -8,16 +8,16 @@ certificates for running infrap4d in secure mode.
 Note: Here target name can be `dpdk` or `es2k`.
 
 Review the files `ca.conf` and `grpc-client.conf` available under
-`/usr/share/stratum/<target_name>` to verify that the configuration settings are
+`/usr/share/stratum/` to verify that the configuration settings are
 as desired.
 
-Run the `generate-certs.sh` available under `/usr/share/stratum/<target_name>`.
+Run the `generate-certs.sh` available under `/usr/share/stratum/`.
 
 Note: Here `IP` is the IP address of gRPC server.
 For example, `IP` can be `127.0.0.1`, `5.5.5.5` or `localhost`.
 
 ```bash
-cd /usr/share/stratum/<target_name>/
+cd /usr/share/stratum/
 
 COMMON_NAME=<IP> ./generate-certs.sh
 ```

--- a/scripts/common/copy_config_files.sh.in
+++ b/scripts/common/copy_config_files.sh.in
@@ -30,15 +30,16 @@ sudo mkdir -p /var/log/stratum/
 
 SOURCE_DIR=${P4CP_INSTALL}/share/stratum/@TARGET_NAME@
 TARGET_DIR=/usr/share/stratum/@TARGET_NAME@
+TLS_CERTS_DIR=/usr/share/stratum
 
 sudo mkdir -p ${TARGET_DIR}
 sudo cp ${SOURCE_DIR}/@TARGET_NAME@_port_config.pb.txt ${TARGET_DIR}/
 sudo cp ${SOURCE_DIR}/@TARGET_NAME@_skip_p4.conf ${TARGET_DIR}/
 
 #... Install files required for TLS certificate generation ...#
-sudo cp ${SOURCE_DIR}/ca.conf ${TARGET_DIR}/
-sudo cp ${SOURCE_DIR}/grpc-client.conf ${TARGET_DIR}/
-sudo cp ${P4CP_INSTALL}/sbin/generate-certs.sh ${TARGET_DIR}/
+sudo cp ${SOURCE_DIR}/ca.conf ${TLS_CERTS_DIR}/
+sudo cp ${SOURCE_DIR}/grpc-client.conf ${TLS_CERTS_DIR}/
+sudo cp ${P4CP_INSTALL}/sbin/generate-certs.sh ${TLS_CERTS_DIR}/
 
 sudo mkdir /usr/share/target_sys/
 sudo cp $SDE_INSTALL/share/target_sys/zlog-cfg /usr/share/target_sys/


### PR DESCRIPTION
A bug was raised where generates-certs.sh script was present in `/usr/share/stratum/es2k` folder and executing the script results in certs in `/usr/share/stratum/es2k/certs` location, while the default location that `infrap4d` uses is `/usr/share/stratum/certs`.

Updating the use expected default location + documentation change to reflect the changes.