### PR TITLE
Add logging to ovs-p4rt

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -33,5 +33,6 @@ add_dependencies(ovs_sidecar_o
 target_link_libraries(ovs_sidecar_o PUBLIC
     stratum_static
     p4_role_config_proto
+    absl::strings
 )
 

--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(ovs_sidecar_o OBJECT
     ovsp4rt_session.h
     ovsp4rt_credentials.cc
     ovsp4rt_credentials.h
+    ovsp4rt_logging.h
 )
 
 if(DPDK_TARGET)

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -1,12 +1,12 @@
 // Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
-// TODO: ovs-p4rt logging
 
 #include <arpa/inet.h>
 
 #include <string>
 
 #include "absl/flags/flag.h"
+#include "absl/strings/str_cat.h"
 #include "openvswitch/ovs-p4rt.h"
 #include "ovsp4rt_credentials.h"
 #include "ovsp4rt_logging.h"
@@ -19,8 +19,6 @@
 #endif
 
 #define DEFAULT_OVS_P4RT_ROLE_NAME "ovs-p4rt"
-
-#define ADD_OR_DEL(x) ((x) ? "ADD" : "DELETE")
 
 ABSL_FLAG(uint64_t, device_id, 1, "P4Runtime device ID.");
 ABSL_FLAG(std::string, role_name, DEFAULT_OVS_P4RT_ROLE_NAME,
@@ -116,6 +114,21 @@ int GetMatchFieldId(const ::p4::config::v1::P4Info& p4info,
 static inline int32_t ValidIpAddr(uint32_t nw_addr) {
   return (nw_addr && nw_addr != INADDR_ANY && nw_addr != INADDR_LOOPBACK &&
           nw_addr != 0xffffffff);
+}
+
+const std::string TableErrorMessage(bool inserting, const char* table) {
+  if (inserting) {
+    return absl::StrCat("Error adding entry to ", table);
+  } else {
+    return absl::StrCat("Error deleting entry from ", table);
+  }
+}
+
+const std::string FormatMac(const uint8_t* mac_addr) {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%x:%x:%x:%x:%x:%x", mac_addr[0], mac_addr[1],
+           mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
+  return buf;
 }
 
 #if defined(ES2K_TARGET)
@@ -2271,42 +2284,43 @@ void ConfigFdbTableEntry(struct mac_learning_info learn_info, bool insert_entry,
       auto status_or_read_response =
           GetFdbTunnelTableEntry(session.get(), learn_info, p4info);
       if (status_or_read_response.ok()) {
-        LOG(ERROR) << "TUNNEL: read FDB L2_FWD_TX_TABLE entry present";
+        LOG(ERROR) << "Error adding to FDB Tunnel Table: entry already exists";
         return;
       }
     }
 
     status = ConfigFdbTunnelTableEntry(session.get(), learn_info, p4info,
                                        insert_entry);
-    if (!status.ok())
-      LOG(ERROR) << ADD_OR_DEL(insert_entry)
-                 << ": Failed to program l2_fwd_tx_table for tunnel";
+    if (!status.ok()) {
+      LOG(ERROR) << TableErrorMessage(insert_entry, "FDB Tunnel Table");
+      // TODO(derek): Most of the error cases don't return. Should they?
+    }
 
     status = ConfigL2TunnelTableEntry(session.get(), learn_info, p4info,
                                       insert_entry);
-    if (!status.ok())
-      LOG(ERROR) << ADD_OR_DEL(insert_entry)
-                 << ": Failed to program l2_tunnel_to_v4_table for tunnel";
+    if (!status.ok()) {
+      LOG(ERROR) << TableErrorMessage(insert_entry, "L2 Tunnel Table");
+    }
 
     status = ConfigFdbSmacTableEntry(session.get(), learn_info, p4info,
                                      insert_entry);
-    if (!status.ok())
-      LOG(ERROR) << ADD_OR_DEL(insert_entry)
-                 << ": Failed to program l2_fwd_smac_table";
+    if (!status.ok()) {
+      LOG(ERROR) << TableErrorMessage(insert_entry, "FDB Source MAC Table");
+    }
   } else {
     if (insert_entry) {
       auto status_or_read_response =
           GetFdbVlanTableEntry(session.get(), learn_info, p4info);
       if (status_or_read_response.ok()) {
-        LOG(WARNING) << "Non TUNNEL: read FDB L2_FWD_TX_TABLE entry present";
+        LOG(WARNING) << "Error adding to FDB Vlan Table: entry already exists";
         return;
       }
 
       status = ConfigFdbRxVlanTableEntry(session.get(), learn_info, p4info,
                                          insert_entry);
-      if (!status.ok())
-        LOG(ERROR) << ADD_OR_DEL(insert_entry)
-                   << ": Failed to program l2_fwd_rx_table";
+      if (!status.ok()) {
+        LOG(ERROR) << TableErrorMessage(insert_entry, "FDB Rx Vlan Table");
+      }
 
       status_or_read_response =
           GetTxAccVsiTableEntry(session.get(), learn_info.src_port, p4info);
@@ -2346,20 +2360,15 @@ void ConfigFdbTableEntry(struct mac_learning_info learn_info, bool insert_entry,
 
     status = ConfigFdbTxVlanTableEntry(session.get(), learn_info, p4info,
                                        insert_entry);
-    if (!status.ok())
-      LOG(ERROR) << ADD_OR_DEL(insert_entry)
-                 << ": Failed to program l2_fwd_tx_table";
+    if (!status.ok()) {
+      LOG(ERROR) << TableErrorMessage(insert_entry, "FDB Tx Vlan Table");
+    }
 
     status = ConfigFdbSmacTableEntry(session.get(), learn_info, p4info,
                                      insert_entry);
     if (!status.ok()) {
-      char buf[32];
-      snprintf(buf, sizeof(buf), "%x:%x:%x:%x:%x:%x", learn_info.mac_addr[0],
-               learn_info.mac_addr[1], learn_info.mac_addr[2],
-               learn_info.mac_addr[3], learn_info.mac_addr[4],
-               learn_info.mac_addr[5]);
-      LOG(ERROR) << ADD_OR_DEL(insert_entry)
-                 << ": Failed to program l2_fwd_smac_table with " << buf;
+      LOG(ERROR) << TableErrorMessage(insert_entry, "FDB Source MAC Table")
+                 << " for " << FormatMac(learn_info.mac_addr);
     }
   }
   if (!status.ok()) return;
@@ -2651,7 +2660,7 @@ void ConfigIpMacMapTableEntry(struct ip_mac_map_info ip_info, bool insert_entry,
     status = ConfigSrcIpMacMapTableEntry(session.get(), ip_info, p4info,
                                          insert_entry);
     if (!status.ok()) {
-      // TODO: print some log once logging support is added
+      LOG(ERROR) << TableErrorMessage(insert_entry, "SRC_IP_MAC_MAP_TABLE");
     }
   }
 
@@ -2668,7 +2677,7 @@ try_dstip:
     status = ConfigDstIpMacMapTableEntry(session.get(), ip_info, p4info,
                                          insert_entry);
     if (!status.ok()) {
-      // TODO: print some log once logging support is added
+      LOG(ERROR) << TableErrorMessage(insert_entry, "DST_IP_MAC_MAP_TABLE");
     }
   }
 

--- a/ovs-p4rt/sidecar/ovsp4rt_logging.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_logging.h
@@ -20,4 +20,4 @@ using ::google::FATAL;
 using ::google::INFO;
 using ::google::WARNING;
 
-#endif // OVSP4RT_LOGGING_H_
+#endif  // OVSP4RT_LOGGING_H_

--- a/ovs-p4rt/sidecar/ovsp4rt_logging.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_logging.h
@@ -1,0 +1,23 @@
+// Copyright 2018 Google LLC
+// Copyright 2018-present Open Networking Foundation
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_LOGGING_H_
+#define OVSP4RT_LOGGING_H_
+
+// P4c lib/log.h already defines the ERROR macro.
+// Issue: https://github.com/p4lang/p4c/issues/2523
+#ifdef ERROR
+#undef ERROR
+#endif
+
+#include "glog/logging.h"  // IWYU pragma: export
+
+// These are exported in open source glog but not base/logging.h
+using ::google::ERROR;
+using ::google::FATAL;
+using ::google::INFO;
+using ::google::WARNING;
+
+#endif // OVSP4RT_LOGGING_H_


### PR DESCRIPTION
This CL uses `glog` instead of `zlog` because ovs-p4rt already depends on Stratum code, which uses `glog`.

We can switch to using the Abseil logger when we upgrade to a newer version of Abseil.

This is an update to PR https://github.com/ipdk-io/networking-recipe/pull/456.