### PR TITLE
Refine p4runtime protobuf generation

### DIFF
--- a/protobufs/CMakeLists.txt
+++ b/protobufs/CMakeLists.txt
@@ -30,8 +30,7 @@ unset(_path)
 # Find the host Protobuf compiler.
 find_package(HostProtoc)
 
-set(GRPC_OUT_ENABLED FALSE CACHE BOOL "Generate grpc_out directory")
-set(WHEEL_ENABLED TRUE CACHE BOOL "Generate Python wheel")
+set(GEN_PY_WHEEL TRUE CACHE BOOL "Generate Python wheel")
 
 # Generation of the Go protobuf files may be enabled/disabled explicitly
 # through the GEN_GO_PROTOBUFS option. If the option is undefined,
@@ -52,13 +51,6 @@ endif()
 set(CPP_OUT ${CMAKE_BINARY_DIR}/cpp_out CACHE PATH "C++ protobuf files")
 file(MAKE_DIRECTORY ${CPP_OUT})
 
-if(GRPC_OUT_ENABLED)
-  set(GRPC_OUT ${CMAKE_BINARY_DIR}/grpc_out CACHE PATH "C++ gRPC files")
-  file(MAKE_DIRECTORY ${GRPC_OUT})
-else()
-  set(GRPC_OUT ${CPP_OUT})
-endif()
-
 # Directory for generated Python files.
 set(PY_OUT ${CMAKE_BINARY_DIR}/py_out CACHE PATH "Python protobuf files")
 file(MAKE_DIRECTORY ${PY_OUT})
@@ -67,9 +59,7 @@ file(MAKE_DIRECTORY ${PY_OUT})
 if(GEN_GO_PROTOBUFS)
   set(GO_OUT ${CMAKE_BINARY_DIR}/go_out CACHE PATH "Go protobuf files")
   file(MAKE_DIRECTORY ${GO_OUT})
-else(GEN_GO_PROTOBUFS)
-  set(_sink ${GO_OUT}) # suppress cmake warning
-endif(GEN_GO_PROTOBUFS)
+endif()
 
 # Where to find the .proto files.
 set(GOOGLE_SOURCE_DIR "../stratum/googleapis")
@@ -78,6 +68,6 @@ set(P4RT_PROTO_DIR "../stratum/p4runtime/proto")
 include(google.cmake)
 include(p4runtime.cmake)
 include(tarballs.cmake)
-if(WHEEL_ENABLED)
+if(GEN_PY_WHEEL)
   include(wheel.cmake)
 endif()

--- a/protobufs/p4runtime.cmake
+++ b/protobufs/p4runtime.cmake
@@ -58,7 +58,7 @@ add_custom_target(p4rt_grpc_out ALL
   COMMAND
     ${HOST_PROTOC_COMMAND}
     ${grpc_proto_sources}
-    --grpc_out ${GRPC_OUT}
+    --grpc_out ${CPP_OUT}
     --plugin=protoc-gen-grpc=${HOST_GRPC_CPP_PLUGIN}
     ${PROTOFLAGS}
   BYPRODUCTS
@@ -96,10 +96,5 @@ if(GEN_GO_PROTOBUFS)
     WORKING_DIRECTORY
       ${CMAKE_CURRENT_SOURCE_DIR}
     VERBATIM
-  )
-else(GEN_GO_PROTOBUFS)
-  add_custom_target(p4rt_go_out ALL
-    COMMAND ""
-    COMMENT "p4rt_go_out is disabled"
   )
 endif(GEN_GO_PROTOBUFS)

--- a/protobufs/tarballs.cmake
+++ b/protobufs/tarballs.cmake
@@ -6,15 +6,13 @@
 #
 
 set(tarball_suffix ${CMAKE_PROJECT_VERSION}.tar.gz)
-set(cpp_tarball_name p4runtime-cpp-${tarball_suffix})
-set(go_tarball_name p4runtime-go-${tarball_suffix})
-
-get_filename_component(cpp_dir ${CPP_OUT} NAME_WE)
-get_filename_component(go_dir "${GO_OUT}" NAME_WE)
-
 set(tar_flags -z --owner=ipdk --group=ipdk --sort=name)
 
 # C++ tarball
+set(cpp_tarball_name p4runtime-cpp-${tarball_suffix})
+set(cpp_tarball ${CMAKE_CURRENT_BINARY_DIR}/${cpp_tarball_name})
+get_filename_component(cpp_dir ${CPP_OUT} NAME_WE)
+
 add_custom_target(cpp-tarball ALL
   COMMAND
     tar -cf ${cpp_tarball_name}
@@ -26,7 +24,7 @@ add_custom_target(cpp-tarball ALL
     p4rt_cpp_out
     p4rt_grpc_out
   BYPRODUCTS
-    ${CMAKE_CURRENT_BINARY_DIR}/${cpp_tarball_name}
+    ${cpp_tarball}
   WORKING_DIRECTORY
     ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT
@@ -38,6 +36,10 @@ add_custom_target(cpp-tarball ALL
 
 # Go tarball
 if(GEN_GO_PROTOBUFS)
+  set(go_tarball_name p4runtime-go-${tarball_suffix})
+  set(go_tarball ${CMAKE_CURRENT_BINARY_DIR}/${go_tarball_name})
+  get_filename_component(go_dir ${GO_OUT} NAME_WE)
+
   add_custom_target(go-tarball ALL
     COMMAND
       tar -cf ${go_tarball_name}
@@ -48,25 +50,20 @@ if(GEN_GO_PROTOBUFS)
       google_go_out
       p4rt_go_out
     BYPRODUCTS
-      ${CMAKE_CURRENT_BINARY_DIR}/${go_tarball_name}
+      ${go_tarball}
     WORKING_DIRECTORY
       ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT
       "Generating Go tarball"
     VERBATIM
   )
-  set(go_tarball ${CMAKE_CURRENT_BINARY_DIR}/${go_tarball_name})
-else(GEN_GO_PROTOBUFS)
-  add_custom_target(go-tarball ALL
-    COMMAND ""
-    COMMENT "go-tarball is disabled"
-  )
+else()
   set(go_tarball "")
-endif(GEN_GO_PROTOBUFS)
+endif()
 
 install(
   FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/${cpp_tarball_name}
+    ${cpp_tarball}
     ${go_tarball}
   DESTINATION
     ${CMAKE_INSTALL_DATAROOTDIR}/p4runtime


### PR DESCRIPTION
- Place definitions of variables related to generating the Go tarball under the control of the GEN_GO_PROTOBUFS conditional. In addition to being better encapsulation, this fixes a cmake "incorrect number of arguments" error when Go protobuf generation is disabled.

- Remove definitions of dummy p4rt_go_out and go-tarball targets when Go protobuf generation is disabled. They serve no useful purpose.

- Remove vestigial GRPC_OUT_ENABLED and GRPC_OUT variables.

- Rename WHEEL_ENABLED variable to GEN_PY_WHEEL.