### PR TITLE
Address LNWv2 discrepancy in ovsp4rt

### DIFF
--- a/ovs-p4rt/sidecar/es2k/ovsp4rt_es2k_private.cc
+++ b/ovs-p4rt/sidecar/es2k/ovsp4rt_es2k_private.cc
@@ -100,12 +100,20 @@ void PrepareFdbRxVlanTableEntry(::p4::v1::TableEntry* table_entry,
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
     auto action = table_action->mutable_action();
+#if defined(LNW_V2)
+    action->set_action_id(GetActionId(p4info, L2_FWD_TX_TABLE_ACTION_L2_FWD));
+#else
     action->set_action_id(GetActionId(p4info, L2_FWD_RX_TABLE_ACTION_L2_FWD));
+#endif
     {
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, L2_FWD_RX_TABLE_ACTION_L2_FWD,
                                      ACTION_L2_FWD_PARAM_PORT));
+#if defined(LNW_V2)
+      auto port_id = learn_info.src_port;
+#else
       auto port_id = learn_info.rx_src_port;
+#endif
       param->set_value(EncodeByteValue(1, port_id));
     }
   }


### PR DESCRIPTION
This CL addresses an apparent bug in PR https://github.com/ipdk-io/networking-recipe/pull/425.

The following unconditional change was made to common code as part of the LNWv3 implementation:

![image](https://github.com/ipdk-io/networking-recipe/assets/12834857/f558fc47-33e7-4de7-8155-502121e0c7f9)

This PR restores the original code when networking-recipe is built for Linux Networking version 2.
