### PR TITLE
Modify ovs-p4rt to log using 'zlog' (variation 2)

### DIFF
--- a/ovs-p4rt/ovs/testcontroller.cmake
+++ b/ovs-p4rt/ovs/testcontroller.cmake
@@ -51,4 +51,6 @@ target_link_libraries(ovs-testcontroller PUBLIC
     stratum_proto
 )
 
+target_link_libraries(ovs-testcontroller PUBLIC sde::target_sys)
+
 install(TARGETS ovs-testcontroller DESTINATION bin)

--- a/ovs-p4rt/ovs/vswitchd.cmake
+++ b/ovs-p4rt/ovs/vswitchd.cmake
@@ -49,4 +49,6 @@ target_link_libraries(ovs-vswitchd PUBLIC
     p4runtime_proto
 )
 
+target_link_libraries(ovs-vswitchd PUBLIC sde::target_sys)
+
 install(TARGETS ovs-vswitchd DESTINATION sbin)

--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(ovs_sidecar_o OBJECT
     ovsp4rt_session.h
     ovsp4rt_credentials.cc
     ovsp4rt_credentials.h
+    ovsp4rt_logging.h
 )
 
 if(DPDK_TARGET)
@@ -30,6 +31,7 @@ add_dependencies(ovs_sidecar_o
 )
 
 target_link_libraries(ovs_sidecar_o PUBLIC
+    sde::target_sys
     stratum_static
     p4_role_config_proto
 )

--- a/ovs-p4rt/sidecar/ovsp4rt_logging.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_logging.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OVSP4RT_LOGGING_H_
+#define OVSP4RT_LOGGING_H_
+
+#include "target-sys/bf_sal/bf_sys_log.h"
+
+#define ovsp4rt_log_critical(...) \
+  bf_sys_log_and_trace(KRNLMON, BF_LOG_CRIT, __VA_ARGS__)
+
+#define ovsp4rt_log_error(...) \
+  bf_sys_log_and_trace(KRNLMON, BF_LOG_ERR, __VA_ARGS__)
+
+#define ovsp4rt_log_warn(...) \
+  bf_sys_log_and_trace(KRNLMON, BF_LOG_WARN, __VA_ARGS__)
+
+#define ovsp4rt_log_info(...) \
+  bf_sys_log_and_trace(KRNLMON, BF_LOG_INFO, __VA_ARGS__)
+
+#define ovsp4rt_log_debug(...) \
+  bf_sys_log_and_trace(KRNLMON, BF_LOG_DBG, __VA_ARGS__)
+
+#define ovsp4rt_log ovsp4rt_log_debug
+
+#endif  // OVSP4RT_LOGGING_H_


### PR DESCRIPTION
I'm proposing two possible approaches to adding logging to `ovs-p4rt`.

This approach uses the same logger as krnlmon. The other uses the same logger as stratum: https://github.com/ipdk-io/networking-recipe/pull/458.