### PR TITLE
Implement basic logging for OVSP4RT

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -44,3 +44,11 @@ target_link_libraries(ovs_sidecar PUBLIC
 )
 
 add_dependencies(ovs_sidecar ovs_sidecar_o)
+
+###########
+# testing #
+###########
+
+set(SIDECAR_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_subdirectory(testing EXCLUDE_FROM_ALL)

--- a/ovs-p4rt/sidecar/common/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/common/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 target_sources(ovs_sidecar_o PUBLIC
+    ovsp4rt_logutils.cc
+    ovsp4rt_logutils.h
     ovsp4rt_private.cc
     ovsp4rt_private.h
     ovsp4rt_public.cc

--- a/ovs-p4rt/sidecar/common/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/common/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build file for ovs-p4rt/sidecar/common
 #
-# Copyright 2022-2024 Intel Corporation
+# Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 

--- a/ovs-p4rt/sidecar/common/ovsp4rt_logutils.cc
+++ b/ovs-p4rt/sidecar/common/ovsp4rt_logutils.cc
@@ -1,0 +1,36 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Logger utility functions.
+//
+
+#include "common/ovsp4rt_logutils.h"
+
+#include <cstdio>
+#include <string>
+
+#include "absl/strings/str_cat.h"
+#include "lib/ovsp4rt_logging.h"
+
+namespace ovs_p4rt {
+
+const std::string TableErrorMessage(bool inserting, const char* table) {
+  if (inserting) {
+    return absl::StrCat("Error adding entry to ", table);
+  } else {
+    return absl::StrCat("Error deleting entry from ", table);
+  }
+}
+
+const std::string FormatMac(const uint8_t* mac_addr) {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%x:%x:%x:%x:%x:%x", mac_addr[0], mac_addr[1],
+           mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
+  return buf;
+}
+
+void LogTableError(bool inserting, const char* table) {
+  ovsp4rt_log_error("%s", TableErrorMessage(inserting, table).c_str());
+}
+
+}  // namespace ovs_p4rt

--- a/ovs-p4rt/sidecar/common/ovsp4rt_logutils.h
+++ b/ovs-p4rt/sidecar/common/ovsp4rt_logutils.h
@@ -1,0 +1,23 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Logger utility function prototypes.
+//
+
+#ifndef OVSP4RT_LOGUTILS_H_
+#define OVSP4RT_LOGUTILS_H_
+
+#include <cstdint>
+#include <string>
+
+namespace ovs_p4rt {
+
+const std::string FormatMac(const uint8_t* mac_addr);
+
+void LogTableError(bool inserting, const char* table);
+
+const std::string TableErrorMessage(bool inserting, const char* table);
+
+}  // namespace ovs_p4rt
+
+#endif  // OVSP4RT_LOGUTILS_H_

--- a/ovs-p4rt/sidecar/common/ovsp4rt_private.cc
+++ b/ovs-p4rt/sidecar/common/ovsp4rt_private.cc
@@ -1,6 +1,5 @@
 // Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
-// TODO: ovs-p4rt logging
 
 #include "common/ovsp4rt_private.h"
 

--- a/ovs-p4rt/sidecar/es2k/ovsp4rt_es2k_public.cc
+++ b/ovs-p4rt/sidecar/es2k/ovsp4rt_es2k_public.cc
@@ -5,13 +5,38 @@
 //
 
 #include "absl/flags/flag.h"
+#include "absl/strings/str_cat.h"
 #include "common/ovsp4rt_private.h"
 #include "common/ovsp4rt_utils.h"
 #include "lib/ovsp4rt_credentials.h"
+#include "lib/ovsp4rt_logging.h"
 #include "lib/ovsp4rt_session.h"
 #include "openvswitch/ovs-p4rt.h"
 #include "ovsp4rt_es2k_defs.h"
 #include "ovsp4rt_es2k_private.h"
+
+namespace {
+
+const std::string TableErrorMessage(bool inserting, const char* table) {
+  if (inserting) {
+    return absl::StrCat("Error adding entry to ", table);
+  } else {
+    return absl::StrCat("Error deleting entry from ", table);
+  }
+}
+
+const std::string FormatMac(const uint8_t* mac_addr) {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%x:%x:%x:%x:%x:%x", mac_addr[0], mac_addr[1],
+           mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
+  return buf;
+}
+
+void LogTableError(bool inserting, const char* table) {
+  ovsp4rt_log_error("%s", TableErrorMessage(inserting, table).c_str());
+}
+
+}  // namespace
 
 //----------------------------------------------------------------------
 // Functions with C interfaces
@@ -66,42 +91,45 @@ void ConfigFdbTableEntry(struct mac_learning_info learn_info, bool insert_entry,
       auto status_or_read_response =
           GetFdbTunnelTableEntry(session.get(), learn_info, p4info);
       if (status_or_read_response.ok()) {
-        printf("TUNNEL: read FDB L2_FWD_TX_TABLE entry present\n");
+        ovsp4rt_log_error(
+            "Error adding to FDB Tunnel Table: entry already exists");
         return;
       }
     }
 
     status = ConfigFdbTunnelTableEntry(session.get(), learn_info, p4info,
                                        insert_entry);
-    if (!status.ok())
-      printf("%s: Failed to program l2_fwd_tx_table for tunnel\n",
-             insert_entry ? "ADD" : "DELETE");
+    if (!status.ok()) {
+      LogTableError(insert_entry, "FDB Tunnel Table");
+      // TODO(derek): Most of the error cases don't return. Should they?
+    }
 
     status = ConfigL2TunnelTableEntry(session.get(), learn_info, p4info,
                                       insert_entry);
-    if (!status.ok())
-      printf("%s: Failed to program l2_tunnel_to_v4_table for tunnel\n",
-             insert_entry ? "ADD" : "DELETE");
+    if (!status.ok()) {
+      LogTableError(insert_entry, "L2 Tunnel Table");
+    }
 
     status = ConfigFdbSmacTableEntry(session.get(), learn_info, p4info,
                                      insert_entry);
-    if (!status.ok())
-      printf("%s: Failed to program l2_fwd_smac_table\n",
-             insert_entry ? "ADD" : "DELETE");
+    if (!status.ok()) {
+      LogTableError(insert_entry, "FDB Source MAC Table");
+    }
   } else {
     if (insert_entry) {
       auto status_or_read_response =
           GetFdbVlanTableEntry(session.get(), learn_info, p4info);
       if (status_or_read_response.ok()) {
-        printf("Non TUNNEL: read FDB L2_FWD_TX_TABLE entry present\n");
+        ovsp4rt_log_error(
+            "Error adding to FDB Vlan Table: entry already exists");
         return;
       }
 
       status = ConfigFdbRxVlanTableEntry(session.get(), learn_info, p4info,
                                          insert_entry);
-      if (!status.ok())
-        printf("%s: Failed to program l2_fwd_rx_table\n",
-               insert_entry ? "ADD" : "DELETE");
+      if (!status.ok()) {
+        LogTableError(insert_entry, "FDB Rx Vlan Table");
+      }
 
       status_or_read_response =
           GetTxAccVsiTableEntry(session.get(), learn_info.src_port, p4info);
@@ -141,18 +169,18 @@ void ConfigFdbTableEntry(struct mac_learning_info learn_info, bool insert_entry,
 
     status = ConfigFdbTxVlanTableEntry(session.get(), learn_info, p4info,
                                        insert_entry);
-    if (!status.ok())
-      printf("%s: Failed to program l2_fwd_tx_table\n",
-             insert_entry ? "ADD" : "DELETE");
+    if (!status.ok()) {
+      LogTableError(insert_entry, "FDB Tx Vlan Table");
+    }
 
     status = ConfigFdbSmacTableEntry(session.get(), learn_info, p4info,
                                      insert_entry);
-    if (!status.ok())
-      printf("%s: Failed to program l2_fwd_smac_table with %x:%x:%x:%x:%x:%x\n",
-             insert_entry ? "ADD" : "DELETE", learn_info.mac_addr[0],
-             learn_info.mac_addr[1], learn_info.mac_addr[2],
-             learn_info.mac_addr[3], learn_info.mac_addr[4],
-             learn_info.mac_addr[5]);
+    if (!status.ok()) {
+      ovsp4rt_log_error(
+          "%s for %s",
+          TableErrorMessage(insert_entry, "FDB Source MAC Table").c_str(),
+          FormatMac(learn_info.mac_addr).c_str());
+    }
   }
   if (!status.ok()) return;
 }
@@ -332,7 +360,7 @@ void ConfigIpMacMapTableEntry(struct ip_mac_map_info ip_info, bool insert_entry,
     status = ConfigSrcIpMacMapTableEntry(session.get(), ip_info, p4info,
                                          insert_entry);
     if (!status.ok()) {
-      // TODO: print some log once logging support is added
+      LogTableError(insert_entry, "SRC_IP_MAC_MAP_TABLE");
     }
   }
 
@@ -349,7 +377,7 @@ try_dstip:
     status = ConfigDstIpMacMapTableEntry(session.get(), ip_info, p4info,
                                          insert_entry);
     if (!status.ok()) {
-      // TODO: print some log once logging support is added
+      LogTableError(insert_entry, "DST_IP_MAC_MAP_TABLE");
     }
   }
 }

