### PR TITLE
client changes for packetIO

### DIFF
--- a/clients/p4rt-ctl/p4rt-ctl.in
+++ b/clients/p4rt-ctl/p4rt-ctl.in
@@ -37,6 +37,8 @@ import struct
 import sys
 import threading
 import time
+import fcntl
+import select
 from functools import wraps
 
 import google.protobuf.text_format
@@ -660,6 +662,26 @@ class P4RuntimeClient:
             pass
         return None
 
+    def get_packet_in(self, timeout=3):
+        msg = self.get_stream_packet("packet", timeout)
+        if msg is not None:
+            return msg.packet
+
+    def send_packet_out(self, payload):
+        packet_out = p4runtime_pb2.PacketOut()
+        packet_out.payload = payload
+        packet_out_req = p4runtime_pb2.StreamMessageRequest()
+        packet_out_req.packet.CopyFrom(packet_out)
+        self.stream_out_q.put(packet_out_req)
+
+    # Continously poll for pkts from the server
+    def pktio_rx(self, tap_device):
+        print("Waiting for Rx pkts...")
+        while True:
+            pkt = self.get_packet_in()
+            if pkt is not None:
+                tap_device.write(pkt.payload)
+
     @parse_p4runtime_error
     def get_p4info(self):
         req = p4runtime_pb2.GetForwardingPipelineConfigRequest()
@@ -769,6 +791,54 @@ def p4ctl_show(client, bridge):
 def p4ctl_set_pipe(client, bridge, device_config, p4info):
     client.set_fwd_pipe_config(p4info, device_config)
 
+TUNSETIFF = 0x400454CA
+IFF_TAP = 0x0002
+IFF_NO_PI = 0x1000
+MAX_FRAME_SIZE = 1500
+SELECT_TIMEOUT = 0.1
+
+class TapDevice:
+    def __init__(self, tap_name):
+        try:
+            self.tap = os.open("/dev/net/tun", os.O_RDWR)
+
+            # Configure the TAP interface.
+            ifr = struct.pack('16sH', tap_name.encode(), IFF_TAP | IFF_NO_PI)
+            fcntl.ioctl(self.tap, TUNSETIFF, ifr)
+
+            # Bring the TAP interface up.
+            os.system(f"sudo ip link set dev {tap_name} up")
+
+            print(f"Created TAP device {tap_name}")
+        except Exception as e:
+            print(f"Error creating TAP interface: {e}")
+
+    # Continuously reads pkts from TAP port and sends them out to the server
+    def read(self, client):
+        while True:
+            readable, _, _ = select.select([self.tap], [], [], SELECT_TIMEOUT)
+            if self.tap in readable:
+                # read pkt from tap port
+                data = os.read(self.tap, MAX_FRAME_SIZE)
+
+                # send the packet to the server
+                client.send_packet_out(data)
+
+    # Sends pkts to the tap port
+    def write(self, data):
+        os.write(self.tap, data)
+
+# Thread function to read pkts from TAP port
+def read_from_tap(tap, client):
+    print("Tx thread polling on TAP port")
+    tap.read(client)
+
+@with_client
+def p4ctl_start_pktio(client, bridge):
+    tap_device = TapDevice("pktioTap0")
+    tx_thread = threading.Thread(target=read_from_tap, args=(tap_device,client))
+    tx_thread.start()
+    client.pktio_rx(tap_device)
 
 @with_client
 def p4ctl_get_pipe(client, bridge):
