### PR TITLE
Modify ovs-p4rt to log using bf_log (zlog)

### DIFF
--- a/ovs-p4rt/ovs/testcontroller.cmake
+++ b/ovs-p4rt/ovs/testcontroller.cmake
@@ -26,4 +26,6 @@ target_link_libraries(ovs-testcontroller
 
 set_ovs_target_properties(ovs-testcontroller)
 
+target_link_libraries(ovs-testcontroller PUBLIC sde::target_sys)
+
 install(TARGETS ovs-testcontroller DESTINATION bin)

--- a/ovs-p4rt/ovs/vswitchd.cmake
+++ b/ovs-p4rt/ovs/vswitchd.cmake
@@ -27,4 +27,6 @@ target_link_libraries(ovs-vswitchd
 
 set_ovs_target_properties(ovs-vswitchd)
 
+target_link_libraries(ovs-vswitchd PUBLIC sde::target_sys)
+
 install(TARGETS ovs-vswitchd DESTINATION sbin)

--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(ovs_sidecar_o OBJECT
     ovsp4rt_session.h
     ovsp4rt_credentials.cc
     ovsp4rt_credentials.h
+    ovsp4rt_logging.h
 )
 
 if(DPDK_TARGET)
@@ -30,7 +31,8 @@ add_dependencies(ovs_sidecar_o
 )
 
 target_link_libraries(ovs_sidecar_o PUBLIC
+    sde::target_sys
     stratum_static
     p4_role_config_proto
+    absl::strings
 )
-

--- a/ovs-p4rt/sidecar/ovsp4rt_logging.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_logging.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OVSP4RT_LOGGING_H_
+#define OVSP4RT_LOGGING_H_
+
+#include "target-sys/bf_sal/bf_sys_log.h"
+
+#define ovsp4rt_log_critical(...) \
+  bf_sys_log_and_trace(OVSP4RT, BF_LOG_CRIT, __VA_ARGS__)
+
+#define ovsp4rt_log_error(...) \
+  bf_sys_log_and_trace(OVSP4RT, BF_LOG_ERR, __VA_ARGS__)
+
+#define ovsp4rt_log_warn(...) \
+  bf_sys_log_and_trace(OVSP4RT, BF_LOG_WARN, __VA_ARGS__)
+
+#define ovsp4rt_log_info(...) \
+  bf_sys_log_and_trace(OVSP4RT, BF_LOG_INFO, __VA_ARGS__)
+
+#define ovsp4rt_log_debug(...) \
+  bf_sys_log_and_trace(OVSP4RT, BF_LOG_DBG, __VA_ARGS__)
+
+#define ovsp4rt_log ovsp4rt_log_debug
+
+#endif  // OVSP4RT_LOGGING_H_

--- a/ovs-p4rt/sidecar/ovsp4rt_logging.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_logging.h
@@ -20,6 +20,12 @@
 
 #include "target-sys/bf_sal/bf_sys_log.h"
 
+// There's a syntax error in the definition of OVSP4RT in bf_sys_log.h,
+// which is in target-sysutils. Work around the problem by replacing
+// the defective definition with a valid one.
+#undef OVSP4RT
+#define OVSP4RT (BF_MOD_START + 23)
+
 #define ovsp4rt_log_critical(...) \
   bf_sys_log_and_trace(OVSP4RT, BF_LOG_CRIT, __VA_ARGS__)
 


### PR DESCRIPTION
 This PR replaces the `glog` implementation (#458), which was deeply flawed. See the comments in the earlier PR for more information.