### PR TITLE
Adding documentation for OpenSSL upgrade

### DIFF
--- a/docs/guides/security/openssl-guide.md
+++ b/docs/guides/security/openssl-guide.md
@@ -1,0 +1,25 @@
+# OpenSSL Guide
+
+This document provides information about supported OpenSSL versions and
+security details that you need to consider.
+
+OpenSSL is a package dependency as infrap4d uses the library for gRPC.
+
+## End of Life for OpenSSL 1.1.1
+
+OpenSSL 1.1.1 has reached End of Life (EOL) in September 2023. 
+
+It is highly recommended that you upgrade OpenSSL from 1.1.1x to OpenSSL 3.x.
+The official migration guide is [available here](https://www.openssl.org/docs/man3.0/man7/migration_guide.html).
+
+Starting Fedora 37, Ubuntu 22.04 and Rocky Linux 9.0 OpenSSL 3.0.x comes
+standard and requires no further action.
+
+Older distributions of Linux systems download and install OpenSSL 1.1.1 when
+running `yum install` or `apt install` commands. If you are using these
+operating systems, you will need to upgrade the installed package (either find
+an RPM to install upgrade or compile from source).
+
+Note that infrap4d will compile and run normally with OpenSSL 1.1.1 since
+OpenSSL 3.0 is backwards-compatible. In the interest of best security practices
+and future security risks, we still recommend upgrading to OpenSSL 3.0.

--- a/docs/guides/security/openssl-guide.md
+++ b/docs/guides/security/openssl-guide.md
@@ -3,7 +3,7 @@
 This document provides information about supported OpenSSL versions and
 security details that you need to consider.
 
-OpenSSL is a package dependency as infrap4d uses the library for gRPC.
+OpenSSL is a package dependency, as infrap4d uses the library for gRPC.
 
 ## End of Life for OpenSSL 1.1.1
 

--- a/docs/guides/security/openssl-guide.md
+++ b/docs/guides/security/openssl-guide.md
@@ -10,16 +10,17 @@ OpenSSL is a package dependency, as infrap4d uses the library for gRPC.
 OpenSSL 1.1.1 has reached End of Life (EOL) in September 2023. 
 
 It is highly recommended that you upgrade OpenSSL from 1.1.1x to OpenSSL 3.x.
-The official migration guide is [available here](https://www.openssl.org/docs/man3.0/man7/migration_guide.html).
+See the [official migration guide](https://www.openssl.org/docs/man3.0/man7/migration_guide.html)
+for more information.
 
-Starting Fedora 37, Ubuntu 22.04 and Rocky Linux 9.0 OpenSSL 3.0.x comes
+Beginning with Fedora 37, Ubuntu 22.04, and Rocky Linux 9.0, OpenSSL 3.0.x comes
 standard and requires no further action.
 
 Older distributions of Linux systems download and install OpenSSL 1.1.1 when
-running `yum install` or `apt install` commands. If you are using these
-operating systems, you will need to upgrade the installed package (either find
-an RPM to install upgrade or compile from source).
+you run the `yum install` or `apt install` command. If you are using one of these
+distributions, you will need to find an RPM or DEB package to install
+or build OpenSSL 3.x from source.
 
-Note that infrap4d will compile and run normally with OpenSSL 1.1.1 since
-OpenSSL 3.0 is backwards-compatible. In the interest of best security practices
-and future security risks, we still recommend upgrading to OpenSSL 3.0.
+Note that infrap4d will compile and run normally with OpenSSL 1.1.1, since
+OpenSSL 3.0 is backward compatible. In the interest of following best security practices
+and avoiding future security issues, we recommend upgrading to OpenSSL 3.0.

--- a/docs/guides/setup/dpdk-setup-guide.md
+++ b/docs/guides/setup/dpdk-setup-guide.md
@@ -17,6 +17,9 @@ For build instructions, see [P4 SDE Readme](https://github.com/p4lang/p4-dpdk-ta
 
 ### Install basic utilities
 
+Note: See [OpenSSL security guide](/guides/security/openssl-guide.md)
+for OpenSSL version and EOL information.
+
 ```bash
 For Fedora distro: yum install libatomic libnl3-devel openssl
 For Ubuntu distro: apt install libatomic1 libnl-route-3-dev openssl

--- a/docs/guides/setup/dpdk-setup-guide.md
+++ b/docs/guides/setup/dpdk-setup-guide.md
@@ -20,6 +20,8 @@ For build instructions, see [P4 SDE Readme](https://github.com/p4lang/p4-dpdk-ta
 See the [OpenSSL security guide](/guides/security/openssl-guide.md)
 for OpenSSL version and EOL information.
 
+---
+
 ```bash
 For Fedora distro: yum install libatomic libnl3-devel openssl
 For Ubuntu distro: apt install libatomic1 libnl-route-3-dev openssl

--- a/docs/guides/setup/dpdk-setup-guide.md
+++ b/docs/guides/setup/dpdk-setup-guide.md
@@ -17,7 +17,7 @@ For build instructions, see [P4 SDE Readme](https://github.com/p4lang/p4-dpdk-ta
 
 ### Install basic utilities
 
-Note: See [OpenSSL security guide](/guides/security/openssl-guide.md)
+See the [OpenSSL security guide](/guides/security/openssl-guide.md)
 for OpenSSL version and EOL information.
 
 ```bash

--- a/docs/guides/setup/es2k-setup-guide.md
+++ b/docs/guides/setup/es2k-setup-guide.md
@@ -13,6 +13,9 @@ For the ACC, see [Building for the ES2K ACC](/guides/building-for-es2k-acc).
 
 ### Install basic utilities
 
+Note: See [OpenSSL security guide](/guides/security/openssl-guide.md)
+for OpenSSL version and EOL information.
+
 For a Fedora system:
 
 ```bash

--- a/docs/guides/setup/es2k-setup-guide.md
+++ b/docs/guides/setup/es2k-setup-guide.md
@@ -16,6 +16,8 @@ For the ACC, see [Building for the ES2K ACC](/guides/building-for-es2k-acc).
 See the [OpenSSL security guide](/guides/security/openssl-guide.md)
 for OpenSSL version and EOL information.
 
+---
+
 For a Fedora system:
 
 ```bash

--- a/docs/guides/setup/es2k-setup-guide.md
+++ b/docs/guides/setup/es2k-setup-guide.md
@@ -13,7 +13,7 @@ For the ACC, see [Building for the ES2K ACC](/guides/building-for-es2k-acc).
 
 ### Install basic utilities
 
-Note: See [OpenSSL security guide](/guides/security/openssl-guide.md)
+See the [OpenSSL security guide](/guides/security/openssl-guide.md)
 for OpenSSL version and EOL information.
 
 For a Fedora system:

--- a/docs/guides/setup/tofino-setup-guide.md
+++ b/docs/guides/setup/tofino-setup-guide.md
@@ -60,6 +60,9 @@ docker exec -it infrap4d bash
 
 ### Install basic utilities
 
+Note: See [OpenSSL security guide](/guides/security/openssl-guide.md)
+for OpenSSL version and EOL information.
+
 ```bash
 apt-get update
 apt-get install sudo git cmake autoconf gcc g++ libtool python3 python3-dev python3-distutils iproute2 libssl-dev

--- a/docs/guides/setup/tofino-setup-guide.md
+++ b/docs/guides/setup/tofino-setup-guide.md
@@ -63,6 +63,8 @@ docker exec -it infrap4d bash
 See the [OpenSSL security guide](/guides/security/openssl-guide.md)
 for OpenSSL version and EOL information.
 
+---
+
 ```bash
 apt-get update
 apt-get install sudo git cmake autoconf gcc g++ libtool python3 python3-dev python3-distutils iproute2 libssl-dev

--- a/docs/guides/setup/tofino-setup-guide.md
+++ b/docs/guides/setup/tofino-setup-guide.md
@@ -60,7 +60,7 @@ docker exec -it infrap4d bash
 
 ### Install basic utilities
 
-Note: See [OpenSSL security guide](/guides/security/openssl-guide.md)
+See the [OpenSSL security guide](/guides/security/openssl-guide.md)
 for OpenSSL version and EOL information.
 
 ```bash

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@ P4 Control Plane User Guide
 
    guides/security/security-guide
    guides/security/using-tls-certificates
+   guides/security/openssl-guide
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Documentation update for OpenSSL from 1.1.1 to 3.0.

No functional changes are required in software since libs are backwards-compatible