### PR TITLE
Rename ovsp4rt public functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,24 @@ section of the User Guide for a description of the components.
 
 ## Major changes
 
-The Stratum dependencies component has formally moved from the `setup`
-directory to a new <https://github.com/ipdk-io/stratum-deps> repository.
+### ovs-p4rt interface
 
-See the [README file](setup/README.md) in the `setup` directory
-for more information.
+The functions that ovs-p4rt publishes for use by OVS have been renamed
+to make them more consistent with C programming conventions.
+
+### Setup directory
+
+The Stratum dependencies have moved from the `setup` directory
+to a new <https://github.com/ipdk-io/stratum-deps> repository.
+
+This change allows the dependencies to be downloaded and built independently
+of the Networking Recipe (P4 Control Plane).
+It also makes them easier to maintain.
+
+See the [README file](https://github.com/ipdk-io/stratum-deps/blob/main/README.md)
+and
+[Transition Guide](https://github.com/ipdk-io/stratum-deps/blob/main/docs/transition-guide.md)
+in the `stratum-deps` repository for more information.
 
 ## Source code
 

--- a/ovs-p4rt/include/ovsp4rt/ovs-p4rt.h
+++ b/ovs-p4rt/include/ovsp4rt/ovs-p4rt.h
@@ -127,30 +127,33 @@ struct ip_mac_map_info {
 // Function prototypes
 //----------------------------------------------------------------------
 
-extern void ConfigFdbTableEntry(struct mac_learning_info learn_info,
-                                bool insert_entry, const char* grpc_addr);
-
-extern void ConfigIpMacMapTableEntry(struct ip_mac_map_info learn_info,
+extern void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
                                      bool insert_entry, const char* grpc_addr);
 
-extern void ConfigRxTunnelSrcTableEntry(struct tunnel_info tunnel_info,
-                                        bool insert_entry,
-                                        const char* grpc_addr);
+extern void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info learn_info,
+                                            bool insert_entry,
+                                            const char* grpc_addr);
 
-extern void ConfigSrcPortTableEntry(struct src_port_info vsi_sp,
-                                    bool insert_entry, const char* grpc_addr);
+extern void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
+                                               bool insert_entry,
+                                               const char* grpc_addr);
 
-extern void ConfigTunnelSrcPortTableEntry(struct src_port_info tnl_sp,
+extern void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
                                           bool insert_entry,
                                           const char* grpc_addr);
 
-extern void ConfigTunnelTableEntry(struct tunnel_info tunnel_info,
-                                   bool insert_entry, const char* grpc_addr);
+extern void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
+                                                 bool insert_entry,
+                                                 const char* grpc_addr);
 
-extern void ConfigVlanTableEntry(uint16_t vlan_id, bool insert_entry,
-                                 const char* grpc_addr);
+extern void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
+                                        bool insert_entry,
+                                        const char* grpc_addr);
 
-extern enum ovs_tunnel_type TunnelTypeStrtoEnum(const char* tnl_type);
+extern void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
+                                      const char* grpc_addr);
+
+extern enum ovs_tunnel_type ovsp4rt_str_to_tunnel_type(const char* tnl_type);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/ovs-p4rt/sidecar/common/ovsp4rt_public.cc
+++ b/ovs-p4rt/sidecar/common/ovsp4rt_public.cc
@@ -20,7 +20,7 @@
 // Functions with C interfaces
 //----------------------------------------------------------------------
 
