### PR TITLE
Refine ovs-p4rt build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,13 @@ set(HOST_DEPEND_DIR "" CACHE PATH "Host dependencies install directory")
 
 set(PB_OUT_DIR "${CMAKE_BINARY_DIR}/pb.out" CACHE PATH
     "Path to generated Protobuf files")
+mark_as_advanced(PB_OUT_DIR)
 file(MAKE_DIRECTORY ${PB_OUT_DIR})
+
+set(STRATUM_SOURCE_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/stratum/stratum" CACHE PATH
+    "Path to Stratum source directory")
+mark_as_advanced(STRATUM_SOURCE_DIR)
 
 ###################
 # Feature toggles #

--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -52,7 +52,3 @@ target_link_libraries(ovs_sidecar PUBLIC
 add_dependencies(ovs_sidecar ovs_sidecar_o)
 
 set_install_rpath(ovs_sidecar $ORIGIN ${SDE_ELEMENT} ${DEP_ELEMENT})
-
-if(TARGET ovs_sidecar)
-  install(TARGETS ovs_sidecar LIBRARY)
-endif()

--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -4,12 +4,16 @@
 # SPDX-License-Identifier: Apache 2.0
 #
 
+#################
+# ovs_sidecar_o #
+#################
+
 add_library(ovs_sidecar_o OBJECT
     ovsp4rt.cc
-    ovsp4rt_session.cc
-    ovsp4rt_session.h
     ovsp4rt_credentials.cc
     ovsp4rt_credentials.h
+    ovsp4rt_session.cc
+    ovsp4rt_session.h
 )
 
 if(DPDK_TARGET)
@@ -18,19 +22,37 @@ elseif(ES2K_TARGET)
     add_subdirectory(es2k)
 endif()
 
-target_include_directories(ovs_sidecar_o PRIVATE
-    ${OVS_INCLUDE_DIR}
+target_include_directories(ovs_sidecar_o PUBLIC
     ${STRATUM_SOURCE_DIR}
-    ${PB_OUT_DIR}
-)
-
-add_dependencies(ovs_sidecar_o
-    stratum_proto
-    p4runtime_proto
+    ${OVS_INCLUDE_DIR}
 )
 
 target_link_libraries(ovs_sidecar_o PUBLIC
-    stratum_static
+    absl::strings
     p4_role_config_proto
+    p4runtime_proto
+    sde::target_sys
 )
 
+###############
+# ovs_sidecar #
+###############
+
+add_library(ovs_sidecar SHARED EXCLUDE_FROM_ALL
+    $<TARGET_OBJECTS:ovs_sidecar_o>
+)
+
+target_link_libraries(ovs_sidecar PUBLIC
+    absl::strings
+    p4_role_config_proto
+    p4runtime_proto
+    sde::target_sys
+)
+
+add_dependencies(ovs_sidecar ovs_sidecar_o)
+
+set_install_rpath(ovs_sidecar $ORIGIN ${SDE_ELEMENT} ${DEP_ELEMENT})
+
+if(TARGET ovs_sidecar)
+  install(TARGETS ovs_sidecar LIBRARY)
+endif()

--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -21,15 +21,15 @@ set(P4RUNTIME_SOURCE_DIR
     "Path to P4Runtime source directory")
 mark_as_advanced(P4RUNTIME_SOURCE_DIR)
 
-set(STRATUM_SOURCE_DIR
-    "${CMAKE_CURRENT_SOURCE_DIR}/stratum" CACHE PATH
-    "Path to Stratum source directory")
-mark_as_advanced(STRATUM_SOURCE_DIR)
-
-set(PB_OUT_DIR "${CMAKE_BINARY_DIR}/pb.out" CACHE PATH
-    "Path to directory for generated Protobuf files")
-mark_as_advanced(PB_OUT_DIR)
-file(MAKE_DIRECTORY ${PB_OUT_DIR})
+#set(STRATUM_SOURCE_DIR
+#    "${CMAKE_CURRENT_SOURCE_DIR}/stratum" CACHE PATH
+#    "Path to Stratum source directory")
+#mark_as_advanced(STRATUM_SOURCE_DIR)
+#
+#set(PB_OUT_DIR "${CMAKE_BINARY_DIR}/pb.out" CACHE PATH
+#    "Path to directory for generated Protobuf files")
+#mark_as_advanced(PB_OUT_DIR)
+#file(MAKE_DIRECTORY ${PB_OUT_DIR})
 
 set(STRATUM_INCLUDES
     ${STRATUM_SOURCE_DIR}


### PR DESCRIPTION
This PR makes it possible to do test builds of `ovs-p4rt` without having to build the entire networking-recipe.

- Moved the definition of `STRATUM_SOURCE_DIR` to the top-level listfile, to ensure that it is available to the ovs-p4rt and krnlmon builds.

- Updated the properties of the `ovs_sidecar_o` target to specify the dependencies needed to do a standalone build.

- Defined an on-demand `ovs_sidecar` target to generate a shared library, providing a concrete target that can be checked for unresolved external symbols.