### PR TITLE
Edit dpdk-linux-networking document

### DIFF
--- a/docs/apps/lnw/dpdk/dpdk-linux-networking.md
+++ b/docs/apps/lnw/dpdk/dpdk-linux-networking.md
@@ -28,11 +28,17 @@ This document explains how to run Linux networking scenario.
 
 Notes about topology:
 
-- VHOST ports, TAP ports, Physical LINK ports are created by GNMI CLI and LINK port is bound to the DPDK target.
-- VLAN 1, VLAN 2, .... VLAN N created using Linux commands and are on top a TAP port. These VLAN ports should be equal to number of VM's that are spawned.
-- br-int, VxLAN0 ports are created using ovs-vsctl command provided by the networking recipe and all the VLAN ports are attached to br-int using ovs-vsctl command.
+- VHOST ports, TAP ports, Physical LINK ports are created by the GNMI CLI,
+  and LINK port is bound to the DPDK target.
+- VLAN 1, VLAN 2, .... VLAN N created using Linux commands and are on top of a
+  TAP port. These VLAN ports should be equal to number of VM's that are spawned.
+- br-int, VxLAN0 ports are created using ovs-vsctl command provided by the
+  networking recipe and all the VLAN ports are attached to br-int using the
+  ovs-vsctl command.
 
-System under test will have above topology running the networking recipe. Link Partner can have either the networking recipe or legacy OVS or kernel VxLAN. Note the limitations below before setting up the topology.
+System under test will have above topology running the networking recipe.
+Link Partner can have either the networking recipe or legacy OVS or kernel
+VxLAN.  Note the limitations below before setting up the topology.
 
 ## Create P4 artifacts
 
@@ -67,25 +73,6 @@ System under test will have above topology running the networking recipe. Link P
   tdi_pipeline_builder --p4c_conf_file=lnw.conf --bf_pipeline_config_binary_file=lnw.pb.bin
   ```
 
-## Limitations
-
-Current SAI enablement for the networking recipe has following limitations:
-
-- Always all VHOST user ports need to be configured first and only then TAP ports/physical ports.
-- TAP port created for the corresponding link port should be created using
-  "gnmi-ctl control port creation got the link port". For example,
-
-  ```bash
-  gnmi-ctl set "device:physical-device,name:PORT0,pipeline-name:pipe,mempool-name:MEMPOOL0,control-port:TAP1,mtu:1500,pci-bdf:0000:18:00.0,packet-dir=network,port-type:link
-  ```
-
-- All VLAN interfaces created on top of TAP ports, should always be in lowercase format "vlan+vlan_id"
-Ex: vlan1, vlan2, vlan3, ... vlan4094
-- br-int port, vxlan0 port and adding vlan ports to br-int need to be done after loading the pipeline.
-- VxLAN destination port should always be standard port. i.e., 4789. (limitation by p4 parser)
-- Only VNI 0 is supported.
-- We are not supporting any ofproto rules which would not allow for FDB learning on OVS.
-
 ## Creating the topology
 
 The [gnmi-ctl](/clients/gnmi-ctl) and [p4rt-ctl](/clients/p4rt-ctl) utilities
@@ -101,7 +88,7 @@ modprobe uio
 modprobe vfio-pci
 ```
 
-Bind the devices to DPDK using dpdk-devbind.py script:
+Bind the devices to DPDK using the dpdk-devbind.py script:
 
 ```bash
 cd $SDE_INSTALL/bin
@@ -116,7 +103,7 @@ For example,
 
 PCI-BDF can be obtained using the lspci command.
 Check if the device is bound correctly using `./dpdk-devbind.py -s`.
-(Refer to the section "Network devices using DPDK-compatible driver".)
+<!-- (See the section "Network devices using DPDK-compatible driver") -->
 
 ### 2. Export environment variables and start infrap4d
 
@@ -142,7 +129,9 @@ gnmi-ctl set "device:physical-device,name:PORT0,control-port:TAP1,pci-bdf:0000:1
 gnmi-ctl set "device:physical-device,name:PORT1,control-port:TAP2,pci-bdf:0000:18:00.1,packet-dir:network,port-type:link"
 ```
 
