### PR TITLE
Address shellcheck issues

### DIFF
--- a/scripts/common/setup_env.sh
+++ b/scripts/common/setup_env.sh
@@ -29,7 +29,8 @@ export DEPEND_INSTALL=$3
 
 # Get the OS and Version details
 # shellcheck source=/dev/null
-SCRIPT_DIR="$( cd "$(dirname "$( readlink -f ${BASH_SOURCE[0]} )")" >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$( cd "$(dirname "$( readlink -f "${BASH_SOURCE[0]}" )")" >/dev/null 2>&1 && pwd)"
+# shellcheck disable=SC1090
 . "${SCRIPT_DIR}/os_ver_details.sh"
 get_os_ver_details
 echo "OS and Version details..."
@@ -38,11 +39,11 @@ echo "${OS} : ${VER}"
 # Update SDE libraries
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${SDE_INSTALL}/lib
 
-if [ -d ${SDE_INSTALL}/lib64 ]; then
+if [ -d "${SDE_INSTALL}/lib64" ]; then
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${SDE_INSTALL}/lib64
 fi
 
-if [ -d ${SDE_INSTALL}/lib/x86_64-linux-gnu ]; then
+if [ -d "${SDE_INSTALL}/lib/x86_64-linux-gnu" ]; then
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${SDE_INSTALL}/lib/x86_64-linux-gnu
 fi
 


### PR DESCRIPTION
Fixed issues reported by shellcheck.

```text
In ./scripts/common/setup_env.sh line 32:
SCRIPT_DIR="$( cd "$(dirname "$( readlink -f ${BASH_SOURCE[0]} )")" >/dev/null 2>&1 && pwd)"
                                             ^---------------^ SC2086: Double quote to prevent globbing and word splitting.
Did you mean:
SCRIPT_DIR="$( cd "$(dirname "$( readlink -f "${BASH_SOURCE[0]}" )")" >/dev/null 2>&1 && pwd)"

In ./scripts/common/setup_env.sh line 33:
. "${SCRIPT_DIR}/os_ver_details.sh"
  ^-- SC1090: Can't follow non-constant source. Use a directive to specify location.

In ./scripts/common/setup_env.sh line 41:
if [ -d ${SDE_INSTALL}/lib64 ]; then
        ^------------^ SC2086: Double quote to prevent globbing and word splitting.
Did you mean:
if [ -d "${SDE_INSTALL}"/lib64 ]; then

In ./scripts/common/setup_env.sh line 45:
if [ -d ${SDE_INSTALL}/lib/x86_64-linux-gnu ]; then
        ^------------^ SC2086: Double quote to prevent globbing and word splitting.
Did you mean:
if [ -d "${SDE_INSTALL}"/lib/x86_64-linux-gnu ]; then
```