### PR TITLE
Refine top-level index in user guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,20 +19,17 @@ P4 Control Plane User Guide
 
 .. toctree::
    :maxdepth: 1
+   :caption: Applications
+
+   apps/apps-index
+
+.. toctree::
+   :maxdepth: 1
    :caption: Building
 
    guides/building-for-es2k-host
    guides/building-for-es2k-acc
    scripts/helper-scripts
-
-.. toctree::
-   :maxdepth: 1
-   :caption: P4 Programs
-
-   guides/es2k/compiling-p4-programs
-   guides/es2k/deploying-p4-programs
-   guides/es2k/running-infrap4d
-   guides/es2k/enabling-comm-channel
 
 .. toctree::
    :maxdepth: 1
@@ -42,9 +39,12 @@ P4 Control Plane User Guide
 
 .. toctree::
    :maxdepth: 1
-   :caption: Applications
+   :caption: P4 Programs
 
-   apps/apps-index
+   guides/es2k/compiling-p4-programs
+   guides/es2k/deploying-p4-programs
+   guides/es2k/running-infrap4d
+   guides/es2k/enabling-comm-channel
 
 .. toctree::
    :maxdepth: 1

--- a/docs/updates/dev-updates-index.rst
+++ b/docs/updates/dev-updates-index.rst
@@ -1,0 +1,14 @@
+.. Copyright 2023-2024 Intel Corporation
+   SPDX-License-Identifier: Apache-2.0
+
+===================
+Development Updates
+===================
+
+.. toctree::
+   :maxdepth: 1
+
+   development-update-23.21
+   development-update-22.50
+   development-update-22.44
+

--- a/docs/updates/updates-index.rst
+++ b/docs/updates/updates-index.rst
@@ -4,7 +4,5 @@
 .. toctree::
    :maxdepth: 1
 
-   development-update-23.21
-   development-update-22.50
-   development-update-22.44
    changes-from-p4-ovs
+   dev-updates-index


### PR DESCRIPTION
The top-level index is becoming increasingly confusing. Make a couple of simplifications.

- Alphabetize the section headings (but keep General at the top).

- Create a separate index page for development updates.