### PR TITLE
Move p4_role_config cmake build to stratum

### DIFF
--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build file for Stratum code.
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -36,6 +36,9 @@ set(STRATUM_INCLUDES
     # Protobuf C++ header files.
     ${PB_OUT_DIR}
 )
+
+set(PB_HEADER_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/stratum/pb)
+set(DOT_PROTO_INSTALL_DIR ${CMAKE_INSTALL_DATAROOTDIR}/stratum/proto)
 
 add_subdirectory(proto)
 add_subdirectory(stratum)

--- a/stratum/proto/CMakeLists.txt
+++ b/stratum/proto/CMakeLists.txt
@@ -19,9 +19,6 @@ string(JOIN ":" PROTO_IMPORT_PATH
     /usr/local/include      # variable?
 )
 
-set(PB_HEADER_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/stratum/pb)
-set(DOT_PROTO_INSTALL_DIR ${CMAKE_INSTALL_DATAROOTDIR}/stratum/proto)
-
 include(ProtobufCompile)
 
 #######################
@@ -177,18 +174,3 @@ add_library(stratum_proto SHARED
 target_link_libraries(stratum_proto PUBLIC protobuf::libprotobuf)
 
 install(TARGETS stratum_proto LIBRARY)
-
-########################
-# Build p4_role_config #
-########################
-
-generate_proto_files("stratum/public/proto/p4_role_config.proto" "${STRATUM_SOURCE_DIR}")
-
-add_library(p4_role_config SHARED
-    ${PB_OUT_DIR}/stratum/public/proto/p4_role_config.pb.cc
-    ${PB_OUT_DIR}/stratum/public/proto/p4_role_config.pb.h
-)
-
-target_include_directories(p4_role_config PUBLIC ${PB_OUT_DIR})
-
-install(TARGETS p4_role_config LIBRARY)


### PR DESCRIPTION
- Moved the cmake code to build p4_role_config from networking-recipe to the stratum repository.

This is the first step toward relocating the remainder of the cmake build system for stratum from `networking-recipe` to the `stratum` repository. This should make it easier to make changes (especially adding new files), since we would only have to update one repository, instead of having to coordinate updates to both networking-recipe and stratum.

Paired with https://github.com/ipdk-io/stratum-dev/pull/206