### PR TITLE
Publish common function prototypes

### DIFF
--- a/ovs-p4rt/sidecar/common/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/common/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(ovs_sidecar_o PUBLIC
     ovsp4rt.cc
     ovsp4rt_credentials.cc
     ovsp4rt_credentials.h
+    ovsp4rt_private.h
     ovsp4rt_session.cc
     ovsp4rt_session.h
     ovsp4rt_utils.cc

--- a/ovs-p4rt/sidecar/common/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/common/ovsp4rt.cc
@@ -8,6 +8,7 @@
 
 #include "absl/flags/flag.h"
 #include "common/ovsp4rt_credentials.h"
+#include "common/ovsp4rt_private.h"
 #include "common/ovsp4rt_session.h"
 #include "common/ovsp4rt_utils.h"
 #include "openvswitch/ovs-p4rt.h"

--- a/ovs-p4rt/sidecar/common/ovsp4rt_private.h
+++ b/ovs-p4rt/sidecar/common/ovsp4rt_private.h
@@ -1,0 +1,81 @@
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Private functions defined by ovsp4rt.cc.
+//
+
+#include <cstdbool>
+#include <cstdint>
+#include <string>
+
+#include "absl/flags/declare.h"
+#include "absl/status/status.h"
+#include "common/ovsp4rt_session.h"
+#include "openvswitch/ovs-p4rt.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+
+ABSL_DECLARE_FLAG(uint64_t, device_id);
+ABSL_DECLARE_FLAG(std::string, role_name);
+
+namespace ovs_p4rt {
+
+//----------------------------------------------------------------------
+// 'Config' functions
+//----------------------------------------------------------------------
+
+extern absl::Status ConfigEncapTableEntry(
+    ovs_p4rt::OvsP4rtSession* session, const struct tunnel_info& tunnel_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
+extern absl::Status ConfigFdbRxVlanTableEntry(
+    ovs_p4rt::OvsP4rtSession* session,
+    const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
+extern absl::Status ConfigFdbTxVlanTableEntry(
+    ovs_p4rt::OvsP4rtSession* session,
+    const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
+extern absl::Status ConfigFdbTunnelTableEntry(
+    ovs_p4rt::OvsP4rtSession* session,
+    const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
+extern absl::Status ConfigTunnelTermTableEntry(
+    ovs_p4rt::OvsP4rtSession* session, const struct tunnel_info& tunnel_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
+//----------------------------------------------------------------------
+// 'Prepare' functions
+//----------------------------------------------------------------------
+
+extern void PrepareFdbTableEntryforV4GeneveTunnel(
+    p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
+extern void PrepareFdbTableEntryforV4VxlanTunnel(
+    p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
+extern void PrepareFdbTxVlanTableEntry(
+    p4::v1::TableEntry* table_entry, const struct mac_learning_info& learn_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
+extern void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                        const struct tunnel_info& tunnel_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry);
+
+extern void PrepareEncapTableEntry(p4::v1::TableEntry* table_entry,
+                                   const struct tunnel_info& tunnel_info,
+                                   const ::p4::config::v1::P4Info& p4info,
+                                   bool insert_entry);
+
+extern void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
+                                        const struct tunnel_info& tunnel_info,
+                                        const ::p4::config::v1::P4Info& p4info,
+                                        bool insert_entry);
+
+}  // namespace ovs_p4rt


### PR DESCRIPTION
- Created a header file for the private common functions, in preparation for refactoring ovsp4rt.cc into multiple source files. The prototypes for the public functions are already defined in ovs-p4rt.h.