### PR TITLE
Refine p4cp github lint workflows

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,4 +1,4 @@
-name: "Lint P4CP Documentation"
+name: "P4CP lint checks"
 
 on:
   push:
@@ -9,6 +9,11 @@ on:
     branches:
       - main
       - ipdk_v*
+
+concurrency:
+  # If workflow is currently running, stop it and start a new one.
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions: read-all
 
@@ -106,3 +111,48 @@ jobs:
         if: steps.changed.outputs.any_changed == 'true'
         run: |
           rstcheck ${{ steps.changed.outputs.all_changed_files }}
+
+  #---------------------------------------------------------------------
+  # 4-py_bandit_check
+  #---------------------------------------------------------------------
+  py_bandit_check:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone networking-recipe
+        uses: actions/checkout@v4
+
+      - name: Check Python files
+        uses: tj-actions/bandit@v5.5
+        with:
+          targets: |  # or a single string "."
+            **/**.py
+            clients/p4rt-ctl/p4rt-ctl.in
+          options: "-v"
+
+  #---------------------------------------------------------------------
+  # 5-clang_format_check
+  #---------------------------------------------------------------------
+  clang_format_check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get list of changed files
+        id: changed
+        uses: tj-actions/changed-files@v41
+        with:
+          files: |
+            **.c
+            **.cc
+            **.h
+
+      - name: Check for formatting errors
+        if: steps.changed.outputs.any_changed == 'true'
+        run: |
+          clang-format -n -Werror ${{ steps.changed.outputs.all_changed_files }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,4 +1,4 @@
-name: "P4 Control Plane CI Pipeline"
+name: "P4CP build checks"
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
       - ipdk_v*
 
 concurrency:
-  # If workflow for PR or push is already running, stop it and start a new one.
+  # If workflow is currently running, stop it and start a new one.
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
@@ -126,26 +126,7 @@ jobs:
           cmake --build build --target krnlmon-test
 
   #---------------------------------------------------------------------
-  # 3-py_bandit_check
-  #---------------------------------------------------------------------
-  py_bandit_check:
-     timeout-minutes: 5
-     runs-on: ubuntu-latest
-     steps:
-       - name: Clone networking-recipe
-         uses: actions/checkout@v4
-         with:
-           path: recipe
-
-       - name: Check p4rt-ctl
-         uses: tj-actions/bandit@v5.5
-         with:
-           targets: |  # or a single string "."
-            ./recipe/clients/p4rt-ctl/p4rt-ctl.in
-           options: "-v"
-
-  #---------------------------------------------------------------------
-  # 4-build_p4runtime_protos
+  # 3-build_p4runtime_protos
   #---------------------------------------------------------------------
   build_p4runtime_protos:
     runs-on: ubuntu-latest
@@ -212,30 +193,3 @@ jobs:
           cmake -B build
           cmake --build build
           cmake --install build --prefix install
-
-  #---------------------------------------------------------------------
-  # 5-clang_format_check
-  #---------------------------------------------------------------------
-  clang_format_check:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get list of changed files
-        id: changed
-        uses: tj-actions/changed-files@v42
-        with:
-          files: |
-            **.c
-            **.cc
-            **.h
-
-      - name: Check for formatting errors
-        if: steps.changed.outputs.any_changed == 'true'
-        run: |
-          clang-format -n -Werror ${{ steps.changed.outputs.all_changed_files }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041 -->
-[![P4 Control Plane CI Pipeline](https://github.com/ipdk-io/networking-recipe/actions/workflows/pipeline.yml/badge.svg)](https://github.com/ipdk-io/networking-recipe/actions/workflows/pipeline.yml)
+[![P4CP build checks](https://github.com/ipdk-io/networking-recipe/actions/workflows/pipeline.yml/badge.svg)](https://github.com/ipdk-io/networking-recipe/actions/workflows/pipeline.yml)
 <!-- markdownlint-enable MD041 -->
 # P4 Control Plane
 


### PR DESCRIPTION
- Rename lintdocs.yml to linters.yml.

- Move py_bandit_check and clang_format_check to linters.yml.

- Expand py_bandit_check to apply to all .py files.