### PR TITLE
Let cmake supply default build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,6 @@
 # Version 3.15 is the baseline for P4 Control Plane.
 cmake_minimum_required(VERSION 3.15)
 
-# CMAKE_BUILD_TYPE must be set before the first project() command.
-set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Type of build to perform")
-
 project(networking-recipe VERSION 23.07 LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -19,9 +16,17 @@ include(CTest)
 include(FindPkgConfig)
 include(GNUInstallDirs)
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the build type"
+      FORCE)
+endif()
+
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug;MinSizeRel;Release;RelWithDebInfo")
+
+cmake_print_variables(CMAKE_STAGING_PREFIX)
 cmake_print_variables(CMAKE_SYSROOT)
 cmake_print_variables(CMAKE_TOOLCHAIN_FILE)
-cmake_print_variables(CMAKE_STAGING_PREFIX)
 
 #############################
 # Symbolic path definitions #

--- a/docs/scripts/config-cross-recipe.rst
+++ b/docs/scripts/config-cross-recipe.rst
@@ -53,8 +53,8 @@ General
 ``--help``, ``-h``
   Displays usage information and exits.
 
-Paths
------
+Host paths
+----------
 
 ``--build=BLDDIR``, ``-B BLDDIR``
   Directory that CMake will use to perform the build.
@@ -65,16 +65,6 @@ Paths
   cross-compiled builds.
   Defaults to ``build``.
 
-``--deps=DEPS``, ``-D DEPS`` *(see note)*
-  Directory in which the Stratum dependencies for the runtime system
-  are installed.
-
-  P4 Control Plane will be linked with these libraries.
-  Supplies the value of the ``DEPEND_INSTALL_DIR`` listfile variable.
-  Defaults to the value of the ``DEPEND_INSTALL`` environment variable,
-  if defined.
-  Otherwise, defaults to ``//opt/deps``.
-
 ``--host=HOST``, ``-H HOST``
   Directory in which the Stratum dependencies for the development
   system are installed.
@@ -84,6 +74,26 @@ Paths
   Defaults to the value of the ``HOST_INSTALL`` environment variable,
   if defined.
   Otherwise, defaults to ``setup/hostdeps``.
+
+``--toolchain=FILE``, ``-T FILE``
+  Path to the CMake toolchain file.
+
+  Specifies the value of the ``CMAKE_TOOLCHAIN_FILE`` variable.
+  Defaults to the value of the ``CMAKE_TOOLCHAIN_FILE`` environment
+  variable.
+
+Target paths
+------------
+
+``--deps=DEPS``, ``-D DEPS`` *(see note)*
+  Directory in which the Stratum dependencies for the runtime system
+  are installed.
+
+  P4 Control Plane will be linked with these libraries.
+  Supplies the value of the ``DEPEND_INSTALL_DIR`` listfile variable.
+  Defaults to the value of the ``DEPEND_INSTALL`` environment variable,
+  if defined.
+  Otherwise, defaults to ``//opt/deps``.
 
 ``--ovs=OVS``, ``-O OVS`` *(see note)*
   Directory in which Open vSwitch is installed.
@@ -113,13 +123,6 @@ Paths
   Defaults to the value of the ``SDE_INSTALL`` environment variable,
   if defined.
   Otherwise, defaults to ``//opt/p4sde``.
-
-``--toolchain=FILE``, ``-T FILE``
-  Path to the CMake toolchain file.
-
-  Specifies the value of the ``CMAKE_TOOLCHAIN_FILE`` variable.
-  Defaults to the value of the ``CMAKE_TOOLCHAIN_FILE`` environment
-  variable.
 
 .. note::
   ``//`` at the beginning of the directory path will be replaced with

--- a/ovs/CMakeLists.txt
+++ b/ovs/CMakeLists.txt
@@ -16,6 +16,18 @@ include(GNUInstallDirs)
 option(P4OVS "Build OVS with P4Runtime support" OFF)
 option(WITH_RUNDIRS "Build with OVS runtime directories" OFF)
 
+##############
+# Build type #
+##############
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
+        "Choose the build type" FORCE)
+endif()
+
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug;MinSizeRel;Release;RelWithDebInfo")
+
 ####################
 # Path definitions #
 ####################

--- a/scripts/es2k/config-cross-recipe.sh
+++ b/scripts/es2k/config-cross-recipe.sh
@@ -24,7 +24,6 @@ _SYSROOT=${SDKTARGETSYSROOT}
 # Default values #
 ##################
 
-_BLD_TYPE=RelWithDebInfo
 _DEPS_DIR="${DEPEND_INSTALL:-//opt/deps}"
 _HOST_DIR="${HOST_INSTALL:-setup/host-deps}"
 _OVS_DIR="${OVS_INSTALL:-//opt/ovs}"
