### PR TITLE
Define Linux Networking version for ovs-p4rt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build file for superproject.
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -150,6 +150,9 @@ cmake_print_variables(CMAKE_PREFIX_PATH)
 
 # Stratum dependencies for the target system.
 include(StratumDependencies)
+
+# LNW version options.
+include(LnwVersion)
 
 # Protobuf compiler for the development system.
 find_package(HostProtoc)

--- a/cmake/LnwVersion.cmake
+++ b/cmake/LnwVersion.cmake
@@ -1,0 +1,28 @@
+# cmake/LnwVersion.cmake
+#
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+# Processes the Linux Networking Version (LNW_VERSION) option.
+#
+
+if(ES2K_TARGET)
+  string(STRIP "${LNW_VERSION}" LNW_VERSION)
+
+  if(LNW_VERSION STREQUAL "2")
+    set(LNW_VERSION "2" CACHE STRING "" FORCE)
+  elseif(LNW_VERSION STREQUAL "3")
+    set(LNW_VERSION "3" CACHE STRING "" FORCE)
+  elseif(LNW_VERSION STREQUAL "")
+    set(LNW_VERSION "3" CACHE STRING "" FORCE)
+  else()
+    message(FATAL_ERROR "Invalid LNW_VERSION: '${LNW_VERSION}'")
+  endif()
+
+  set(lnw_flag "LNW_V${LNW_VERSION}")
+  add_compile_options("-D${lnw_flag}")
+  set(${lnw_flag} TRUE)
+  unset(lnw_flag)
+else()
+  set(LNW_VERSION "0" CACHE STRING "" FORCE)
+endif()


### PR DESCRIPTION
Made the LNW_VERSION definitions available in networking-recipe, so the LNW_V2 and LNW_V3 conditionals are available for ovs-p4rt to use.