### PR TITLE
Using copy_config_files.sh under es2k

### DIFF
--- a/scripts/common/copy_config_files.sh.in
+++ b/scripts/common/copy_config_files.sh.in
@@ -41,6 +41,6 @@ sudo cp ${SOURCE_DIR}/ca.conf ${TLS_CERTS_DIR}/
 sudo cp ${SOURCE_DIR}/grpc-client.conf ${TLS_CERTS_DIR}/
 sudo cp ${P4CP_INSTALL}/sbin/generate-certs.sh ${TLS_CERTS_DIR}/
 
-sudo mkdir /usr/share/target_sys/
+sudo mkdir -p /usr/share/target_sys/
 sudo cp $SDE_INSTALL/share/target_sys/zlog-cfg /usr/share/target_sys/
 set +e

--- a/scripts/es2k/CMakeLists.txt
+++ b/scripts/es2k/CMakeLists.txt
@@ -4,18 +4,9 @@
 # SPDX-License-Identifier: Apache 2.0
 #
 
-# Customize copy_config_files.sh script
-
-set(TARGET_NAME "es2k")
-
-configure_file("../common/copy_config_files.sh.in"
-               ${CMAKE_CURRENT_BINARY_DIR}/copy_config_files.sh @ONLY)
-
-unset(TARGET_NAME)
-
 install(
     PROGRAMS
-        ${CMAKE_CURRENT_BINARY_DIR}/copy_config_files.sh
+        copy_config_files.sh
     TYPE
         SBIN
 )

--- a/scripts/es2k/copy_config_files.sh
+++ b/scripts/es2k/copy_config_files.sh
@@ -18,17 +18,32 @@ then
     return 0
 fi
 
-export IPDK_INSTALL=$1
+export P4CP_INSTALL=$1
 export SDE_INSTALL=$2
 
+SOURCE_DIR=${P4CP_INSTALL}/share/stratum/es2k
+TARGET_DIR=/usr/share/stratum/es2k
+TLS_CERTS_DIR=/usr/share/stratum
+
 #... Create required directories and copy the config files ...#
-cd $IPDK_INSTALL
+cd $P4CP_INSTALL
 sudo mkdir -p /etc/stratum/
 sudo mkdir -p /var/log/stratum/
 sudo mkdir -p /usr/share/stratum/es2k
+sudo mkdir -p /usr/share/target_sys/
 sudo mkdir -p /usr/share/bf_rt_shared
-sudo cp $IPDK_INSTALL/share/stratum/es2k/es2k_port_config.pb.txt /usr/share/stratum/es2k/
-sudo cp $IPDK_INSTALL/share/stratum/es2k/es2k_skip_p4.conf /usr/share/stratum/es2k/
-sudo cp $SDE_INSTALL/share/bf_rt_shared/tdi_pktio.json /usr/share/bf_rt_shared/
+
+sudo cp ${SOURCE_DIR}/es2k_port_config.pb.txt /usr/share/stratum/es2k/
+sudo cp ${SOURCE_DIR}/es2k_skip_p4.conf /usr/share/stratum/es2k/
+
+#... Install files required for TLS certificate generation ...#
+sudo cp ${SOURCE_DIR}/ca.conf ${TLS_CERTS_DIR}/
+sudo cp ${SOURCE_DIR}/grpc-client.conf ${TLS_CERTS_DIR}/
+sudo cp ${P4CP_INSTALL}/sbin/generate-certs.sh ${TLS_CERTS_DIR}/
+
 sudo cp $SDE_INSTALL/share/target_sys/zlog-cfg /usr/share/target_sys/
+
+#... Install packetIO json file ...#
+sudo cp $SDE_INSTALL/share/bf_rt_shared/tdi_pktio.json /usr/share/bf_rt_shared/
+
 set +e

--- a/scripts/es2k/copy_config_files.sh
+++ b/scripts/es2k/copy_config_files.sh
@@ -18,15 +18,17 @@ then
     return 0
 fi
 
-export IPDK_RECIPE=$1
+export IPDK_INSTALL=$1
 export SDE_INSTALL=$2
 
 #... Create required directories and copy the config files ...#
-cd $IPDK_RECIPE
+cd $IPDK_INSTALL
 sudo mkdir -p /etc/stratum/
 sudo mkdir -p /var/log/stratum/
 sudo mkdir -p /usr/share/stratum/es2k
-sudo cp ./install/share/stratum/es2k/es2k_port_config.pb.txt /usr/share/stratum/es2k/
-sudo cp ./install/share/stratum/es2k/es2k_skip_p4.conf /usr/share/stratum/es2k/
+sudo mkdir -p /usr/share/bf_rt_shared
+sudo cp $IPDK_INSTALL/share/stratum/es2k/es2k_port_config.pb.txt /usr/share/stratum/es2k/
+sudo cp $IPDK_INSTALL/share/stratum/es2k/es2k_skip_p4.conf /usr/share/stratum/es2k/
+sudo cp $SDE_INSTALL/share/bf_rt_shared/tdi_pktio.json /usr/share/bf_rt_shared/
 sudo cp $SDE_INSTALL/share/target_sys/zlog-cfg /usr/share/target_sys/
 set +e


### PR DESCRIPTION
**Three changes in this PR:**
1. `copy_config_files.sh.in` under scripts/common has content that is target-specific. It needs cleaning up. 
For now, `copy_config_files.sh` under  scripts/es2k is to be used for copying files for es2k target. 
2. A minor fix in copy_config_files.sh.in
3. Installing tdi_pktio.json from SDE_INSTALL path. This file is needed for packetIO feature.