@@ -41,20 +40,24 @@ _DRY_RUN=0
 
 print_help() {
     echo ""
-    echo "Configure P4 Control Plane build"
+    echo "Configure P4 Control Plane build for ACC"
     echo ""
-    echo "Paths:"
+    echo "General:"
+    echo "  --dry-run        -n  Display cmake parameters and exit"
+    echo "  --help           -h  Display help text and exit"
+    echo ""
+    echo "Host paths:"
     echo "  --build=DIR      -B  Build directory path [${_BLD_DIR}]"
+    echo "  --host=DIR       -H  Host dependencies directory [${_HOST_DIR}]"
+    echo "  --toolchain=FILE -T  CMake toolchain file"
+    echo ""
+    echo "Target paths:"
     echo "  --deps=DIR*      -D  Target dependencies directory [${_DEPS_DIR}]"
-    echo "  --host=DIR*      -H  Host dependencies directory [${_HOST_DIR}]"
     echo "  --ovs=DIR*       -O  OVS install directory [${_OVS_DIR}]"
     echo "  --prefix=DIR*    -P  Install directory prefix [${_PREFIX}]"
     echo "  --sde=DIR*       -S  SDE install directory [${_SDE_DIR}]"
-    echo "  --toolchain=FILE -T  CMake toolchain file"
     echo ""
     echo "Options:"
-    echo "  --dry-run        -n  Display cmake parameter values and exit"
-    echo "  --help           -h  Display this help text"
     echo "  --no-krnlmon         Exclude Kernel Monitor"
     echo "  --no-ovs             Exclude OVS support"
     echo ""
@@ -77,7 +80,6 @@ print_help() {
 
 print_cmake_params() {
     echo ""
-    echo "CMAKE_BUILD_TYPE=${_BLD_TYPE}"
     echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
     echo "CMAKE_TOOLCHAIN_FILE=${_TOOLFILE}"
     echo "DEPEND_INSTALL_DIR=${_DEPS_DIR}"
@@ -160,7 +162,6 @@ done
 [ "${_PREFIX:0:2}" = "//" ] && _PREFIX=${_SYSROOT}/${_PREFIX:2}
 [ "${_SDE_DIR:0:2}" = "//" ] && _SDE_DIR=${_SYSROOT}/${_SDE_DIR:2}
 
-# Expand WITH_KRNLMON and WITH_OVSP4RT if not empty
 [ -n "${_WITH_KRNLMON}" ] && _WITH_KRNLMON=-DWITH_KRNLMON=${_WITH_KRNLMON}
 [ -n "${_WITH_OVSP4RT}" ] && _WITH_OVSP4RT=-DWITH_OVSP4RT=${_WITH_OVSP4RT}
 
@@ -176,9 +177,8 @@ fi
 
 rm -fr "${_BLD_DIR}"
 
- # shellcheck disable=SC2086
- cmake -S . -B "${_BLD_DIR}" \
-    -DCMAKE_BUILD_TYPE=${_BLD_TYPE} \
+# shellcheck disable=SC2086
+cmake -S . -B "${_BLD_DIR}" \
     -DCMAKE_INSTALL_PREFIX="${_PREFIX}" \
     -DCMAKE_TOOLCHAIN_FILE="${_TOOLFILE}" \
     -DDEPEND_INSTALL_DIR="${_DEPS_DIR}" \

--- a/scripts/es2k/make-cross-ovs.sh
+++ b/scripts/es2k/make-cross-ovs.sh
@@ -26,7 +26,6 @@ _SYSROOT=${SDKTARGETSYSROOT}
 ##################
 
 _BLD_DIR=ovs/build
-_BLD_TYPE=RelWithDebInfo
 _DRY_RUN=0
 _NJOBS=8
 _PREFIX=//opt/ovs
@@ -65,7 +64,6 @@ print_help() {
 
 print_cmake_params() {
     echo ""
-    echo "CMAKE_BUILD_TYPE=${_BLD_TYPE}"
     echo "CMAKE_INSTALL_PREFIX=${_PREFIX}"
     echo "CMAKE_TOOLCHAIN_FILE=${_TOOLFILE}"
     echo "JOBS=${_NJOBS}"
@@ -136,7 +134,6 @@ fi
 rm -fr "${_BLD_DIR}"
 
 cmake -S ovs -B "${_BLD_DIR}" \
-    -DCMAKE_BUILD_TYPE=${_BLD_TYPE} \
     -DCMAKE_INSTALL_PREFIX="${_PREFIX}" \
     -DCMAKE_TOOLCHAIN_FILE="${_TOOLFILE}" \
     -DP4OVS=TRUE


### PR DESCRIPTION
- In CMakeLists.txt, define default CMAKE_BUILD_TYPE after project() command. Provide list of valid build types for user interface tools.

- In make-all.sh, don't define CMAKE_BUILD_TYPE if type is not explicitly specified.

- In make-cross-ovs.sh and config-cross-recipe.sh, don't define default CMAKE_BUILD_TYPE.

- Separate Path options in the config-cross-recipe.sh help text and user guide into Host and Target categories.