### PR TITLE
Move utility functions to ovsp4rt_utils

### DIFF
--- a/ovs-p4rt/sidecar/common/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/common/CMakeLists.txt
@@ -10,4 +10,6 @@ target_sources(ovs_sidecar_o PUBLIC
     ovsp4rt_credentials.h
     ovsp4rt_session.cc
     ovsp4rt_session.h
+    ovsp4rt_utils.cc
+    ovsp4rt_utils.h
 )

--- a/ovs-p4rt/sidecar/common/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/common/ovsp4rt.cc
@@ -9,6 +9,7 @@
 #include "absl/flags/flag.h"
 #include "common/ovsp4rt_credentials.h"
 #include "common/ovsp4rt_session.h"
+#include "common/ovsp4rt_utils.h"
 #include "openvswitch/ovs-p4rt.h"
 
 #if defined(DPDK_TARGET)
@@ -35,87 +36,6 @@ static const std::string tunnel_v6_param_name[] = {
 
 using OvsP4rtStream = ::grpc::ClientReaderWriter<p4::v1::StreamMessageRequest,
                                                  p4::v1::StreamMessageResponse>;
-
-std::string EncodeByteValue(int arg_count...) {
-  std::string byte_value;
-  va_list args;
-  va_start(args, arg_count);
-
-  for (int arg = 0; arg < arg_count; ++arg) {
-    uint8_t byte = va_arg(args, int);
-    byte_value.push_back(byte);
-  }
-
-  va_end(args);
-  return byte_value;
-}
-
-std::string CanonicalizeIp(const uint32_t ipv4addr) {
-  return EncodeByteValue(4, (ipv4addr & 0xff), ((ipv4addr >> 8) & 0xff),
-                         ((ipv4addr >> 16) & 0xff), ((ipv4addr >> 24) & 0xff));
-}
-
-std::string CanonicalizeIpv6(const struct in6_addr ipv6addr) {
-  return EncodeByteValue(
-      16, ipv6addr.__in6_u.__u6_addr8[0], ipv6addr.__in6_u.__u6_addr8[1],
-      ipv6addr.__in6_u.__u6_addr8[2], ipv6addr.__in6_u.__u6_addr8[3],
-      ipv6addr.__in6_u.__u6_addr8[4], ipv6addr.__in6_u.__u6_addr8[5],
-      ipv6addr.__in6_u.__u6_addr8[6], ipv6addr.__in6_u.__u6_addr8[7],
-      ipv6addr.__in6_u.__u6_addr8[8], ipv6addr.__in6_u.__u6_addr8[9],
-      ipv6addr.__in6_u.__u6_addr8[10], ipv6addr.__in6_u.__u6_addr8[11],
-      ipv6addr.__in6_u.__u6_addr8[12], ipv6addr.__in6_u.__u6_addr8[13],
-      ipv6addr.__in6_u.__u6_addr8[14], ipv6addr.__in6_u.__u6_addr8[15]);
-}
-
-std::string CanonicalizeMac(const uint8_t mac[6]) {
-  return EncodeByteValue(6, (mac[0] & 0xff), (mac[1] & 0xff), (mac[2] & 0xff),
-                         (mac[3] & 0xff), (mac[4] & 0xff), (mac[5] & 0xff));
-}
-
-int GetTableId(const ::p4::config::v1::P4Info& p4info,
-               const std::string& t_name) {
-  for (const auto& table : p4info.tables()) {
-    const auto& pre = table.preamble();
-    if (pre.name() == t_name) return pre.id();
-  }
-  return -1;
-}
-
-int GetActionId(const ::p4::config::v1::P4Info& p4info,
-                const std::string& a_name) {
-  for (const auto& action : p4info.actions()) {
-    const auto& pre = action.preamble();
-    if (pre.name() == a_name) return pre.id();
-  }
-  return -1;
-}
-
-int GetParamId(const ::p4::config::v1::P4Info& p4info,
-               const std::string& a_name, const std::string& param_name) {
-  for (const auto& action : p4info.actions()) {
-    const auto& pre = action.preamble();
-    if (pre.name() != a_name) continue;
-    for (const auto& param : action.params())
-      if (param.name() == param_name) return param.id();
-  }
-  return -1;
-}
-
-int GetMatchFieldId(const ::p4::config::v1::P4Info& p4info,
-                    const std::string& t_name, const std::string& mf_name) {
-  for (const auto& table : p4info.tables()) {
-    const auto& pre = table.preamble();
-    if (pre.name() != t_name) continue;
-    for (const auto& mf : table.match_fields())
-      if (mf.name() == mf_name) return mf.id();
-  }
-  return -1;
-}
-
-static inline int32_t ValidIpAddr(uint32_t nw_addr) {
-  return (nw_addr && nw_addr != INADDR_ANY && nw_addr != INADDR_LOOPBACK &&
-          nw_addr != 0xffffffff);
-}
 
 #if defined(ES2K_TARGET)
 #ifdef LNW_V2

--- a/ovs-p4rt/sidecar/common/ovsp4rt_utils.cc
+++ b/ovs-p4rt/sidecar/common/ovsp4rt_utils.cc
@@ -1,0 +1,90 @@
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ovsp4rt_utils.h"
+
+#include <cstdarg>
+#include <cstdint>
+#include <string>
+
+#include "p4/config/v1/p4info.pb.h"
+
+namespace ovs_p4rt {
+
+std::string EncodeByteValue(int arg_count...) {
+  std::string byte_value;
+  va_list args;
+  va_start(args, arg_count);
+
+  for (int arg = 0; arg < arg_count; ++arg) {
+    uint8_t byte = va_arg(args, int);
+    byte_value.push_back(byte);
+  }
+
+  va_end(args);
+  return byte_value;
+}
+
+std::string CanonicalizeIp(const uint32_t ipv4addr) {
+  return EncodeByteValue(4, (ipv4addr & 0xff), ((ipv4addr >> 8) & 0xff),
+                         ((ipv4addr >> 16) & 0xff), ((ipv4addr >> 24) & 0xff));
+}
+
+std::string CanonicalizeIpv6(const struct in6_addr ipv6addr) {
+  return EncodeByteValue(
+      16, ipv6addr.__in6_u.__u6_addr8[0], ipv6addr.__in6_u.__u6_addr8[1],
+      ipv6addr.__in6_u.__u6_addr8[2], ipv6addr.__in6_u.__u6_addr8[3],
+      ipv6addr.__in6_u.__u6_addr8[4], ipv6addr.__in6_u.__u6_addr8[5],
+      ipv6addr.__in6_u.__u6_addr8[6], ipv6addr.__in6_u.__u6_addr8[7],
+      ipv6addr.__in6_u.__u6_addr8[8], ipv6addr.__in6_u.__u6_addr8[9],
+      ipv6addr.__in6_u.__u6_addr8[10], ipv6addr.__in6_u.__u6_addr8[11],
+      ipv6addr.__in6_u.__u6_addr8[12], ipv6addr.__in6_u.__u6_addr8[13],
+      ipv6addr.__in6_u.__u6_addr8[14], ipv6addr.__in6_u.__u6_addr8[15]);
+}
+
+std::string CanonicalizeMac(const uint8_t mac[6]) {
+  return EncodeByteValue(6, (mac[0] & 0xff), (mac[1] & 0xff), (mac[2] & 0xff),
+                         (mac[3] & 0xff), (mac[4] & 0xff), (mac[5] & 0xff));
+}
+
+int GetTableId(const ::p4::config::v1::P4Info& p4info,
+               const std::string& t_name) {
+  for (const auto& table : p4info.tables()) {
+    const auto& pre = table.preamble();
+    if (pre.name() == t_name) return pre.id();
+  }
+  return -1;
+}
+
+int GetActionId(const ::p4::config::v1::P4Info& p4info,
+                const std::string& a_name) {
+  for (const auto& action : p4info.actions()) {
+    const auto& pre = action.preamble();
+    if (pre.name() == a_name) return pre.id();
+  }
+  return -1;
+}
+
+int GetParamId(const ::p4::config::v1::P4Info& p4info,
+               const std::string& a_name, const std::string& param_name) {
+  for (const auto& action : p4info.actions()) {
+    const auto& pre = action.preamble();
+    if (pre.name() != a_name) continue;
+    for (const auto& param : action.params())
+      if (param.name() == param_name) return param.id();
+  }
+  return -1;
+}
+
+int GetMatchFieldId(const ::p4::config::v1::P4Info& p4info,
+                    const std::string& t_name, const std::string& mf_name) {
+  for (const auto& table : p4info.tables()) {
+    const auto& pre = table.preamble();
+    if (pre.name() != t_name) continue;
+    for (const auto& mf : table.match_fields())
+      if (mf.name() == mf_name) return mf.id();
+  }
+  return -1;
+}
+
+}  // namespace ovs_p4rt

--- a/ovs-p4rt/sidecar/common/ovsp4rt_utils.h
+++ b/ovs-p4rt/sidecar/common/ovsp4rt_utils.h
@@ -1,0 +1,44 @@
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_UTILS_H_
+#define OVSP4RT_UTILS_H_
+
+#include <netinet/in.h>
+
+#include <cstdint>
+#include <string>
+
+#include "p4/config/v1/p4info.pb.h"
+
+namespace ovs_p4rt {
+
+extern std::string CanonicalizeIp(const uint32_t ipv4addr);
+
+extern std::string CanonicalizeIpv6(const struct in6_addr ipv6addr);
+
+extern std::string CanonicalizeMac(const uint8_t mac[6]);
+
+extern std::string EncodeByteValue(int arg_count...);
+
+extern int GetActionId(const ::p4::config::v1::P4Info& p4info,
+                       const std::string& a_name);
+
+extern int GetMatchFieldId(const ::p4::config::v1::P4Info& p4info,
+                           const std::string& t_name,
+                           const std::string& mf_name);
+
+extern int GetParamId(const ::p4::config::v1::P4Info& p4info,
+                      const std::string& a_name, const std::string& param_name);
+
+extern int GetTableId(const ::p4::config::v1::P4Info& p4info,
+                      const std::string& t_name);
+
+static inline int32_t ValidIpAddr(uint32_t nw_addr) {
+  return (nw_addr && nw_addr != INADDR_ANY && nw_addr != INADDR_LOOPBACK &&
+          nw_addr != 0xffffffff);
+}
+
+}  // namespace ovs_p4rt
+
+#endif  // OVSP4RT_UTILS_H_


### PR DESCRIPTION
- Extracted utility functions from `ovsp4rt.cc` and moved them to `ovsp4rt_utils.cc`.
- Defined prototypes for the functions in `ovsp4rt_utils.h`.