### PR TITLE
Adding MAC addresses to logs when failure occurs

### DIFF
--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -2276,20 +2276,29 @@ void ConfigFdbTableEntry(struct mac_learning_info learn_info, bool insert_entry,
     status = ConfigFdbTunnelTableEntry(session.get(), learn_info, p4info,
                                        insert_entry);
     if (!status.ok())
-      printf("%s: Failed to program l2_fwd_tx_table for tunnel\n",
-             insert_entry ? "ADD" : "DELETE");
+      printf("%s: Failed to program l2_fwd_tx_table for tunnel with mac %x:%x:%x:%x:%x:%x\n",
+             insert_entry ? "ADD" : "DELETE", learn_info.mac_addr[0],
+             learn_info.mac_addr[1], learn_info.mac_addr[2],
+             learn_info.mac_addr[3], learn_info.mac_addr[4],
+             learn_info.mac_addr[5]);
 
     status = ConfigL2TunnelTableEntry(session.get(), learn_info, p4info,
                                       insert_entry);
     if (!status.ok())
-      printf("%s: Failed to program l2_tunnel_to_v4_table for tunnel\n",
-             insert_entry ? "ADD" : "DELETE");
+      printf("%s: Failed to program l2_tunnel_to_v4_table for tunnel with mac %x:%x:%x:%x:%x:%x\n",
+             insert_entry ? "ADD" : "DELETE", learn_info.mac_addr[0],
+             learn_info.mac_addr[1], learn_info.mac_addr[2],
+             learn_info.mac_addr[3], learn_info.mac_addr[4],
+             learn_info.mac_addr[5]);
 
     status = ConfigFdbSmacTableEntry(session.get(), learn_info, p4info,
                                      insert_entry);
     if (!status.ok())
-      printf("%s: Failed to program l2_fwd_smac_table\n",
-             insert_entry ? "ADD" : "DELETE");
+      printf("%s: Failed to program l2_fwd_smac_table with mac %x:%x:%x:%x:%x:%x\n",
+             insert_entry ? "ADD" : "DELETE", learn_info.mac_addr[0],
+             learn_info.mac_addr[1], learn_info.mac_addr[2],
+             learn_info.mac_addr[3], learn_info.mac_addr[4],
+             learn_info.mac_addr[5]);
   } else {
     if (insert_entry) {
       auto status_or_read_response =
@@ -2302,8 +2311,11 @@ void ConfigFdbTableEntry(struct mac_learning_info learn_info, bool insert_entry,
       status = ConfigFdbRxVlanTableEntry(session.get(), learn_info, p4info,
                                          insert_entry);
       if (!status.ok())
-        printf("%s: Failed to program l2_fwd_rx_table\n",
-               insert_entry ? "ADD" : "DELETE");
+        printf("%s: Failed to program l2_fwd_rx_table with mac %x:%x:%x:%x:%x:%x\n",
+             insert_entry ? "ADD" : "DELETE", learn_info.mac_addr[0],
+             learn_info.mac_addr[1], learn_info.mac_addr[2],
+             learn_info.mac_addr[3], learn_info.mac_addr[4],
+             learn_info.mac_addr[5]);
 
       status_or_read_response =
           GetTxAccVsiTableEntry(session.get(), learn_info.src_port, p4info);
@@ -2344,8 +2356,11 @@ void ConfigFdbTableEntry(struct mac_learning_info learn_info, bool insert_entry,
     status = ConfigFdbTxVlanTableEntry(session.get(), learn_info, p4info,
                                        insert_entry);
     if (!status.ok())
-      printf("%s: Failed to program l2_fwd_tx_table\n",
-             insert_entry ? "ADD" : "DELETE");
+      printf("%s: Failed to program l2_fwd_tx_table with mac %x:%x:%x:%x:%x:%x\n",
+             insert_entry ? "ADD" : "DELETE", learn_info.mac_addr[0],
+             learn_info.mac_addr[1], learn_info.mac_addr[2],
+             learn_info.mac_addr[3], learn_info.mac_addr[4],
+             learn_info.mac_addr[5]);
 
     status = ConfigFdbSmacTableEntry(session.get(), learn_info, p4info,
                                      insert_entry);


### PR DESCRIPTION
Adding MAC addresses in log printouts so that we can get more detailed information during debug sessions