### PR TITLE
Update README in protobufs directory

### DIFF
--- a/protobufs/README.md
+++ b/protobufs/README.md
@@ -41,7 +41,7 @@ protobufs.
 ## Main directory
 
 To build the P4Runtime protobufs in the main directory, you must first
-configure cmake to build for the x86 host (not cross-compiled for the ACC).
+configure cmake to build for the x86 host (not cross-compile for the ACC).
 
 If you've done a recent build, there should already be a configuration.
 

--- a/protobufs/README.md
+++ b/protobufs/README.md
@@ -154,7 +154,8 @@ used to escape temporarily to the host build environment.
 4. Neutralize the cross-compilation environment.
 
    ```bash
-   unset CMAKE_TOOLCHAIN_FILE CMAKE_SYSROOT
+   unset CMAKE_TOOLCHAIN_FILE
+   unset CMAKE_SYSROOT
    ```
 
 5. Build the P4Runtime protobufs.

--- a/protobufs/README.md
+++ b/protobufs/README.md
@@ -11,16 +11,37 @@ The following packages must be installed:
 
 - Stratum dependencies
 - Python 3.8 or above
-- Python dependencies (`requirements.txt`)
+- Python dependencies
+
+The Python wheel requires that the `build`, `setuptools`, and `wheel`
+modules be installed. These are included in the `requirements.txt` file.
 
 If you wish to generate protobufs for Go, follow the instructions in the
 [Quick start](https://grpc.io/docs/languages/go/quickstart/) guide
-to install Go and the gRPC plugins.
+to install golang and the gRPC plugins.
+
+## Build environment
+
+The P4Runtime protobufs are built in HOST mode. They are are not
+cross-compiled, and will not build correctly in the cross-compilation
+environment.
+
+The build requires the Host (x86) dependencies, not the ACC (aarch64)
+dependencies.
+
+You may use the `DEPEND_INSTALL` environment variable
+or the `DEPEND_INSTALL_DIR` cmake variable
+to specify the location of the host dependencies.
+
+If you are in the ACC build environment, see
+[Escaping the ACC build environment](#escaping-the-acc-build-environment)
+for a way to change the environment temporarily so you can build the
+protobufs.
 
 ## Main directory
 
 To build the P4Runtime protobufs in the main directory, you must first
-configure cmake.
+configure cmake to build for the x86 host (not cross-compiled for the ACC).
 
 If you've done a recent build, there should already be a configuration.
 
@@ -75,16 +96,90 @@ The Go tarball will be omitted if golang is not installed.
 
 The P4Runtime protocol buffers can also be built in the `protobufs` directory.
 
-Change to the `protobufs` directory.
+1. Change to the `protobufs` directory.
 
-Make sure the `DEPEND_INSTALL` environment variable is set.
+2. Remove the `build` directory, if it exists.
 
-Issue the following commands:
+   ```bash
+   rm -fr build
+   ```
 
-```bash
-cmake -B build
-cmake --build build
-cmake --install build --prefix install
-```
+3. Issue the following commands:
 
-The tarballs will be installed in the local `install` directory.
+   ```bash
+   cmake -B build [-DDEPEND_INSTALL_DIR=<host dependencies>]
+   cmake --build build
+   cmake --install build --prefix <install directory>
+   ```
+
+   `<host dependencies>` is the directory containing the host dependencies
+   (the Stratum dependencies compiled for the x86).
+
+   `<install directory>` is the directory in which you are installing
+   P4 Control Plane, or an alternative location (e.g. `install`).
+
+   You may omit `DEPEND_INSTALL_DIR` if the `DEPEND_INSTALL` environment
+   variable is set to the location of the host dependencies.
+
+The tarballs and Python wheel will be installed in the `share/p4runtime`
+folder under the `<install directory>`.
+
+The Go tarball will be omitted if golang is not installed.
+
+## Escaping the ACC build environment
+
+As noted above, the P4Runtime protobufs must be generated in the host build
+environment, not the environment used to cross-compile P4 Control Plane
+for the ACC.
+
+If you're in the ACC build environment, the following procedure may be
+used to escape temporarily to the host build environment.
+
+1. Change to the `protobufs` directory.
+
+2. Remove the `build` directory, if it exists.
+
+   ```bash
+   rm -fr build
+   ```
+
+3. Start a subshell.
+
+   ```bash
+   bash
+   ```
+
+   This preserves your current environment.
+
+4. Neutralize the cross-compilation environment.
+
+   ```bash
+   unset CMAKE_TOOLCHAIN_FILE CMAKE_SYSROOT
+   ```
+
+5. Build the P4Runtime protobufs.
+
+   ```bash
+   cmake -B build -DDEPEND_INSTALL_DIR=<host dependencies>
+   cmake --build build
+   cmake --install build --prefix <install directory>
+   ```
+
+   `<host dependencies>` is the directory containing the host dependencies
+   (the Stratum dependencies compiled for the x86).
+
+   `<install directory>` is the directory in which you are installing
+   P4 Control Plane, or an alternative location (e.g. `install`).
+
+6. Exit the subshell.
+
+   ```bash
+   exit
+   ```
+
+   This restores your original environment.
+
+The tarballs and Python wheel will be installed in the `share/p4runtime`
+folder under the `<install directory>`.
+
+The Go tarball will be omitted if golang is not installed.


### PR DESCRIPTION
- Add "Build environment" section.

- Add "Escaping the ACC build environment" section.

No, I did not forget to number the steps in the "Main directory" section. 🙂 This section has a _narrative_ structure; it talks the reader through the process. The other two sections have a _procedural_ structure; each enumerates a list of steps. This is done in part to highlight the differences between the second and third sections.

"Though this be madness, yet there is method in't." (Hamlet, Act 2, Scene 2)

----

I do not currently have access to an ACC cross-development environment. Could someone who does please test the procedure described in the "Escaping the ACC build environment" section to make sure it works? Thanks.