### PR TITLE
Fix VLAN TAG issue in original packet.

### DIFF
--- a/ovs-p4rt/ovs_p4rt.cc
+++ b/ovs-p4rt/ovs_p4rt.cc
@@ -177,25 +177,6 @@ void PrepareFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
                        ACTION_REMOVE_VLAN_AND_FWD_PARAM_VLAN_PTR));
         param->set_value(EncodeByteValue(1, learn_info.vlan_info.port_vlan));
       }
-    } else if (learn_info.vlan_info.port_vlan_mode ==
-               P4_PORT_VLAN_NATIVE_TAGGED) {
-      action->set_action_id(
-          GetActionId(p4info, L2_FWD_TX_TABLE_ACTION_ADD_VLAN_AND_FWD));
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info,
-                                       L2_FWD_TX_TABLE_ACTION_ADD_VLAN_AND_FWD,
-                                       ACTION_ADD_VLAN_AND_FWD_PARAM_PORT_ID));
-        auto port_id = learn_info.src_port;
-        param->set_value(EncodeByteValue(1, port_id));
-      }
-      {
-        auto param = action->add_params();
-        param->set_param_id(GetParamId(p4info,
-                                       L2_FWD_TX_TABLE_ACTION_ADD_VLAN_AND_FWD,
-                                       ACTION_ADD_VLAN_AND_FWD_PARAM_VLAN_PTR));
-        param->set_value(EncodeByteValue(1, learn_info.vlan_info.port_vlan));
-      }
     } else {
       action->set_action_id(GetActionId(p4info, L2_FWD_TX_TABLE_ACTION_L2_FWD));
       {


### PR DESCRIPTION
With the existing code, for a VLAN TAG port when we receive a TAG packet, we are appedning one more level of TAG and forwarding the packet. This is causing double VLAN tag on the egress packet. This causes traffic to be dropped.

With this code, If a port is already configured with TAG, then we know that it can receive only TAG traffic and that means original pkt will already have a TAG and we dont need to add one more tag to the packet. Remove piece of code which adds TAG to the orig packet.