### PR TITLE
Create README file for /docs directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is the superproject for P4 Control Plane.
 It is the successor to P4-OVS.
 
 - also called the IPDK Networking Recipe
-- formally known as P4-OVS Split Architecture
+- formerly known as P4-OVS Split Architecture
 
 P4 Control Plane modularizes P4-OVS and reduces coupling between its
 components, making the code easier to maintain and more suitable for

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,5 +11,5 @@ We recommend that you access the User Guide through the link above.
 
 There are also links to the User Guide on the main page of the
 [networking-recipe repository](https://github.com/ipdk-io/networking-recipe)
-(upper right-corner, in the **About** section), and under _Documentation_
+(upper right-hand corner, in the **About** section), and under _Documentation_
 in the [README file](https://github.com/ipdk-io/networking-recipe#readme).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Source Files for the P4 Control Plane User Guide
+
+The files in this directory are used to build the
+[P4 Control Plane User Guide](https://ipdk.io/p4cp-userguide/).
+
+They can be read individually, but the internal links are relative to the
+root of the user guide and won't work correctly if you're not browsing the
+user guide itself.
+
+We recommend that you use the link above to read the User Guide itself.
+
+There are also links to it on the main page of the
+[networking-recipe repository](https://github.com/ipdk-io/networking-recipe)
+(upper right-corner, in the **About** section), and under _Documentation_
+in the [README file](https://github.com/ipdk-io/networking-recipe#readme).

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,13 +3,13 @@
 The files in this directory are used to build the
 [P4 Control Plane User Guide](https://ipdk.io/p4cp-userguide/).
 
-They can be read individually, but the internal links are relative to the
-root of the user guide and won't work correctly if you're not browsing the
-user guide itself.
+You can view the source files individually, but the internal links are
+relative to the root of the user guide. Many of them won't work correctly
+outside the context of the finished document.
 
-We recommend that you use the link above to read the User Guide itself.
+We recommend that you access the User Guide through the link above.
 
-There are also links to it on the main page of the
+There are also links to the User Guide on the main page of the
 [networking-recipe repository](https://github.com/ipdk-io/networking-recipe)
 (upper right-corner, in the **About** section), and under _Documentation_
 in the [README file](https://github.com/ipdk-io/networking-recipe#readme).

--- a/setup/README.md
+++ b/setup/README.md
@@ -5,9 +5,9 @@
 The Stratum dependencies have formally moved from the `setup` directory
 to a new <https://github.com/ipdk-io/stratum-deps> repository.
 
-This change makes the dependencies easier to maintain, and it allows
-them to be downloaded and built independently of the Networking Recipe
-(P4 Control Plane).
+This change allows the dependencies to be downloaded and built independently
+of the Networking Recipe (P4 Control Plane).
+It also makes them easier to maintain.
 
 See the [README file](https://github.com/ipdk-io/stratum-deps/blob/main/README.md)
 in the `stratum-deps` repository for more information.


### PR DESCRIPTION
- Users frequently access the files under the `/docs` folder directly, and wonder why internal links don't work. This README explains the nature of the files and recommends that the reader visit the website for the user guide instead of its source.
- Made minor changes to two other README files along the way.