### PR TITLE
Fix cmake configuration error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,9 @@ cmake_print_variables(CMAKE_PREFIX_PATH)
 # External packages #
 #####################
 
-find_package(absl REQUIRED)
+find_package(absl CONFIG REQUIRED)
+set(GFLAGS_USE_TARGET_NAMESPACE TRUE)
+find_package(gflags CONFIG REQUIRED)
 
 if(DPDK_TARGET)
     include(dpdk-driver)


### PR DESCRIPTION
- As the result of the most recent changes, the cmake configuration step fails because the gflags::gflags_shared target is undefined. Address this by finding the gflags package in the top-level cmake listfile.