### PR TITLE
Run clang-format on client source

### DIFF
--- a/clients/gnmi-ctl/gnmi_ctl_utils.c
+++ b/clients/gnmi-ctl/gnmi_ctl_utils.c
@@ -1,6 +1,8 @@
 /*
- * Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Nicira, Inc.
+ * Copyright (c) 2008-2016 Nicira, Inc.
  * Copyright (c) 2022-2023 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/gnmi-ctl/gnmi_ctl_utils.h
+++ b/clients/gnmi-ctl/gnmi_ctl_utils.h
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017 Nicira, Inc.
+ * Copyright (c) 2008-2017 Nicira, Inc.
  * Copyright (c) 2022-2023 Intel Corporation.
+ *
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/clients/p4rt_perf_test/p4rt_perf_simple_l2_demo.cc
+++ b/clients/p4rt_perf_test/p4rt_perf_simple_l2_demo.cc
@@ -41,8 +41,8 @@ void PrepareSimpleL2DemoTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 int SimpleL2DemoTest(P4rtSession* session,
-                      const ::p4::config::v1::P4Info& p4info,
-                      ThreadInfo& t_data) {
+                     const ::p4::config::v1::P4Info& p4info,
+                     ThreadInfo& t_data) {
   ::p4::v1::TableEntry* table_entry;
   SimpleL2DemoMacInfo mac_info;
   p4::v1::WriteRequest write_request;

--- a/clients/p4rt_perf_test/p4rt_perf_simple_l2_demo.h
+++ b/clients/p4rt_perf_test/p4rt_perf_simple_l2_demo.h
@@ -14,7 +14,7 @@ void PrepareSimpleL2DemoTableEntry(p4::v1::TableEntry* table_entry,
                                    bool insert_entry);
 
 int SimpleL2DemoTest(P4rtSession* session,
-                      const ::p4::config::v1::P4Info& p4info,
-                      ThreadInfo& t_data);
+                     const ::p4::config::v1::P4Info& p4info,
+                     ThreadInfo& t_data);
 
 #endif

--- a/clients/sgnmi_cli/sgnmi_cli.cc
+++ b/clients/sgnmi_cli/sgnmi_cli.cc
@@ -26,7 +26,7 @@
 #define DEFAULT_CERTS_DIR "/usr/share/stratum/certs/"
 
 DEFINE_bool(grpc_use_insecure_mode, false,
-              "grpc communication in insecure mode");
+            "grpc communication in insecure mode");
 DEFINE_string(grpc_addr, stratum::kLocalStratumUrl, "gNMI server address");
 DEFINE_string(bool_val, "", "Boolean value to be set");
 DEFINE_string(int_val, "", "Integer value to be set (64-bit)");
@@ -243,7 +243,6 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
 }
 
 ::util::Status Main(int argc, char** argv) {
-
   // Default certificate file location for TLS-mode
   FLAGS_ca_cert_file = DEFAULT_CERTS_DIR "ca.crt";
   FLAGS_server_key_file = DEFAULT_CERTS_DIR "stratum.key";
@@ -288,13 +287,13 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
   std::shared_ptr<::grpc::Channel> channel;
   if (FLAGS_grpc_use_insecure_mode) {
     ASSIGN_OR_RETURN(auto credentials_manager,
-                    CredentialsManager::CreateInstance(true));
+                     CredentialsManager::CreateInstance(true));
     channel = ::grpc::CreateChannel(
         FLAGS_grpc_addr,
         credentials_manager->GenerateExternalFacingClientCredentials());
   } else {
     std::shared_ptr<::grpc::ChannelCredentials> channel_credentials =
-      ::grpc::InsecureChannelCredentials();
+        ::grpc::InsecureChannelCredentials();
     channel = ::grpc::CreateChannel(FLAGS_grpc_addr, channel_credentials);
   }
 


### PR DESCRIPTION
- Ran clang-format on the C and C++ source files under networking-recipe/clients.