### PR TITLE
Adding the IPDK_ROLE_FIX flag to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ file(MAKE_DIRECTORY ${PB_OUT_DIR})
 # Feature toggles #
 ###################
 
+option(IPDK_ROLE_FIX "Enable IPDK role config changes" ON)
 option(SET_RPATH    "Set RPATH in libraries and executables" OFF)
 option(WITH_KRNLMON "Enable Kernel Monitor support" ON)
 option(WITH_OVSP4RT "Enable OVS support" ON)


### PR DESCRIPTION
The role config fix has been conditionalized in stratum. Instead of using a `#define`, enabling the control via CMake option
