### PR TITLE
RBAC client side support

### DIFF
--- a/clients/p4rt-ctl/p4rt-ctl.in
+++ b/clients/p4rt-ctl/p4rt-ctl.in
@@ -1,6 +1,6 @@
 #! @PYTHON3@
 #
-# Copyright (c) 2021-2023 Intel Corporation.
+# Copyright (c) 2021-2024 Intel Corporation.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -590,8 +590,11 @@ class P4RuntimeClient:
 
     def __init__(self, device_id, grpc_addr='localhost:9559',
                  election_id=(1, 0)):
+        global client_role_name
+
         self.device_id = device_id
         self.election_id = election_id
+        self.role_name = client_role_name
         grpc_addr = str(grpc_server_addr)
 
         root_ca_file_path = '/usr/share/stratum/certs/ca.crt'
@@ -664,6 +667,8 @@ class P4RuntimeClient:
         election_id = arbitration.election_id
         election_id.high = self.election_id[0]
         election_id.low = self.election_id[1]
+        if self.role_name is not None:
+            arbitration.role.name = self.role_name
         self.stream_out_q.put(req)
 
         rep = self.get_stream_packet("arbitration", timeout=2)
@@ -730,6 +735,8 @@ class P4RuntimeClient:
         election_id = req.election_id
         election_id.high = self.election_id[0]
         election_id.low = self.election_id[1]
+        if self.role_name is not None:
+            req.role = self.role_name
         req.action = p4runtime_pb2.SetForwardingPipelineConfigRequest. \
             VERIFY_AND_COMMIT
         with open(p4info_path, 'r') as f1:
@@ -757,6 +764,8 @@ class P4RuntimeClient:
         election_id = req.election_id
         election_id.high = self.election_id[0]
         election_id.low = self.election_id[1]
+        if self.role_name is not None:
+            req.role = self.role_name
         return self.stub.Write(req)
 
     @parse_p4runtime_write_error
@@ -766,6 +775,8 @@ class P4RuntimeClient:
         election_id = req.election_id
         election_id.high = self.election_id[0]
         election_id.low = self.election_id[1]
+        if self.role_name is not None:
+            req.role = self.role_name
         req.updates.extend([update])
         return self.stub.Write(req)
 
@@ -1976,16 +1987,20 @@ def validate_args(argv, command, expected_nr):
         raise Exception("p4rt-ctl: '{}' command requires at least {} "
                         "arguments".format(command, expected_nr))
 
-# Global variable
+# Global variables
 grpc_server_addr = ""
+client_role_name = None
 
 def main():
     global grpc_server_addr
+    global client_role_name
+
     if len(sys.argv) < 2:
         print("p4rt-ctl: missing command name; use --help for help")
         sys.exit(1)
     parser = argparse.ArgumentParser(usage=USAGE)
     parser.add_argument('-g', '--grpc_addr', required=False, type=str, help="P4Runtime gRPC server address, format : <server IP>:<port>")
+    parser.add_argument('-r', '--role_name', required=False, type=str, help="Role name of this client")
     parser.add_argument('command', nargs='*', help='Subcommand to run')
     args = parser.parse_args()
     if args.grpc_addr is None:
@@ -1997,6 +2012,11 @@ def main():
         else:
             print("Invalid IP address for GRPC server ")
             system.exit(1)
+    
+    # client_role_name will default to 'None' (global var) unless user sets
+    # a name using the args.role_name flag
+    client_role_name = args.role_name
+
     if args.command[0] not in all_commands.keys():
         usage()
 

