### PR TITLE
Mark CompilerSettings options as advanced

### DIFF
--- a/cmake/CompilerSettings.cmake
+++ b/cmake/CompilerSettings.cmake
@@ -13,7 +13,9 @@ include(CMakePrintHelpers)
 # Disabled by default, on the assumption that the choice of warnings
 # is best left to the application.
 option(ENABLE_WARNING_SETTINGS "Enable compiler warnings" OFF)
-option(ENABLE_SPECTRE_SETTINGS "Enable Spectre mitigations" ON)
+option(ENABLE_SPECTRE_SETTINGS "Enable Spectre mitigations" OFF)
+mark_as_advanced(ENABLE_WARNING_SETTINGS)
+mark_as_advanced(ENABLE_SPECTRE_SETTINGS)
 
 macro(check_and_add_compile_option _option _have_flag)
   check_c_compiler_flag(${_option} ${_have_flag})


### PR DESCRIPTION
- Set the 'advanced' flag on the ENABLE_WARNING_SETTINGS and ENABLE_SPECTRE_SETTINGS cache variables, so they're not displayed unless the 'show advanced' mode is enabled.

- Disable ENABLE_SPECTRE_SETTINGS by default. This feature is not fully implemented.