### PR TITLE
Improve SDE error check

### DIFF
--- a/cmake/FindDpdkDriver.cmake
+++ b/cmake/FindDpdkDriver.cmake
@@ -15,7 +15,12 @@ find_path(SDE_INCLUDE_DIR
     PATHS ${SDE_INSTALL_DIR}/include
 )
 if(NOT SDE_INCLUDE_DIR)
-  message(FATAL_ERROR "bf_switchd.h not found")
+  message(STATUS "bf_switchd.h not found")
+  message("---------------------------------------------")
+  message("Your SDE_INSTALL_DIR appears to be incorrect.")
+  message("Its current value is '${SDE_INSTALL_DIR}'.")
+  message("---------------------------------------------")
+  message(FATAL_ERROR "DPDK SDE setup failed")
 endif()
 mark_as_advanced(SDE_INCLUDE_DIR)
 

--- a/cmake/FindEs2kDriver.cmake
+++ b/cmake/FindEs2kDriver.cmake
@@ -15,7 +15,12 @@ find_path(SDE_INCLUDE_DIR
     PATHS ${SDE_INSTALL_DIR}/include
 )
 if(NOT SDE_INCLUDE_DIR)
-  message(FATAL_ERROR "bf_switchd.h not found")
+  message(STATUS "bf_switchd.h not found")
+  message("---------------------------------------------")
+  message("Your SDE_INSTALL_DIR appears to be incorrect.")
+  message("Its current value is '${SDE_INSTALL_DIR}'.")
+  message("---------------------------------------------")
+  message(FATAL_ERROR "ES2K SDE setup failed")
 endif()
 mark_as_advanced(SDE_INCLUDE_DIR)
 

--- a/cmake/FindTofinoDriver.cmake
+++ b/cmake/FindTofinoDriver.cmake
@@ -15,7 +15,12 @@ find_path(SDE_INCLUDE_DIR
     PATHS ${SDE_INSTALL_DIR}/include
 )
 if(NOT SDE_INCLUDE_DIR)
-  message(FATAL_ERROR "bf_switchd.h not found")
+  message(STATUS "bf_switchd.h not found")
+  message("---------------------------------------------")
+  message("Your SDE_INSTALL_DIR appears to be incorrect.")
+  message("Its current value is '${SDE_INSTALL_DIR}'.")
+  message("---------------------------------------------")
+  message(FATAL_ERROR "Tofino SDE setup failed")
 endif()
 mark_as_advanced(SDE_INCLUDE_DIR)
 


### PR DESCRIPTION
- Make the error message displayed by the SDE sanity check more prominent, and add some explanatory text.

```text
-- bf_switchd.h not found
---------------------------------------------
Your SDE_INSTALL_DIR appears to be incorrect.
Its current value is '/home/dfoster/work/latest/dummy_sde'.
---------------------------------------------
CMake Error at cmake/FindTofinoDriver.cmake:23 (message):
  Tofino SDE setup failed
Call Stack (most recent call first):
  CMakeLists.txt:156 (find_package)


-- Configuring incomplete, errors occurred!
```