### PR TITLE
Add LNW with LAG to user guide

### DIFF
--- a/docs/apps/lnw/lnw-index.rst
+++ b/docs/apps/lnw/lnw-index.rst
@@ -24,4 +24,5 @@ ES2K
    es2k/es2k-linux-networking-ipv6
    es2k/es2k-linux-networking-ecmp
    es2k/es2k-linux-networking-frr
+   es2k/es2k-linux-networking-lag
    


### PR DESCRIPTION
This PR against the `update_lag_guide` PR is needed to make the document part of the user guide.

@aashishkuma - You should be able to merge this into your PR. It does not require any approvals