-enum ovs_tunnel_type TunnelTypeStrtoEnum(const char* tnl_type) {
+enum ovs_tunnel_type ovsp4rt_str_to_tunnel_type(const char* tnl_type) {
   if (tnl_type) {
     if (strcmp(tnl_type, "vxlan") == 0) {
       return OVS_TUNNEL_VXLAN;
@@ -31,8 +31,8 @@ enum ovs_tunnel_type TunnelTypeStrtoEnum(const char* tnl_type) {
   return OVS_TUNNEL_UNKNOWN;
 }
 
-void ConfigTunnelTableEntry(struct tunnel_info tunnel_info, bool insert_entry,
-                            const char* grpc_addr) {
+void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
+                                 bool insert_entry, const char* grpc_addr) {
   using namespace ovs_p4rt;
 
   // Start a new client session.

--- a/ovs-p4rt/sidecar/dpdk/ovsp4rt_dpdk_public.cc
+++ b/ovs-p4rt/sidecar/dpdk/ovsp4rt_dpdk_public.cc
@@ -15,8 +15,8 @@
 // Functions with C interfaces
 //----------------------------------------------------------------------
 
-void ConfigFdbTableEntry(struct mac_learning_info learn_info, bool insert_entry,
-                         const char* grpc_addr) {
+void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
+                              bool insert_entry, const char* grpc_addr) {
   using namespace ovs_p4rt;
 
   // Start a new client session.
@@ -47,17 +47,20 @@ void ConfigFdbTableEntry(struct mac_learning_info learn_info, bool insert_entry,
   }
 }
 
-void ConfigRxTunnelSrcTableEntry(struct tunnel_info tunnel_info,
-                                 bool insert_entry, const char* grpc_addr) {}
+void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
+                                        bool insert_entry,
+                                        const char* grpc_addr) {}
 
-void ConfigVlanTableEntry(uint16_t vlan_id, bool insert_entry,
-                          const char* grpc_addr) {}
+void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
+                               const char* grpc_addr) {}
 
-void ConfigTunnelSrcPortTableEntry(struct src_port_info tnl_sp,
+void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
+                                          bool insert_entry,
+                                          const char* grpc_addr) {}
+
+void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
                                    bool insert_entry, const char* grpc_addr) {}
 
-void ConfigSrcPortTableEntry(struct src_port_info vsi_sp, bool insert_entry,
-                             const char* grpc_addr) {}
-
-void ConfigIpMacMapTableEntry(struct ip_mac_map_info ip_info, bool insert_entry,
-                              const char* grpc_addr) {}
+void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
+                                     bool insert_entry, const char* grpc_addr) {
+}

--- a/ovs-p4rt/sidecar/es2k/ovsp4rt_es2k_public.cc
+++ b/ovs-p4rt/sidecar/es2k/ovsp4rt_es2k_public.cc
@@ -19,8 +19,8 @@
 // Functions with C interfaces
 //----------------------------------------------------------------------
 
-void ConfigFdbTableEntry(struct mac_learning_info learn_info, bool insert_entry,
-                         const char* grpc_addr) {
+void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
+                              bool insert_entry, const char* grpc_addr) {
   using namespace ovs_p4rt;
 
   // Start a new client session.
@@ -162,8 +162,9 @@ void ConfigFdbTableEntry(struct mac_learning_info learn_info, bool insert_entry,
   if (!status.ok()) return;
 }
 
-void ConfigRxTunnelSrcTableEntry(struct tunnel_info tunnel_info,
-                                 bool insert_entry, const char* grpc_addr) {
+void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
+                                        bool insert_entry,
+                                        const char* grpc_addr) {
   using namespace ovs_p4rt;
 
   // Start a new client session.
@@ -184,8 +185,9 @@ void ConfigRxTunnelSrcTableEntry(struct tunnel_info tunnel_info,
   if (!status.ok()) return;
 }
 
-void ConfigTunnelSrcPortTableEntry(struct src_port_info tnl_sp,
-                                   bool insert_entry, const char* grpc_addr) {
+void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
+                                          bool insert_entry,
+                                          const char* grpc_addr) {
   using namespace ovs_p4rt;
 
   ::p4::v1::WriteRequest write_request;
@@ -220,8 +222,8 @@ void ConfigTunnelSrcPortTableEntry(struct src_port_info tnl_sp,
   if (!status.ok()) return;
 }
 
-void ConfigSrcPortTableEntry(struct src_port_info vsi_sp, bool insert_entry,
-                             const char* grpc_addr) {
+void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
+                                   bool insert_entry, const char* grpc_addr) {
   using namespace ovs_p4rt;
 
   ::p4::v1::WriteRequest write_request;
@@ -278,8 +280,8 @@ void ConfigSrcPortTableEntry(struct src_port_info vsi_sp, bool insert_entry,
   if (!status.ok()) return;
 }
 
-void ConfigVlanTableEntry(uint16_t vlan_id, bool insert_entry,
-                          const char* grpc_addr) {
+void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
+                               const char* grpc_addr) {
   using namespace ovs_p4rt;
 
   ::p4::v1::WriteRequest write_request;
@@ -307,8 +309,8 @@ void ConfigVlanTableEntry(uint16_t vlan_id, bool insert_entry,
   if (!status.ok()) return;
 }
 
-void ConfigIpMacMapTableEntry(struct ip_mac_map_info ip_info, bool insert_entry,
-                              const char* grpc_addr) {
+void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
+                                     bool insert_entry, const char* grpc_addr) {
   using namespace ovs_p4rt;
 
   // Start a new client session.


### PR DESCRIPTION
- Renamed the public functions that ovs-p4rt publishes for use by OVS to conform better to C naming conventions.

- Updated README file to mention changes in the ovs-p4rt public interface.

- Referred reader to README file in stratum-deps repository for information on the dependencies changes.

Must be merged after https://github.com/ipdk-io/ovs/pull/114.