### PR TITLE
Update p4runtime in requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-p4runtime==1.3.0
+https://github.com/ipdk-io/p4runtime-dev/releases/download/2024.3.0/p4runtime-2024.3.0-py3-none-any.whl
 Jinja2>=3.0.0
 setuptools
 build


### PR DESCRIPTION
- Replaced `p4runtime==1.3.0` with the URL of the current release in the p4runtime-dev repository on ipdk-io. This ensures that the installed python library supports the current version of `p4rt-ctl`.