### PR TITLE
Restructure ES2K build instructions

### DIFF
--- a/docs/guides/building-for-es2k-acc.rst
+++ b/docs/guides/building-for-es2k-acc.rst
@@ -1,0 +1,15 @@
+.. Copyright 2023 Intel Corporation
+   SPDX-License-Identifier: Apache-2.0
+
+=========================
+Building for the ES2K ACC
+=========================
+
+.. toctree::
+   :maxdepth: 1
+
+   /guides/es2k/installing-acc-sdk
+   /guides/es2k/defining-acc-environment
+   Building Host Dependencies </guides/deps/building-stratum-deps>
+   Building ACC Target Dependencies </guides/deps/building-acc-stratum-deps>
+   Building P4 Control Plane </guides/es2k/building-acc-p4cp>

--- a/docs/guides/building-for-es2k-acc.rst
+++ b/docs/guides/building-for-es2k-acc.rst
@@ -9,7 +9,7 @@ Building for the ES2K ACC
    :maxdepth: 1
 
    /guides/es2k/installing-acc-sdk
-   /guides/es2k/defining-acc-environment
-   Building Host Dependencies </guides/deps/building-stratum-deps>
-   Building ACC Target Dependencies </guides/deps/building-acc-stratum-deps>
+   Defining the build environment </guides/es2k/defining-acc-environment>
+   Building host dependencies </guides/deps/building-stratum-deps>
+   Building ACC target dependencies </guides/deps/building-acc-stratum-deps>
    Building P4 Control Plane </guides/es2k/building-acc-p4cp>

--- a/docs/guides/building-for-es2k-host.rst
+++ b/docs/guides/building-for-es2k-host.rst
@@ -1,0 +1,12 @@
+.. Copyright 2023 Intel Corporation
+   SPDX-License-Identifier: Apache-2.0
+
+==========================
+Building for the ES2K Host
+==========================
+
+.. toctree::
+   :maxdepth: 1
+
+   /guides/setup/es2k-setup-guide
+   /guides/deps/building-stratum-deps

--- a/docs/guides/setup/es2k-setup-guide.md
+++ b/docs/guides/setup/es2k-setup-guide.md
@@ -6,7 +6,8 @@ This document explains how to install, build, and run P4 Control Plane
 for the ES2K target.
 
 P4 Control Plane can be built to run on an x86 host processor or the ARM
-Compute Complex (ACC). The instructions here are for the host processor.
+Compute Complex (ACC). These instructions are for the host processor.
+For the ACC, see [Building for the ES2K ACC](/guides/building-for-es2k-acc).
 
 ## Setup
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,11 +21,8 @@ P4 Control Plane User Guide
    :maxdepth: 1
    :caption: Building
 
-   guides/deps/building-stratum-deps
-   guides/deps/building-acc-stratum-deps
-   guides/es2k/installing-acc-sdk
-   guides/es2k/defining-acc-environment
-   guides/es2k/building-acc-p4cp
+   guides/building-for-es2k-host
+   guides/building-for-es2k-acc
    scripts/helper-scripts
 
 .. toctree::


### PR DESCRIPTION
- Create separate index pages for building for the es2k host and building for the es2k acc.
- Add a link on the ES2K Setup Guide to the Building for the ES2K ACC page.