-Note: Specify the pci-bdf of the devices bound to user-space in step 1. Corresponding control port for physical link port will be created if control port attribute is specified.
+Note: Specify the pci-bdf of the devices bound to user-space in step 1.
+Corresponding control port for physical link port will be created if
+control port attribute is specified.
 
 ### 5. Create two TAP ports
 
@@ -259,7 +248,8 @@ sudo $P4CP_INSTALL/bin/ovs-vsctl add-port br-int vxlan1 --\
      options:remote_ip=30.1.1.1 options:dst_port=4789
 ```
 
-Note: VXLAN destination port should always be standard port, i.e. 4789. (limitation of p4 parser)
+Note: VXLAN destination port should always be standard port, i.e. 4789.
+(limitation of p4 parser)
 
 ### 11. Configure VLAN ports on TAP0 and add them to br-int
 
@@ -272,19 +262,24 @@ ip link set dev vlan1 up
 ip link set dev vlan2 up
 ```
 
-Note: All VLAN interfaces should be created on top of TAP ports, and should
-always be in lowercase format "vlan+vlan_id. (Eg: vlan1, vlan2, vlan3 …. vlan4094)
+VLAN interfaces should be created on top of TAP ports, and should always be
+in lowercase format "vlan+vlan_id".
 
 ### 12. Configure rules to push and pop VLAN from vhost 0 and 1 ports to TAP0 port (vhost-user and vlan port mapping)
 
-Note: Port number used in p4rt-ctl commands are target datapath indexes (unique identifier for each port) which can be queried using following commands below. With current SDE implementation, both tdi-portin-id and tdi-portout-id are the same.
+Note: Port numbers used in p4rt-ctl commands are target datapath indexes
+(unique identifier for each port) which can be queried using the
+commands below. In the current SDE implementation, tdi-portin-id and
+tdi-portout-id are the same.
 
 ```bash
 gnmi-ctl get "device:virtual-device,name:net_vhost0,tdi-portin-id"
 gnmi-ctl get "device:virtual-device,name:net_vhost0,tdi-portout-id"
 ```
 
-Target DP index of control TAP port will be Target DP index of corresponding physical port + 1. If the ports are created in the order mentioned in the above step, target datapath indexes will be:
+Target DP index of control TAP port will be Target DP index of the
+corresponding physical port + 1.  If the ports are created in the order
+specified in the above step, target datapath indexes will be:
 
 | Port name          | DP index |
 | ------------------ | :------: |
@@ -297,44 +292,50 @@ Target DP index of control TAP port will be Target DP index of corresponding phy
 | TAP0               | 6        |
 | TAP3               | 7        |
 
-For any tx control packet from VM1 (TDP 0), pipeline should add a VLAN tag 1 and send it to TAP0 port (TDP 6):
+For any tx control packet from VM1 (TDP 0), pipeline should add a VLAN tag
+1 and send it to TAP0 port (TDP 6):
 
 ```bash
 p4rt-ctl add-entry br0 linux_networking_control.handle_tx_control_pkts_table \
   "istd.input_port=0,action=linux_networking_control.push_vlan_fwd(6,1)"
 ```
 
-For any tx control packet from VM2 (TDP 1), pipeline should add a VLAN tag 2 and send it to TAP0 port (TDP 6):
+For any tx control packet from VM2 (TDP 1), pipeline should add a VLAN tag
+2 and send it to TAP0 port (TDP 6):
 
 ```bash
 p4rt-ctl add-entry br0 linux_networking_control.handle_tx_control_pkts_table \
   "istd.input_port=1,action=linux_networking_control.push_vlan_fwd(6,2)"
 ```
 
-For any tx control packet from TAP0 port (TDP 6) with VLAN tag 1, pipeline should pop the VLAN tag and send it to VM1 (TDP 0):
+For any tx control packet from TAP0 port (TDP 6) with VLAN tag 1, pipeline
+should pop the VLAN tag and send it to VM1 (TDP 0):
 
 ```bash
 p4rt-ctl add-entry br0 linux_networking_control.handle_tx_control_vlan_pkts_table \
   "istd.input_port=6,local_metadata.vlan_id=1,action=linux_networking_control.pop_vlan_fwd(0)"
 ```
 