--- a/ovs-p4rt/CMakeLists.txt
+++ b/ovs-p4rt/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build file for ovs-p4rt
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -58,12 +58,16 @@ target_include_directories(ovs_sidecar_o PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+target_include_directories(ovs_sidecar_o PRIVATE ${STRATUM_SOURCE_DIR})
+
 target_include_directories(ovs_sidecar_o PRIVATE ${PROTO_INCLUDES})
 
 add_dependencies(ovs_sidecar_o
     stratum_proto
     p4runtime_proto
 )
+
+target_link_libraries(ovs_sidecar_o PUBLIC p4_role_config)
 
 ################
 # ovs-vswitchd #
@@ -106,6 +110,8 @@ target_link_libraries(ovs-vswitchd PUBLIC
     absl::flags_private_handle_accessor
     absl::flags
 )
+
+target_link_libraries(ovs-vswitchd PUBLIC stratum_static p4_role_config)
 
 target_link_libraries(ovs-vswitchd PUBLIC stratum_static)
 
@@ -158,6 +164,8 @@ target_link_libraries(ovs-testcontroller PUBLIC
     absl::flags_private_handle_accessor
     absl::flags
 )
+
+target_link_libraries(ovs-testcontroller PUBLIC stratum_static p4_role_config)
 
 target_link_libraries(ovs-testcontroller PUBLIC stratum_static)
 

--- a/ovs-p4rt/CMakeLists.txt
+++ b/ovs-p4rt/CMakeLists.txt
@@ -113,8 +113,6 @@ target_link_libraries(ovs-vswitchd PUBLIC
 
 target_link_libraries(ovs-vswitchd PUBLIC stratum_static p4_role_config)
 
-target_link_libraries(ovs-vswitchd PUBLIC stratum_static)
-
 target_link_libraries(ovs-vswitchd PUBLIC
     stratum_proto
     p4runtime_proto
@@ -166,8 +164,6 @@ target_link_libraries(ovs-testcontroller PUBLIC
 )
 
 target_link_libraries(ovs-testcontroller PUBLIC stratum_static p4_role_config)
-
-target_link_libraries(ovs-testcontroller PUBLIC stratum_static)
 
 target_link_libraries(ovs-testcontroller PUBLIC
     stratum_proto

--- a/ovs-p4rt/CMakeLists.txt
+++ b/ovs-p4rt/CMakeLists.txt
@@ -67,7 +67,7 @@ add_dependencies(ovs_sidecar_o
     p4runtime_proto
 )
 
-target_link_libraries(ovs_sidecar_o PUBLIC p4_role_config)
+target_link_libraries(ovs_sidecar_o PUBLIC stratum_static p4_role_config)
 
 ################
 # ovs-vswitchd #

--- a/ovs-p4rt/ovs_p4rt.cc
+++ b/ovs-p4rt/ovs_p4rt.cc
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 // TODO: ovs-p4rt logging
 
@@ -15,9 +15,13 @@
 #include "es2k/p4_name_mapping.h"
 #endif
 
+#define DEFAULT_OVS_P4RT_ROLE_NAME "ovs-p4rt"
+
 ABSL_FLAG(std::string, grpc_addr, "localhost:9559",
           "P4Runtime server address.");
 ABSL_FLAG(uint64_t, device_id, 1, "P4Runtime device ID.");
+ABSL_FLAG(std::string, role_name, DEFAULT_OVS_P4RT_ROLE_NAME,
+          "P4 config role name.");
 
 namespace ovs_p4rt {
 
@@ -2046,7 +2050,7 @@ void ConfigFdbTableEntry(struct mac_learning_info learn_info,
   // Start a new client session.
   auto status_or_session = ovs_p4rt::OvsP4rtSession::Create(
       absl::GetFlag(FLAGS_grpc_addr), GenerateClientCredentials(),
-      absl::GetFlag(FLAGS_device_id));
+      absl::GetFlag(FLAGS_device_id), absl::GetFlag(FLAGS_role_name));
   if (!status_or_session.ok()) return;
 
   // Unwrap the session from the StatusOr object.
@@ -2174,7 +2178,7 @@ void ConfigIpTunnelTermTableEntry(struct tunnel_info tunnel_info,
   // Start a new client session.
   auto status_or_session = OvsP4rtSession::Create(
       absl::GetFlag(FLAGS_grpc_addr), GenerateClientCredentials(),
-      absl::GetFlag(FLAGS_device_id));
+      absl::GetFlag(FLAGS_device_id), absl::GetFlag(FLAGS_role_name));
   if (!status_or_session.ok()) return;
 
   // Unwrap the session from the StatusOr object.
@@ -2198,7 +2202,7 @@ void ConfigRxTunnelSrcTableEntry(struct tunnel_info tunnel_info,
   // Start a new client session.
   auto status_or_session = OvsP4rtSession::Create(
       absl::GetFlag(FLAGS_grpc_addr), GenerateClientCredentials(),
-      absl::GetFlag(FLAGS_device_id));
+      absl::GetFlag(FLAGS_device_id), absl::GetFlag(FLAGS_role_name));
   if (!status_or_session.ok()) return;
 
   // Unwrap the session from the StatusOr object.
@@ -2225,7 +2229,7 @@ void ConfigTunnelSrcPortTableEntry(struct src_port_info tnl_sp,
   // Start a new client session.
   auto status_or_session = OvsP4rtSession::Create(
       absl::GetFlag(FLAGS_grpc_addr), GenerateClientCredentials(),
-      absl::GetFlag(FLAGS_device_id));
+      absl::GetFlag(FLAGS_device_id), absl::GetFlag(FLAGS_role_name));
   if (!status_or_session.ok()) return;
 
   // Unwrap the session from the StatusOr object.
@@ -2259,7 +2263,7 @@ void ConfigSrcPortTableEntry(struct src_port_info vsi_sp, bool insert_entry) {
   // Start a new client session.
   auto status_or_session = OvsP4rtSession::Create(
       absl::GetFlag(FLAGS_grpc_addr), GenerateClientCredentials(),
-      absl::GetFlag(FLAGS_device_id));
+      absl::GetFlag(FLAGS_device_id), absl::GetFlag(FLAGS_role_name));
   if (!status_or_session.ok()) return;
 
   // Unwrap the session from the StatusOr object.
@@ -2318,7 +2322,7 @@ void ConfigVlanTableEntry(uint16_t vlan_id, bool insert_entry) {
   // Start a new client session.
   auto status_or_session = OvsP4rtSession::Create(
       absl::GetFlag(FLAGS_grpc_addr), GenerateClientCredentials(),
-      absl::GetFlag(FLAGS_device_id));
+      absl::GetFlag(FLAGS_device_id), absl::GetFlag(FLAGS_role_name));
   if (!status_or_session.ok()) return;
 
   // Unwrap the session from the StatusOr object.
@@ -2348,7 +2352,7 @@ void ConfigFdbTableEntry(struct mac_learning_info learn_info,
   // Start a new client session.
   auto status_or_session = ovs_p4rt::OvsP4rtSession::Create(
       absl::GetFlag(FLAGS_grpc_addr), GenerateClientCredentials(),
-      absl::GetFlag(FLAGS_device_id));
+      absl::GetFlag(FLAGS_device_id), absl::GetFlag(FLAGS_role_name));
   if (!status_or_session.ok()) return;
 
   // Unwrap the session from the StatusOr object.
@@ -2408,7 +2412,7 @@ void ConfigTunnelTableEntry(struct tunnel_info tunnel_info, bool insert_entry) {
   // Start a new client session.
   auto status_or_session = OvsP4rtSession::Create(
       absl::GetFlag(FLAGS_grpc_addr), GenerateClientCredentials(),
-      absl::GetFlag(FLAGS_device_id));
+      absl::GetFlag(FLAGS_device_id), absl::GetFlag(FLAGS_role_name));
   if (!status_or_session.ok()) return;
 
   // Unwrap the session from the StatusOr object.

--- a/ovs-p4rt/ovs_p4rt_session.cc
+++ b/ovs-p4rt/ovs_p4rt_session.cc
@@ -74,7 +74,7 @@ absl::StatusOr<std::unique_ptr<OvsP4rtSession>> OvsP4rtSession::Create(
   arbitration->set_device_id(device_id);
   arbitration->mutable_role()->set_name(role_name);
   if (stratum::PathExists(DEFAULT_OVS_P4RT_ROLE_CONFIG_FILE)) {
-    // Configuration file, if present, should be parsed & processed
+    // If configuration file is present, it should be parsed & processed
     stratum::P4RoleConfig role_config;
     ::util::Status status = stratum::ReadProtoFromTextFile(
         DEFAULT_OVS_P4RT_ROLE_CONFIG_FILE, &role_config);

--- a/ovs-p4rt/ovs_p4rt_session.cc
+++ b/ovs-p4rt/ovs_p4rt_session.cc
@@ -20,7 +20,7 @@
 
 // TODO: Use ABS_FLAG for file location
 #define DEFAULT_OVS_P4RT_ROLE_CONFIG_FILE \
-  "/usr/share/stratum/networking_role_config.pb.txt"
+  "/usr/share/stratum/ovs_p4rt_role_config.pb.txt"
 
 namespace ovs_p4rt {
 

--- a/ovs-p4rt/ovs_p4rt_session.h
+++ b/ovs-p4rt/ovs_p4rt_session.h
@@ -1,6 +1,6 @@
 // Copyright 2020 Google LLC
 // Copyright 2021-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef OVSP4RT_SESSION_H_
@@ -37,6 +37,7 @@ class OvsP4rtSession {
   // Create the session with given P4runtime stub and device id
   static ::absl::StatusOr<std::unique_ptr<OvsP4rtSession>> Create(
       std::unique_ptr<p4::v1::P4Runtime::Stub> stub, uint32_t device_id,
+      const std::string& role_name,
       ::absl::uint128 election_id = TimeBasedElectionId());
 
   // Create the session with given grpc address, channel credentials
@@ -44,7 +45,8 @@ class OvsP4rtSession {
   static ::absl::StatusOr<std::unique_ptr<OvsP4rtSession>> Create(
       const std::string& address,
       const std::shared_ptr<grpc::ChannelCredentials>& credentials,
-      uint32_t device_id, ::absl::uint128 election_id = TimeBasedElectionId());
+      uint32_t device_id, const std::string& role_name,
+      ::absl::uint128 election_id = TimeBasedElectionId());
 
   // Disable copy semantics.
   OvsP4rtSession(const OvsP4rtSession&) = delete;
@@ -56,12 +58,14 @@ class OvsP4rtSession {
 
   uint32_t DeviceId() const { return device_id_; }
 
+  std::string RoleName() const { return role_name_; }
+
   p4::v1::Uint128 ElectionId() const { return election_id_; }
 
   p4::v1::P4Runtime::Stub& Stub() { return *stub_; }
 
  private:
-  OvsP4rtSession(uint32_t device_id,
+  OvsP4rtSession(uint32_t device_id, std::string role_name,
                  std::unique_ptr<p4::v1::P4Runtime::Stub> stub,
                  ::absl::uint128 election_id)
       : device_id_(device_id),
@@ -75,6 +79,8 @@ class OvsP4rtSession {
   uint32_t device_id_;
 
   p4::v1::Uint128 election_id_;
+
+  std::string role_name_;
 
   std::unique_ptr<p4::v1::P4Runtime::Stub> stub_;
 

--- a/scripts/common/CMakeLists.txt
+++ b/scripts/common/CMakeLists.txt
@@ -8,6 +8,7 @@
 install(
     PROGRAMS
         set_hugepages.sh
+        extract_table_ids_from_p4info.py
     TYPE
         SBIN
 )

--- a/scripts/common/extract_table_ids_from_p4info.py
+++ b/scripts/common/extract_table_ids_from_p4info.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+#
+# Copyright 2024 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generates P4RoleConfig proto file from P4Info input file
+# 
+# This is a helper script that extracts all table IDs from the specified input
+# file and tags as 'exclusive_p4_ids'. User must review and edit as necessary
+# for the client role configuration.
+# See https://github.com/stratum/stratum/blob/main/stratum/public/proto/p4_role_config.md
+# for details
+# 
+
+import re
+import argparse
+
+def parse_input(input_file):
+    with open(input_file, 'r') as file:
+        input_text = file.read()
+
+    # Split the input text into blocks
+    blocks = re.split(r'\n(?=\w)', input_text)
+
+    ids_and_names = []
+
+    # Iterate over each block
+    for block in blocks:
+        # If the block contains a preamble
+        if 'preamble' in block:
+            # Extract the id and name values
+            id_value = re.search(r'id: (\d+)', block)
+            name_value = re.search(r'name: "(.*?)"', block)
+            if id_value and name_value:
+                # Append the id and name to the list as a tuple
+                ids_and_names.append((int(id_value.group(1)), name_value.group(1)))
+
+    return ids_and_names
+
+def write_output(ids_and_names, output_file):
+    with open(output_file, 'w') as file:
+        for id, name in ids_and_names:
+            file.write(f"exclusive_p4_ids: {id}\n")
+        file.write(f"receives_packet_ins: false\n")
+        file.write(f"can_push_pipeline: false\n")
+
+parser = argparse.ArgumentParser(description='This script extracts P4 table ID \
+                                values from the input P4Info.txt file and \
+                                writes them to the output role_config.txt file.')
+parser.add_argument("-i", "--input", required=True, help="input file path")
+parser.add_argument("-o", "--output", required=True, help="output file path")
+args = parser.parse_args()
+
+
+ids_and_names = parse_input(args.input)
+# print(ids_and_names) # debug
+write_output(ids_and_names, args.output)


### PR DESCRIPTION
This PR uses Stratum's RoleConfig proto file definition as present in `stratum/public/proto/p4_role_config.proto` to support role config and role-based access control of P4 clients.

* `ovs-p4rt` sets a role name and pushes a list of P4 entities that it can write to -- client has to list the list of exclusive_p4_ids or shared_p4_ids. If file is present, client will push the roleconfig data to server in the `MasterArbitrationUpdate` message.
* `p4rt-ctl` here only sets the role_name and does not push any other RoleConfig data
   * This follows the p4runtime-shell model since p4rt-ctl is a single-transaction tool. In addition, all calls in the Python script only access networking-recipe section of P4 entities. 

In order to assist in extracting the list of P4 table IDs from a P4Info.txt file, a helper Python script is also included.