### PR TITLE
 Update driver find-modules to update search path

### DIFF
--- a/cmake/FindDpdkDriver.cmake
+++ b/cmake/FindDpdkDriver.cmake
@@ -26,6 +26,11 @@ endif()
 mark_as_advanced(SDE_INCLUDE_DIR)
 
 #-----------------------------------------------------------------------
+# Add SDE install directory to search path
+#-----------------------------------------------------------------------
+list(APPEND CMAKE_PREFIX_PATH ${SDE_INSTALL_DIR})
+
+#-----------------------------------------------------------------------
 # Find libraries
 #-----------------------------------------------------------------------
 find_library(LIBBF_SWITCHD bf_switchd_lib)

--- a/cmake/FindEs2kDriver.cmake
+++ b/cmake/FindEs2kDriver.cmake
@@ -19,6 +19,9 @@ if(NOT SDE_INCLUDE_DIR)
 endif()
 mark_as_advanced(SDE_INCLUDE_DIR)
 
+#-----------------------------------------------------------------------
+# Add SDE install directory to search path
+#-----------------------------------------------------------------------
 if(CMAKE_CROSSCOMPILING)
   list(APPEND CMAKE_FIND_ROOT_PATH ${SDE_INSTALL_DIR})
 else()

--- a/cmake/FindTofinoDriver.cmake
+++ b/cmake/FindTofinoDriver.cmake
@@ -20,6 +20,11 @@ endif()
 mark_as_advanced(SDE_INCLUDE_DIR)
 
 #-----------------------------------------------------------------------
+# Add SDE install directory to search path
+#-----------------------------------------------------------------------
+list(APPEND CMAKE_PREFIX_PATH ${SDE_INSTALL_DIR})
+
+#-----------------------------------------------------------------------
 # Find libraries
 #-----------------------------------------------------------------------
 find_library(LIBDRIVER driver)


### PR DESCRIPTION
 - Modify DPDK and Tofino Driver modules to add SDE_INSTALL_DIR to CMAKE_PREFIX_PATH.

This CL does for DPDK and Tofino what https://github.com/ipdk-io/networking-recipe/pull/310 did for ES2K. It enables standalone builds of the Kernel Monitor for DPDK, and will allow us to perform include-what-you-use analysis (https://github.com/ipdk-io/krnlmon/pull/61).