### PR TITLE
Begin transition to stratum-deps repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ upstreaming.
 It moves the P4-specific components of the architecture from `ovs-vswitchd`
 to a separate process called `infrap4d`.
 
-## Upcoming changes
+See the [Overview](https://ipdk.io/p4cp-userguide/overview/overview.html)
+section of the User Guide for a description of the components.
 
-The Stratum dependencies will be moving from the `setup` directory to
-a separate `stratum-deps` repository towards the end of October 2023.
+## Major changes
 
-See the setup directory's [README file](setup/README.md) for more information.
+The Stratum dependencies component has formally moved from the `setup`
+directory to a new <https://github.com/ipdk-io/stratum-deps> repository.
+
+See the [README file](setup/README.md) in the `setup` directory
+for more information.
 
 ## Source code
 
@@ -27,17 +31,6 @@ To download the source code for P4 Control Plane:
 ```bash
 git clone --recursive https://github.com/ipdk-io/networking-recipe
 ```
-
-## Targets
-
-P4 Control Plane can be configured at build time to support any one
-of the following targets:
-
-| Target | Instructions |
-| ------ | ------------ |
-| dpdk   | [DPDK Setup Guide](https://ipdk.io/p4cp-userguide/guides/setup/dpdk-setup-guide.html) |
-| es2k   | [ES2K Setup Guide](https://ipdk.io/p4cp-userguide/guides/setup/es2k-setup-guide.html) |
-| tofino | [Tofino Setup Guide](https://ipdk.io/p4cp-userguide/guides/setup/tofino-setup-guide.html) |
 
 ## Documentation
 

--- a/docs/guides/setup/tofino-setup-guide.md
+++ b/docs/guides/setup/tofino-setup-guide.md
@@ -1,8 +1,6 @@
 # Tofino Setup Guide
 
-## Overview
-
-This document explains how to install, build, and run the P4 Control Plane
+This document explains how to build, install, and run the P4 Control Plane
 software on Tofino hardware.
 
 Similar steps apply when running on the Tofino simulation model. Please see
@@ -34,10 +32,16 @@ docker run --privileged --cap-add=ALL -it --name infrap4d --network host -d ubun
 
 ### Git
 
-Clone IPDK networking-recipe
+Clone IPDK networking-recipe:
 
 ```bash
 git clone --recursive git@github.com:ipdk-io/networking-recipe.git ipdk.recipe
+```
+
+Clone the repository used to build the Stratum dependencies:
+
+```bash
+git clone --recursive https://github.com/ipdk-io/stratum-deps.git
 ```
 
 ### Intel P4Studio
@@ -60,22 +64,18 @@ docker exec -it infrap4d bash
 
 ### Install basic utilities
 
-See the [OpenSSL security guide](/guides/security/openssl-guide.md)
-for OpenSSL version and EOL information.
-
----
-
 ```bash
 apt-get update
 apt-get install sudo git cmake autoconf gcc g++ libtool python3 python3-dev python3-distutils iproute2 libssl-dev
 ```
 
-### Build and install infrap4d dependencies
+See the [OpenSSL security guide](/guides/security/openssl-guide.md)
+for OpenSSL version and EOL information.
+
+### Build and install stratum dependencies
 
 ```bash
-cd ipdk.recipe
-export IPDK_RECIPE=`pwd`
-cd $IPDK_RECIPE/setup
+cd stratum-deps
 cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/
 make
 ldconfig

--- a/docs/overview/overview.md
+++ b/docs/overview/overview.md
@@ -1,4 +1,4 @@
-# P4 Control Plane
+# Overview
 
 P4 Control Plane (formerly P4-OVS Split Architecture) modularizes P4-OVS
 and reduces coupling between its components, making the code easier to maintain

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,42 +1,26 @@
-# Stratum Dependencies
+<!-- markdownlint-disable MD026 -->
+# We've Moved!
+<!-- markdownlint-enable MD026 -->
 
-Stratum is the component of `infrap4d` that implements the P4Runtime and gNMI
-(OpenConfig) services.
+The Stratum dependencies have formally moved from the `setup` directory
+to a new <https://github.com/ipdk-io/stratum-deps> repository.
 
-This directory allows you to build and install the third-party libraries
-that Stratum requires.
+This change makes the dependencies easier to maintain, and it allows
+them to be downloaded and built independently of the Networking Recipe
+(P4 Control Plane).
 
-<!-- markdownlint-disable-next-line -->
-## We're Moving!
+See the [README file](https://github.com/ipdk-io/stratum-deps/blob/main/README.md)
+in the `stratum-deps` repository for more information.
 
-The Stratum dependencies are being relocated to their own repository,
-<https://github.com/ipdk-io/stratum-deps>.
+## Transition
 
-This allows the dependencies to be updated independently of the Networking
-Recipe (P4 Control Plane).
+We are retaining the `setup` directory for now, to allow users time to
+to transition to the `stratum-deps` repository. Note that this is an older
+version of the component and does not include any recent improvements.
 
-### Development
-
-New development is currently taking place in the `stratum-deps` repository.
+We will be removing the `setup` directory in the near future.
+You are encouraged to transition to `stratum-deps` as soon as possible.
 
 See the
-[change history](https://github.com/ipdk-io/stratum-deps/blob/main/docs/change-history.md)
-for more information.
-
-### Transition
-
-We plan to phase out the `networking-recipe/setup` directory toward the end
-of October 2023.
-
-If you would like to start using `stratum-deps` before then,
-[version 1.2.0](https://github.com/ipdk-io/stratum-deps/tree/v1.2.0)
-is a good place to start.
-
-### Documentation
-
-The `stratum-deps` repository includes updated versions of relevant sections
-of the user manual, plus new documentation on the helper scripts.
-
-See the repository's
-[README file](https://github.com/ipdk-io/stratum-deps/blob/main/README.md)
-for links to the documentation.
+[Transition Guide](https://github.com/ipdk-io/stratum-deps/blob/main/docs/transition-guide.md)
+for details.


### PR DESCRIPTION
This PR transfers responsibility for the Stratum dependencies to the stratum-deps repository.

- Update `README.md` and `setup/README.md` to refer the reader to `stratum-deps`. Note that the `setup` directory is still available, but no longer current.

- Revise the DPDK, ES2K, and Tofino setup guides.