### PR TITLE
Add SDE_INSTALL lib path to LD_LIBARY_PATH only if directories exist

### DIFF
--- a/scripts/common/setup_env.sh
+++ b/scripts/common/setup_env.sh
@@ -37,11 +37,12 @@ echo "${OS} : ${VER}"
 
 # Update SDE libraries
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${SDE_INSTALL}/lib
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${SDE_INSTALL}/lib64
 
-if [ "$OS" = "Fedora" ]; then
+if [ -d ${SDE_INSTALL}/lib64 ]; then
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${SDE_INSTALL}/lib64
-else
+fi
+
+if [ -d ${SDE_INSTALL}/lib/x86_64-linux-gnu ]; then
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${SDE_INSTALL}/lib/x86_64-linux-gnu
 fi
 


### PR DESCRIPTION
The `setup_env.sh` script was defaulting to add `{SDE_INSTALL}/lib/x86_64-linux-gnu` for all non-Fedora systems, whether the directory exists or not.
There was also no check for Rocky Linux. 

Updated the script to check if directory exists and only then add to LD_LIBRARY_PATH env var.

Older script would set the following paths on Rocky Linux (the `/opt/p4/p4sde/lib/x86_64-linux-gnu` does not exist):

`
LD_LIBRARY_PATH: /opt/p4/p4-cp-nws/lib:/opt/p4/p4-cp-nws/lib64:/opt/p4/p4-cp-nws/lib:/opt/p4/p4-cp-nws/lib64::/opt/p4/p4sde/lib:/opt/p4/p4sde/lib64:/opt/p4/p4sde/lib/x86_64-linux-gnu:/usr/local/lib:/usr/local/lib64
`

Updated script sets following paths:
`
LD_LIBRARY_PATH: /opt/p4/p4-cp-nws/lib:/opt/p4/p4-cp-nws/lib64:/opt/p4/p4-cp-nws/lib:/opt/p4/p4-cp-nws/lib64::/opt/p4/p4sde/lib:/opt/p4/p4sde/lib64:/usr/local/lib:/usr/local/lib64`