--- a/ovs-p4rt/sidecar/es2k/ovsp4rt_es2k_public.cc
+++ b/ovs-p4rt/sidecar/es2k/ovsp4rt_es2k_public.cc
@@ -5,7 +5,7 @@
 //
 
 #include "absl/flags/flag.h"
-#include "absl/strings/str_cat.h"
+#include "common/ovsp4rt_logutils.h"
 #include "common/ovsp4rt_private.h"
 #include "common/ovsp4rt_utils.h"
 #include "lib/ovsp4rt_credentials.h"
@@ -14,29 +14,6 @@
 #include "openvswitch/ovs-p4rt.h"
 #include "ovsp4rt_es2k_defs.h"
 #include "ovsp4rt_es2k_private.h"
-
-namespace {
-
-const std::string TableErrorMessage(bool inserting, const char* table) {
-  if (inserting) {
-    return absl::StrCat("Error adding entry to ", table);
-  } else {
-    return absl::StrCat("Error deleting entry from ", table);
-  }
-}
-
-const std::string FormatMac(const uint8_t* mac_addr) {
-  char buf[32];
-  snprintf(buf, sizeof(buf), "%x:%x:%x:%x:%x:%x", mac_addr[0], mac_addr[1],
-           mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
-  return buf;
-}
-
-void LogTableError(bool inserting, const char* table) {
-  ovsp4rt_log_error("%s", TableErrorMessage(inserting, table).c_str());
-}
-
-}  // namespace
 
 //----------------------------------------------------------------------
 // Functions with C interfaces

--- a/ovs-p4rt/sidecar/lib/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/lib/CMakeLists.txt
@@ -7,6 +7,8 @@
 target_sources(ovs_sidecar_o PUBLIC
     ovsp4rt_credentials.cc
     ovsp4rt_credentials.h
+    ovsp4rt_logging.cc
+    ovsp4rt_logging.h
     ovsp4rt_session.cc
     ovsp4rt_session.h
 )

--- a/ovs-p4rt/sidecar/lib/ovsp4rt_logging.cc
+++ b/ovs-p4rt/sidecar/lib/ovsp4rt_logging.cc
@@ -1,0 +1,35 @@
+// Copyright 2024 Intel Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ovsp4rt_logging.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+
+namespace {
+
+const char* get_level_name(int level) {
+  switch (level) {
+    case OVSP4RT_LEVEL_ERROR:
+      return "ERROR";
+    case OVSP4RT_LEVEL_WARN:
+      return "WARN";
+    case OVSP4RT_LEVEL_INFO:
+      return "INFO";
+    case OVSP4RT_LEVEL_DEBUG:
+      return "DEBUG";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+}  // namespace
+
+void ovsp4rt_log_message(int level, const char* format, ...) {
+  printf("OVSP4RT %s - ", get_level_name(level));
+  va_list args;
+  va_start(args, format);
+  vprintf(format, args);
+  va_end(args);
+  printf("\n");
+}

--- a/ovs-p4rt/sidecar/lib/ovsp4rt_logging.h
+++ b/ovs-p4rt/sidecar/lib/ovsp4rt_logging.h
@@ -1,0 +1,36 @@
+// Copyright 2024 Intel Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_LOGGING_H_
+#define OVSP4RT_LOGGING_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+  OVSP4RT_LEVEL_DEBUG,
+  OVSP4RT_LEVEL_INFO,
+  OVSP4RT_LEVEL_WARN,
+  OVSP4RT_LEVEL_ERROR,
+};
+
+#define ovsp4rt_log_debug(...) \
+  ovsp4rt_log_message(OVSP4RT_LEVEL_DEBUG, __VA_ARGS__)
+
+#define ovsp4rt_log_error(...) \
+  ovsp4rt_log_message(OVSP4RT_LEVEL_ERROR, __VA_ARGS__)
+
+#define ovsp4rt_log_info(...) \
+  ovsp4rt_log_message(OVSP4RT_LEVEL_INFO, __VA_ARGS__)
+
+#define ovsp4rt_log_warn(...) \
+  ovsp4rt_log_message(OVSP4RT_LEVEL_WARN, __VA_ARGS__)
+
+extern void ovsp4rt_log_message(int level, const char* format, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OVSP4RT_LOGGING_H_

--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_library(ovsp4rt_logging_o OBJECT
+  ${SIDECAR_SOURCE_DIR}/common/ovsp4rt_logutils.cc
+  ${SIDECAR_SOURCE_DIR}/common/ovsp4rt_logutils.h
   ${SIDECAR_SOURCE_DIR}/lib/ovsp4rt_logging.cc
   ${SIDECAR_SOURCE_DIR}/lib/ovsp4rt_logging.h
 )

--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -1,3 +1,9 @@
+# CMake build file for ovs-p4rt/sidecar/testing
+#
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
 add_library(ovsp4rt_logging_o OBJECT
   ${SIDECAR_SOURCE_DIR}/common/ovsp4rt_logutils.cc
   ${SIDECAR_SOURCE_DIR}/common/ovsp4rt_logutils.h

--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -1,0 +1,28 @@
+add_library(ovsp4rt_logging_o OBJECT
+  ${SIDECAR_SOURCE_DIR}/lib/ovsp4rt_logging.cc
+  ${SIDECAR_SOURCE_DIR}/lib/ovsp4rt_logging.h
+)
+
+target_include_directories(ovsp4rt_logging_o PRIVATE
+  ${SIDECAR_SOURCE_DIR}
+  ${SDE_INSTALL_DIR}/include
+)
+
+add_library(ovsp4rt_logging SHARED $<TARGET_OBJECTS:ovsp4rt_logging_o>)
+
+add_executable(logging_test EXCLUDE_FROM_ALL
+  logging_test.cc
+)
+
+target_include_directories(logging_test PUBLIC
+  ${SIDECAR_SOURCE_DIR}
+  ${DEPEND_INSTALL_DIR}/include
+  ${SDE_INSTALL_DIR}/include
+  ${OVS_INCLUDE_DIR}
+)
+
+target_link_libraries(logging_test PUBLIC
+  ovsp4rt_logging
+  absl::strings
+  sde::target_sys
+)

--- a/ovs-p4rt/sidecar/testing/logging_test.cc
+++ b/ovs-p4rt/sidecar/testing/logging_test.cc
@@ -1,0 +1,88 @@
+#define _POSIX_SOURCE
+#include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <iostream>
+#include <string>
+
+#include "absl/strings/str_cat.h"
+#include "lib/ovsp4rt_logging.h"
+#include "openvswitch/ovs-p4rt.h"
+
+const std::string TableErrorMessage(bool inserting, const char* table) {
+  if (inserting) {
+    return absl::StrCat("Error adding entry to ", table);
+  } else {
+    return absl::StrCat("Error deleting entry from ", table);
+  }
+}
+
+const std::string FormatMac(const uint8_t* mac_addr) {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%x:%x:%x:%x:%x:%x", mac_addr[0], mac_addr[1],
+           mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
+  return buf;
+}
+
+void LogTableError(bool inserting, const char* table) {
+  ovsp4rt_log_error("%s", TableErrorMessage(inserting, table).c_str());
+}
+
+void log_messages() {
+  uint8_t mac_addr[6] = {0xb, 0xe, 0xe, 0xb, 0xe, 0xe};
+  bool insert_entry = false;
+
+  ovsp4rt_log_info("Error adding to FDB Tunnel Table: entry already exists");
+
+  LogTableError(insert_entry, "FDB Tunnel Table");
+
+  insert_entry = !insert_entry;
+  LogTableError(insert_entry, "L2 Tunnel Table");
+
+  insert_entry = !insert_entry;
+  LogTableError(insert_entry, "FDB Source MAC Table");
+
+  ovsp4rt_log_warn("Error adding to FDB Vlan Table: entry already exists");
+
+  insert_entry = !insert_entry;
+  LogTableError(insert_entry, "FDB Rx Vlan Table");
+
+  insert_entry = !insert_entry;
+  LogTableError(insert_entry, "FDB Tx Vlan Table");
+
+  insert_entry = !insert_entry;
+  ovsp4rt_log_debug(
+      "%s for %s",
+      TableErrorMessage(insert_entry, "FDB Source MAC Table").c_str(),
+      FormatMac(mac_addr).c_str());
+
+  insert_entry = !insert_entry;
+  LogTableError(insert_entry, "SRC_IP_MAC_MAP_TABLE");
+
+  insert_entry = !insert_entry;
+  LogTableError(insert_entry, "DST_IP_MAC_MAP_TABLE");
+}
+
+constexpr char cfg_file_path[] = {"/.local/etc/ovsp4rt/ovsp4rt-zlog.cfg"};
+constexpr char log_level[] = {"INFO"};
+
+void init_logging() {
+#if 0
+  const char* HOME = getenv("HOME");
+  std::cout << "HOME = \"" << HOME << "\"\n";
+
+  std::string cfg_path = absl::StrCat(HOME, cfg_file_path);
+  std::cout << "cfg_path = \"" << cfg_path << "\"\n";
+
+  bf_sys_log_init((void*)cfg_path.c_str(), (void*)log_level, NULL);
+#endif
+}
+
+int main() {
+  init_logging();
+  log_messages();
+  return 0;
+}

--- a/ovs-p4rt/sidecar/testing/logging_test.cc
+++ b/ovs-p4rt/sidecar/testing/logging_test.cc
@@ -1,3 +1,6 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 #define _POSIX_SOURCE
 #include <limits.h>
 #include <stdbool.h>
@@ -8,28 +11,11 @@
 #include <iostream>
 #include <string>
 
-#include "absl/strings/str_cat.h"
+#include "common/ovsp4rt_logutils.h"
 #include "lib/ovsp4rt_logging.h"
 #include "openvswitch/ovs-p4rt.h"
 
-const std::string TableErrorMessage(bool inserting, const char* table) {
-  if (inserting) {
-    return absl::StrCat("Error adding entry to ", table);
-  } else {
-    return absl::StrCat("Error deleting entry from ", table);
-  }
-}
-
-const std::string FormatMac(const uint8_t* mac_addr) {
-  char buf[32];
-  snprintf(buf, sizeof(buf), "%x:%x:%x:%x:%x:%x", mac_addr[0], mac_addr[1],
-           mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
-  return buf;
-}
-
-void LogTableError(bool inserting, const char* table) {
-  ovsp4rt_log_error("%s", TableErrorMessage(inserting, table).c_str());
-}
+using namespace ovs_p4rt;
 
 void log_messages() {
   uint8_t mac_addr[6] = {0xb, 0xe, 0xe, 0xb, 0xe, 0xe};


### PR DESCRIPTION
- Implemented a rudimentary logger for OVSP4RT. The initial implementation simply prints messages to the console.

- Updated ovsp4rt_es2k_public to use the logger for error messages.

- Added a rudimentary program to test the logger.

----

This PR implements implements the logger front-end with a rudimentary printf-based back-end. This allows us to update OVSP4RT to use the logger interface and test the implementation independently of implementing the logger back-end.

The output of the test program is:

```text
./build/ovs-p4rt/sidecar/testing/logging_test
OVSP4RT INFO - Error adding to FDB Tunnel Table: entry already exists
OVSP4RT ERROR - Error deleting entry from FDB Tunnel Table
OVSP4RT ERROR - Error adding entry to L2 Tunnel Table
OVSP4RT ERROR - Error deleting entry from FDB Source MAC Table
OVSP4RT WARN - Error adding to FDB Vlan Table: entry already exists
OVSP4RT ERROR - Error adding entry to FDB Rx Vlan Table
OVSP4RT ERROR - Error deleting entry from FDB Tx Vlan Table
OVSP4RT DEBUG - Error adding entry to FDB Source MAC Table for b:e:e:b:e:e
OVSP4RT ERROR - Error deleting entry from SRC_IP_MAC_MAP_TABLE
OVSP4RT ERROR - Error adding entry to DST_IP_MAC_MAP_TABLE
```