### PR TITLE
Refine p4runtime protobuf generation

### DIFF
--- a/cmake/FindHostProtoc.cmake
+++ b/cmake/FindHostProtoc.cmake
@@ -13,19 +13,31 @@ include_guard(GLOBAL)
 find_program(HOST_PROTOC_COMMAND "protoc" NO_CMAKE_FIND_ROOT_PATH)
 mark_as_advanced(HOST_PROTOC_COMMAND)
 
-if(HOST_PROTOC_COMMAND)
-  execute_process(
-    COMMAND ${HOST_PROTOC_COMMAND} --version
-    OUTPUT_VARIABLE protoc_output
-  )
-  string(STRIP "${protoc_output}" protoc_output)
-  string(REGEX REPLACE
-    "^libprotoc +([0-9.]+)$" "\\1" PROTOC_VERSION ${protoc_output})
-  message(STATUS "Found protoc: ${HOST_PROTOC_COMMAND} (version found \"${PROTOC_VERSION}\")")
-  unset(protoc_output)
-else()
+if(NOT HOST_PROTOC_COMMAND)
   message(FATAL_ERROR "protoc not found")
 endif()
+
+#-----------------------------------------------------------------------
+# Get compiler version number.
+#-----------------------------------------------------------------------
+execute_process(
+  COMMAND ${HOST_PROTOC_COMMAND} --version
+  OUTPUT_VARIABLE protoc_output
+)
+string(STRIP "${protoc_output}" protoc_output)
+
+string(REGEX REPLACE
+  "^libprotoc +([0-9.]+)$" "\\1" protoc_version "${protoc_output}")
+
+message(STATUS "Found protoc: ${HOST_PROTOC_COMMAND} (version found \"${protoc_version}\")")
+
+if(NOT protoc_version STREQUAL "")
+  set(HOST_PROTOC_VERSION "${protoc_version}" CACHE STRING "Host Protobuf compiler version")
+  mark_as_advanced(HOST_PROTOC_VERSION)
+endif()
+
+unset(protoc_output)
+unset(protoc_version)
 
 #-----------------------------------------------------------------------
 # gRPC c++ plugin for the Protobuf compiler.

--- a/cmake/P4RuntimeProtobufs.cmake
+++ b/cmake/P4RuntimeProtobufs.cmake
@@ -7,7 +7,7 @@
 
 if(DEFINED GEN_GO_PROTOBUFS)
   # Don't forward option to external project if it's undefined.
-  set(gen_go_protobufs -DGEN_GO_PROTOBUFS=${GEN_GO_PROTOBUFS})
+  set(_gen_go_protobufs -DGEN_GO_PROTOBUFS=${GEN_GO_PROTOBUFS})
 endif()
 
 ExternalProject_Add(protobufs
@@ -19,10 +19,10 @@ ExternalProject_Add(protobufs
     -DCPP_OUT=${CMAKE_CURRENT_BINARY_DIR}/cpp_out
     -DGO_OUT=${CMAKE_CURRENT_BINARY_DIR}/go_out
     -DPY_OUT=${CMAKE_CURRENT_BINARY_DIR}/py_out
-    ${gen_go_protobufs}
+    ${_gen_go_protobufs}
   INSTALL_COMMAND
     ${CMAKE_MAKE_PROGRAM} install
   EXCLUDE_FROM_ALL TRUE
 )
 
-unset(gen_go_protobufs)
+unset(_gen_go_protobufs)

--- a/protobufs/CMakeLists.txt
+++ b/protobufs/CMakeLists.txt
@@ -13,26 +13,22 @@ project(protobufs VERSION 2023.11.0 LANGUAGES CXX)
 include(CMakePrintHelpers)
 include(GNUInstallDirs)
 
-# Initialize if we are being configured for a direct build.
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(DEPEND_INSTALL_DIR "$ENV{DEPEND_INSTALL}" CACHE PATH
-      "Dependencies install directory")
+set(DEPEND_INSTALL_DIR "$ENV{DEPEND_INSTALL}" CACHE PATH
+    "Dependencies install directory")
 
-  if(DEPEND_INSTALL_DIR STREQUAL "")
-    message(FATAL_ERROR "DEPEND_INSTALL_DIR (DEPEND_INSTALL) not defined!")
-  endif()
-
-  list(APPEND CMAKE_PREFIX_PATH ${DEPEND_INSTALL_DIR})
-
-  # Add networking-recipe/cmake to the search path for the package file.
-  get_filename_component(_path "../cmake" REALPATH)
-  cmake_print_variables(_path)
-  list(APPEND CMAKE_MODULE_PATH ${_path})
-  unset(_path)
-
-  # Find the host Protobuf compiler.
-  find_package(HostProtoc)
+if(DEPEND_INSTALL_DIR STREQUAL "")
+  message(FATAL_ERROR "DEPEND_INSTALL_DIR (DEPEND_INSTALL) not defined!")
 endif()
+
+list(APPEND CMAKE_PREFIX_PATH ${DEPEND_INSTALL_DIR})
+
+# Add networking-recipe/cmake to the search path for the package file.
+get_filename_component(_path "../cmake" REALPATH)
+list(APPEND CMAKE_MODULE_PATH ${_path})
+unset(_path)
+
+# Find the host Protobuf compiler.
+find_package(HostProtoc)
 
 set(GRPC_OUT_ENABLED FALSE CACHE BOOL "Generate grpc_out directory")
 set(WHEEL_ENABLED TRUE CACHE BOOL "Generate Python wheel")


### PR DESCRIPTION
- Fix parse error in HostProtoC when version string returned by protoc is empty.

- It turns out that there is no effective difference between building as an external project (through networking-recipe) and build when invoked directly in the protobufs directory. Revise project initialization to take this into account.

- Protobuf generation does not use any cross-compilation tools. Don't support it when cross-compiling.