### PR TITLE
Fix issues with ovs sidecar and minor issue with p4rt-ctl

### DIFF
--- a/clients/p4rt-ctl/p4rt-ctl.in
+++ b/clients/p4rt-ctl/p4rt-ctl.in
@@ -1848,7 +1848,6 @@ def _format_me(ce):
     return output_buffer
 
 def _format_dme(ce):
-    pdb.set_trace()
     output_buffer = 'table_id={}'.format(ce.table_entry.table_id)
     output_buffer += ', direct_meter_counter_data_green=(bytes={},packets={})'.format(ce.counter_data.green.byte_count, ce.counter_data.green.packet_count)
     output_buffer += ', direct_meter_counter_data_yellow=(bytes={},packets={})'.format(ce.counter_data.yellow.byte_count, ce.counter_data.yellow.packet_count)


### PR DESCRIPTION
Issues fixed:
  - Tunnel termination table is called twice which results in multiple failure logs. Modify code to call only once.
  - SET_TUNNEL_V6 param was not properly setting all IPv6 bits.
  - read either GetL2ToTunnelV6TableEntry only if entry is not found in GetL2ToTunnelV4TableEntry. This is causing multiple unwanted reads and creating lot of failure logs