@@ -1611,6 +1681,7 @@ def p4ctl_reset_counter_entry(client, bridge, cnt_tbl_name, flow):
 all_commands = {
     "show": (p4ctl_show, 1),
     "set-pipe": (p4ctl_set_pipe, 3),
+    "start-pktio": (p4ctl_start_pktio, 1),
     "get-pipe": (p4ctl_get_pipe, 1),
     "add-entry": (p4ctl_add_entry, 3),
     "modify-entry": (p4ctl_mod_entry, 3),

--- a/clients/p4rt-ctl/p4rt-ctl.in
+++ b/clients/p4rt-ctl/p4rt-ctl.in
@@ -792,11 +792,9 @@ def p4ctl_set_pipe(client, bridge, device_config, p4info):
     client.set_fwd_pipe_config(p4info, device_config)
 
 class TapDevice:
-    def __init__(self, tap_no):
-        if tap_no < 0 or tap_no > 255:
-            raise ValueError("TAP number {%u} is invalid" % tap_no)
+    def __init__(self, tap_name):
 
-        self.tap_name = "pktioTap{}".format(tap_no)
+        self.tap_name = tap_name
 
         TUNSETIFF = 0x400454CA
         IFF_TAP = 0x0002
@@ -807,9 +805,6 @@ class TapDevice:
             # Configure the TAP interface.
             ifr = struct.pack('16sH', self.tap_name.encode(), IFF_TAP | IFF_NO_PI)
             fcntl.ioctl(self.tap, TUNSETIFF, ifr)
-
-            # Bring the TAP interface up.
-            os.system(f"sudo ip link set dev {self.tap_name} up")
 
             print(f"Created TAP device {self.tap_name}")
         except Exception as e:
@@ -842,7 +837,7 @@ def read_from_tap(tap, client):
 @with_client
 def p4ctl_start_pktio(client, bridge):
     try:
-        tap_device = TapDevice(0)
+        tap_device = TapDevice("pktioTap0")
         tx_thread = threading.Thread(target=read_from_tap, args=(tap_device,client))
         tx_thread.start()
         client.pktio_rx(tap_device)

--- a/clients/p4rt-ctl/p4rt-ctl.in
+++ b/clients/p4rt-ctl/p4rt-ctl.in
@@ -806,6 +806,8 @@ class TapDevice:
             print(f"Created TAP device {tap_name}")
         except Exception as e:
             print(f"Error creating TAP interface: {e}")
+            if self.tap is not None:
+                 os.close(self.tap)
 
     # Continuously reads pkts from TAP port and sends them out to the server
     def read(self, client):

--- a/clients/p4rt-ctl/p4rt-ctl.in
+++ b/clients/p4rt-ctl/p4rt-ctl.in
@@ -792,7 +792,12 @@ def p4ctl_set_pipe(client, bridge, device_config, p4info):
     client.set_fwd_pipe_config(p4info, device_config)
 
 class TapDevice:
-    def __init__(self, tap_name):
+    def __init__(self, tap_no):
+        if tap_no < 0 or tap_no > 255:
+            raise ValueError("TAP number {%u} is invalid" % tap_no)
+
+        self.tap_name = "pktioTap{}".format(tap_no)
+
         TUNSETIFF = 0x400454CA
         IFF_TAP = 0x0002
         IFF_NO_PI = 0x1000
@@ -800,10 +805,13 @@ class TapDevice:
             self.tap = os.open("/dev/net/tun", os.O_RDWR)
 
             # Configure the TAP interface.
-            ifr = struct.pack('16sH', tap_name.encode(), IFF_TAP | IFF_NO_PI)
+            ifr = struct.pack('16sH', self.tap_name.encode(), IFF_TAP | IFF_NO_PI)
             fcntl.ioctl(self.tap, TUNSETIFF, ifr)
 
-            print(f"Created TAP device {tap_name}")
+            # Bring the TAP interface up.
+            os.system(f"sudo ip link set dev {self.tap_name} up")
+
+            print(f"Created TAP device {self.tap_name}")
         except Exception as e:
             print(f"Error creating TAP interface: {e}")
             if self.tap is not None:
@@ -833,10 +841,13 @@ def read_from_tap(tap, client):
 
 @with_client
 def p4ctl_start_pktio(client, bridge):
-    tap_device = TapDevice("pktioTap0")
-    tx_thread = threading.Thread(target=read_from_tap, args=(tap_device,client))
-    tx_thread.start()
-    client.pktio_rx(tap_device)
+    try:
+        tap_device = TapDevice(0)
+        tx_thread = threading.Thread(target=read_from_tap, args=(tap_device,client))
+        tx_thread.start()
+        client.pktio_rx(tap_device)
+    except Exception as e:
+        print(f"Error: Failed to start packetIo {e}")
 
 @with_client
 def p4ctl_get_pipe(client, bridge):

--- a/clients/p4rt-ctl/p4rt-ctl.in
+++ b/clients/p4rt-ctl/p4rt-ctl.in
@@ -39,7 +39,6 @@ import threading
 import time
 import fcntl
 import select
-import subprocess
 from functools import wraps
 
 import google.protobuf.text_format
@@ -675,9 +674,9 @@ class P4RuntimeClient:
         packet_out_req.packet.CopyFrom(packet_out)
         self.stream_out_q.put(packet_out_req)
 
-    # Continously poll for pkts from the server
+    # Continuously poll for pkts from the server
     def pktio_rx(self, tap_device):
-        print("Waiting for Rx pkts...")
+        print("Waiting for Rx packets...")
         while True:
             pkt = self.get_packet_in()
             if pkt is not None:
@@ -792,14 +791,11 @@ def p4ctl_show(client, bridge):
 def p4ctl_set_pipe(client, bridge, device_config, p4info):
     client.set_fwd_pipe_config(p4info, device_config)
 
-TUNSETIFF = 0x400454CA
-IFF_TAP = 0x0002
-IFF_NO_PI = 0x1000
-MAX_FRAME_SIZE = 1500
-SELECT_TIMEOUT = 0.1
-
 class TapDevice:
     def __init__(self, tap_name):
+        TUNSETIFF = 0x400454CA
+        IFF_TAP = 0x0002
+        IFF_NO_PI = 0x1000
         try:
             self.tap = os.open("/dev/net/tun", os.O_RDWR)
 
@@ -807,15 +803,14 @@ class TapDevice:
             ifr = struct.pack('16sH', tap_name.encode(), IFF_TAP | IFF_NO_PI)
             fcntl.ioctl(self.tap, TUNSETIFF, ifr)
 
-            # Bring the TAP interface up.
-            subprocess.run(["sudo", "ip", "link", "set", "dev", tap_name, "up"], check=True)
-
             print(f"Created TAP device {tap_name}")
         except Exception as e:
             print(f"Error creating TAP interface: {e}")
 
     # Continuously reads pkts from TAP port and sends them out to the server
     def read(self, client):
+        MAX_FRAME_SIZE = 1500
+        SELECT_TIMEOUT = 0.1
         while True:
             readable, _, _ = select.select([self.tap], [], [], SELECT_TIMEOUT)
             if self.tap in readable:

--- a/clients/p4rt-ctl/p4rt-ctl.in
+++ b/clients/p4rt-ctl/p4rt-ctl.in
@@ -39,6 +39,7 @@ import threading
 import time
 import fcntl
 import select
+import subprocess
 from functools import wraps
 
 import google.protobuf.text_format
@@ -807,7 +808,7 @@ class TapDevice:
             fcntl.ioctl(self.tap, TUNSETIFF, ifr)
 
             # Bring the TAP interface up.
-            os.system(f"sudo ip link set dev {tap_name} up")
+            subprocess.run(["sudo", "ip", "link", "set", "dev", tap_name, "up"], check=True)
 
             print(f"Created TAP device {tap_name}")
         except Exception as e:

--- a/clients/p4rt-ctl/p4rt-ctl.in
+++ b/clients/p4rt-ctl/p4rt-ctl.in
@@ -796,6 +796,8 @@ class TapDevice:
 
         self.tap_name = tap_name
 
+        # constants derived from
+        # https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/if_tun.h#L34
         TUNSETIFF = 0x400454CA
         IFF_TAP = 0x0002
         IFF_NO_PI = 0x1000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 p4runtime==1.3.0
+fcntl
+select


### PR DESCRIPTION
PacketIO feature is enabled by the command: $IPDK_RECIPE/install/bin/p4rt-ctl start-pktio br0

Created a TAP port to enable testing of packetIO feature. 

In order to receive packets asynchronously, the p4rt-ctl must continue running and actively poll for incoming packets. To achieve this, an infinite loop is introduced within the pktio_rx function. Packets received are sent to the TAP port and can verified. 

In order to test PacketOut,  a thread is created to poll for packets on the TAP port. Packets received are sent to the server. With the appropriate forwarding rule, these packets can be verified on the partner device.

Limitation: 
During packetIO, p4rt-ctl client remains connected to the server so other clients cannot connect. The current client needs to exit to do any other operations.