-For any tx control packet from TAP0 port (TDP 6) with VLAN tag 2, pipeline should pop the VLAN tag and send it to VM2 (TDP 1):
+For any tx control packet from TAP0 port (TDP 6) with VLAN tag 2, pipeline
+should pop the VLAN tag and send it to VM2 (TDP 1):
 
 ```bash
 p4rt-ctl add-entry br0 linux_networking_control.handle_tx_control_vlan_pkts_table \
   "istd.input_port=6,local_metadata.vlan_id=2,action=linux_networking_control.pop_vlan_fwd(1)"
 ```
 
-### 13. Configure rules for control packets coming in and out of physical port
+### 13. Configure rules for control packets to or from physical port
 
-Any rx control packet from phy port0 (TDP 2) should be sent to corresponding control port TAP1 (TDP 3):
+Any rx control packet from phy port0 (TDP 2) should be sent to corresponding
+control port TAP1 (TDP 3):
 
 ```bash
 p4rt-ctl add-entry br0 linux_networking_control.handle_rx_control_pkts_table \
   "istd.input_port=2,action=linux_networking_control.set_control_dest(3)"
 ```
 
-Any rx control packet from phy port1 (TDP 4) should be sent to corresponding control port TAP2 (TDP 5):
+Any rx control packet from phy port1 (TDP 4) should be sent to corresponding
+control port TAP2 (TDP 5):
 
 ```bash
 p4rt-ctl add-entry br0 linux_networking_control.handle_rx_control_pkts_table \
@@ -369,32 +370,32 @@ ip route add 30.1.1.1 nexthop via 50.1.1.2 dev TAP1
 
 Install FRR:
 
-- Install FRR via default package manager, like "apt install frr" for Ubuntu /"dnf install frr" for Fedora.
+- Install FRR via default package manager, like `apt install frr` for Ubuntu
+  or `dnf install frr` for Fedora.
 
-- If not, see official FRR documentation available at
-  <https://docs.frrouting.org/en/latest/installation.html>
+- If not, see the [official FRR documentation](https://docs.frrouting.org/en/latest/installation.html)
   and install according to your distribution.
 
 Configure FRR:
 
 - Modify /etc/frr/daemons to enable bgpd daemon
-- Restart FRR service. systemctl restart frr
-- Start VTYSH process, which is a CLI provided by FRR for user configurations.
-- Set the following configuration on the DUT (host1) for single-path scenario.
+- Restart FRR service: `systemctl restart frr`
+- Start VTYSH process, which is a CLI provided by FRR for user configuration
+- Set the following configuration on the DUT (host1) for single-path scenario:
 
   ```bash
   interface TAP1
   ip address 50.1.1.1/24
   exit
-    !
+  !
   interface TEP1
   ip address 40.1.1.1/24
   exit
-    !
+  !
   router bgp 65000
   bgp router-id 40.1.1.1
   neighbor 50.1.1.2 remote-as 65000
-    !
+  !
   address-family ipv4 unicast
     network 40.1.1.0/24
   exit-address-family
@@ -412,3 +413,22 @@ DUT (host1) and also route learnt on the kernel.
 - Ping between VM's on the same host
 - Underlay ping
 - Overlay ping: Ping between VM's on different hosts
+
+## Limitations
+
+Current SAI enablement for the networking recipe has following limitations:
+
+- Always all VHOST user ports need to be configured first and only then TAP ports/physical ports.
+- TAP port created for the corresponding link port should be created using
+  "gnmi-ctl control port creation got the link port". For example,
+
+  ```bash
+  gnmi-ctl set "device:physical-device,name:PORT0,pipeline-name:pipe,mempool-name:MEMPOOL0,control-port:TAP1,mtu:1500,pci-bdf:0000:18:00.0,packet-dir=network,port-type:link
+  ```
+
+- All VLAN interfaces created on top of TAP ports, should always be in lowercase format "vlan+vlan_id"
+Ex: vlan1, vlan2, vlan3, ... vlan4094
+- br-int port, vxlan0 port and adding vlan ports to br-int need to be done after loading the pipeline.
+- VxLAN destination port should always be standard port. i.e., 4789. (limitation by p4 parser)
+- Only VNI 0 is supported.
+- We are not supporting any ofproto rules which would not allow for FDB learning on OVS.


### PR DESCRIPTION
- Reflow overly long text lines.
- Continue long command lines.
- Simplify/repair indentation.
- Move Limitations to end of document.