### PR TITLE
Canonicalize infrap4d source files

### DIFF
--- a/infrap4d/daemon/daemon.c
+++ b/infrap4d/daemon/daemon.c
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 #include "daemon.h"
+
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <unistd.h>
-#include <assert.h>
 #include <stdio.h>
+#include <unistd.h>
 
 /* For each of the standard file descriptors, whether to replace it by
  * /dev/null (if false) or keep it for the daemon to use (if true). */
@@ -31,49 +32,41 @@ static bool infrap4d_save_fds[3];
  * redirect stdout or stderr to a file, in which case it is desirable to keep
  * these file descriptors.  This function, therefore, disables replacing 'fd'
  * by /dev/null when the daemon detaches. */
-void
-daemon_save_fd(int fd)
-{
-    assert(fd == STDIN_FILENO ||
-           fd == STDOUT_FILENO ||
-           fd == STDERR_FILENO);
-    infrap4d_save_fds[fd] = true;
+void daemon_save_fd(int fd) {
+  assert(fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO);
+  infrap4d_save_fds[fd] = true;
 }
 
 /* Returns a readable and writable fd for /dev/null, if successful, otherwise
  * a negative errno value.  The caller must not close the returned fd (because
  * the same fd will be handed out to subsequent callers). */
-static int
-get_null_fd(void)
-{
-    static int null_fd;
-    char *device = "/dev/null";
+static int get_null_fd(void) {
+  static int null_fd;
+  char* device = "/dev/null";
 
-    if (!null_fd) {
-        null_fd = open(device, O_RDWR);
-        if (null_fd < 0) {
-            int error = errno;
-            null_fd = -error;
-        }
+  if (!null_fd) {
+    null_fd = open(device, O_RDWR);
+    if (null_fd < 0) {
+      int error = errno;
+      null_fd = -error;
     }
+  }
 
-    return null_fd;
+  return null_fd;
 }
 
 /* Close standard file descriptors (except any that the client has requested we
  * leave open by calling daemon_save_fd()).  If we're started from e.g. an SSH
  * session, then this keeps us from holding that session open artificially. */
-void
-daemon_close_standard_fds(void)
-{
-    int null_fd = get_null_fd();
-    if (null_fd >= 0) {
-        int fd;
+void daemon_close_standard_fds(void) {
+  int null_fd = get_null_fd();
+  if (null_fd >= 0) {
+    int fd;
 
-        for (fd = 0; fd < 3; fd++) {
-            if (!infrap4d_save_fds[fd]) {
-                dup2(null_fd, fd);
-            }
-        }
+    for (fd = 0; fd < 3; fd++) {
+      if (!infrap4d_save_fds[fd]) {
+        dup2(null_fd, fd);
+      }
     }
+  }
 }

--- a/infrap4d/daemon/fatal-signal.c
+++ b/infrap4d/daemon/fatal-signal.c
@@ -15,30 +15,29 @@
  */
 
 #include "fatal-signal.h"
+
 #include <errno.h>
 #include <signal.h>
 #include <stdbool.h>
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <signal.h>
 
 #ifndef SIG_ATOMIC_MAX
 #define SIG_ATOMIC_MAX TYPE_MAXIMUM(sig_atomic_t)
 #endif
 
 /* Signals to catch. */
-static const int fatal_signals[] = { SIGTERM, SIGINT, SIGHUP, SIGALRM,
-                                     SIGSEGV };
+static const int fatal_signals[] = {SIGTERM, SIGINT, SIGHUP, SIGALRM, SIGSEGV};
 
 /* Hooks to call upon catching a signal */
 struct infrap4d_hook {
-    void (*hook_cb)(void *aux);
-    void (*cancel_cb)(void *aux);
-    void *aux;
-    bool run_at_exit;
+  void (*hook_cb)(void* aux);
+  void (*cancel_cb)(void* aux);
+  void* aux;
+  bool run_at_exit;
 };
 #define MAX_HOOKS 32
 static struct infrap4d_hook infrap4d_hooks[MAX_HOOKS];
@@ -55,22 +54,20 @@ static volatile sig_atomic_t infrap4d_stored_sig_nr = SIG_ATOMIC_MAX;
  * allow it to terminate without calling the hooks registered before calling
  * this function.  New hooks registered after calling this function will take
  * effect normally. */
-void
-daemon_fatal_signal_fork(void)
-{
-    size_t i;
+void daemon_fatal_signal_fork(void) {
+  size_t i;
 
-    for (i = 0; i < infrap4d_n_hooks; i++) {
-        struct infrap4d_hook *h = &infrap4d_hooks[i];
-        if (h->cancel_cb) {
-            h->cancel_cb(h->aux);
-        }
+  for (i = 0; i < infrap4d_n_hooks; i++) {
+    struct infrap4d_hook* h = &infrap4d_hooks[i];
+    if (h->cancel_cb) {
+      h->cancel_cb(h->aux);
     }
-    infrap4d_n_hooks = 0;
+  }
+  infrap4d_n_hooks = 0;
 
-    /* Raise any signals that we have already received with the default
-     * handler. */
-    if (infrap4d_stored_sig_nr != SIG_ATOMIC_MAX) {
-        raise(infrap4d_stored_sig_nr);
-    }
+  /* Raise any signals that we have already received with the default
+   * handler. */
+  if (infrap4d_stored_sig_nr != SIG_ATOMIC_MAX) {
+    raise(infrap4d_stored_sig_nr);
+  }
 }

--- a/infrap4d/infrap4d_lite.cc
+++ b/infrap4d/infrap4d_lite.cc
@@ -7,7 +7,7 @@
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/bin/tdi/main.h"
 
-extern "C"  {
+extern "C" {
 #include "daemon/daemon.h"
 }
 
@@ -18,15 +18,15 @@ int main(int argc, char* argv[]) {
   stratum::hal::tdi::ParseCommandLine(argc, argv, true);
 
   if (FLAGS_detach) {
-      daemonize_start(false);
-      daemonize_complete();
+    daemonize_start(false);
+    daemonize_complete();
   }
 
   auto status = stratum::hal::tdi::Main();
   if (!status.ok()) {
-     // TODO: Figure out logging for infrap4d
-     return status.error_code();
-   }
+    // TODO: Figure out logging for infrap4d
+    return status.error_code();
+  }
 
   return 0;
 }

--- a/infrap4d/infrap4d_main.cc
+++ b/infrap4d/infrap4d_main.cc
@@ -7,7 +7,7 @@
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/bin/tdi/main.h"
 
-extern "C"  {
+extern "C" {
 #include "daemon/daemon.h"
 }
 
@@ -19,8 +19,8 @@ int main(int argc, char* argv[]) {
   stratum::hal::tdi::ParseCommandLine(argc, argv, true);
 
   if (FLAGS_detach) {
-      daemonize_start(false);
-      daemonize_complete();
+    daemonize_start(false);
+    daemonize_complete();
   }
 
   absl::Notification ready_sync;
@@ -36,15 +36,15 @@ int main(int argc, char* argv[]) {
    * sequence, just disables krnlmon logic.
    */
   if (!FLAGS_disable_krnlmon) {
-      krnlmon_create_main_thread(&ready_sync);
-      krnlmon_create_shutdown_thread(&done_sync);
+    krnlmon_create_main_thread(&ready_sync);
+    krnlmon_create_shutdown_thread(&done_sync);
   }
 
   auto status = stratum::hal::tdi::Main(&ready_sync, &done_sync);
   if (!status.ok()) {
-     // TODO: Figure out logging for infrap4d
-     return status.error_code();
-   }
+    // TODO: Figure out logging for infrap4d
+    return status.error_code();
+  }
 
   return 0;
 }


### PR DESCRIPTION
- Use clang-format to ensure that the C and C++ files in the infrap4d folder conform to the coding standard.