### PR TITLE
Fix condition for insecure mode check in sgnmi_cli

### DIFF
--- a/clients/sgnmi_cli/sgnmi_cli.cc
+++ b/clients/sgnmi_cli/sgnmi_cli.cc
@@ -271,16 +271,16 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
   });
 
   std::shared_ptr<::grpc::Channel> channel;
-  if (!FLAGS_grpc_use_insecure_mode) {
+  if (FLAGS_grpc_use_insecure_mode) {
+    std::shared_ptr<::grpc::ChannelCredentials> channel_credentials =
+        ::grpc::InsecureChannelCredentials();
+    channel = ::grpc::CreateChannel(FLAGS_grpc_addr, channel_credentials);
+  } else {
     ASSIGN_OR_RETURN(auto credentials_manager,
                      CredentialsManager::CreateInstance(true));
     channel = ::grpc::CreateChannel(
         FLAGS_grpc_addr,
         credentials_manager->GenerateExternalFacingClientCredentials());
-  } else {
-    std::shared_ptr<::grpc::ChannelCredentials> channel_credentials =
-        ::grpc::InsecureChannelCredentials();
-    channel = ::grpc::CreateChannel(FLAGS_grpc_addr, channel_credentials);
   }
 
   auto stub = ::gnmi::gNMI::NewStub(channel);

--- a/clients/sgnmi_cli/sgnmi_cli.cc
+++ b/clients/sgnmi_cli/sgnmi_cli.cc
@@ -271,7 +271,7 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
   });
 
   std::shared_ptr<::grpc::Channel> channel;
-  if (FLAGS_grpc_use_insecure_mode) {
+  if (!FLAGS_grpc_use_insecure_mode) {
     ASSIGN_OR_RETURN(auto credentials_manager,
                      CredentialsManager::CreateInstance(true));
     channel = ::grpc::CreateChannel(


### PR DESCRIPTION
The flag that checks whether `sgnmi_cli` is using secure_mode or insecure_mode were inverted. Fixing the bug in this PR