### PR TITLE
Reimplement basic logging for OVSP4RT

### DIFF
--- a/ovs-p4rt/ovs/CMakeLists.txt
+++ b/ovs-p4rt/ovs/CMakeLists.txt
@@ -36,8 +36,12 @@ function(set_ovs_target_properties ARTIFACT)
       target_link_libraries(${ARTIFACT} PUBLIC unwind::unwind)
   endif()
 
+
+  if(ES2K_TARGET)
+      target_link_libraries(${ARTIFACT} PUBLIC ovsp4rt_logging)
+  endif()
+
   target_link_libraries(${ARTIFACT} PUBLIC
-      absl::strings
       absl::statusor
       absl::flags_private_handle_accessor
       absl::flags

--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(ovs_sidecar_o OBJECT
     ovsp4rt_session.h
 )
 
+add_subdirectory(lib)
+
 if(DPDK_TARGET)
     add_subdirectory(dpdk)
 elseif(ES2K_TARGET)
@@ -29,7 +31,6 @@ target_include_directories(ovs_sidecar_o PUBLIC
 )
 
 target_link_libraries(ovs_sidecar_o PUBLIC
-    absl::strings
     p4_role_config_proto
     p4runtime_proto
     sde::target_sys
@@ -44,11 +45,14 @@ add_library(ovs_sidecar SHARED EXCLUDE_FROM_ALL
 )
 
 target_link_libraries(ovs_sidecar PUBLIC
-    absl::strings
     p4_role_config_proto
     p4runtime_proto
     sde::target_sys
 )
+
+if(ES2K_TARGET)
+    target_link_libraries(ovs_sidecar PUBLIC ovsp4rt_logging)
+endif()
 
 add_dependencies(ovs_sidecar ovs_sidecar_o)
 
@@ -60,3 +64,11 @@ install(
 )
 
 set_install_rpath(ovs_sidecar $ORIGIN ${SDE_ELEMENT} ${DEP_ELEMENT})
+
+###########
+# testing #
+###########
+
+set(SIDECAR_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_subdirectory(testing EXCLUDE_FROM_ALL)

--- a/ovs-p4rt/sidecar/lib/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/lib/CMakeLists.txt
@@ -1,14 +1,44 @@
 # CMake build file for ovs-p4rt/sidecar/lib
 #
-# Copyright 2022-2024 Intel Corporation
+# Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
-target_sources(ovs_sidecar_o PUBLIC
-    ovsp4rt_credentials.cc
-    ovsp4rt_credentials.h
-    ovsp4rt_logging.cc
-    ovsp4rt_logging.h
-    ovsp4rt_session.cc
-    ovsp4rt_session.h
+add_library(ovsp4rt_logging_o OBJECT
+  ovsp4rt_logging.cc
+  ovsp4rt_logging.h
+  ovsp4rt_logutils.cc
+  ovsp4rt_logutils.h
+)
+
+target_include_directories(ovsp4rt_logging_o PUBLIC
+  ${SIDECAR_SOURCE_DIR}
+)
+
+########################
+# libovsp4rt_logging.a #
+########################
+
+add_library(ovsp4rt_logging STATIC
+  $<TARGET_OBJECTS:ovsp4rt_logging_o>
+)
+
+target_link_libraries(ovsp4rt_logging PUBLIC
+  absl::strings
+)
+
+#########################
+# libovsp4rt_logging.so #
+#########################
+
+add_library(ovsp4rt_logging_so SHARED EXCLUDE_FROM_ALL
+  $<TARGET_OBJECTS:ovsp4rt_logging_o>
+)
+
+target_link_libraries(ovsp4rt_logging_so PUBLIC
+  absl::strings
+)
+
+set_target_properties(ovsp4rt_logging_so PROPERTIES
+  OUTPUT_NAME ovsp4rt_logging
 )

--- a/ovs-p4rt/sidecar/lib/ovsp4rt_logging.cc
+++ b/ovs-p4rt/sidecar/lib/ovsp4rt_logging.cc
@@ -1,0 +1,35 @@
+// Copyright 2024 Intel Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ovsp4rt_logging.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+
+namespace {
+
+const char* get_level_name(int level) {
+  switch (level) {
+    case OVSP4RT_LEVEL_ERROR:
+      return "ERROR";
+    case OVSP4RT_LEVEL_WARN:
+      return "WARN";
+    case OVSP4RT_LEVEL_INFO:
+      return "INFO";
+    case OVSP4RT_LEVEL_DEBUG:
+      return "DEBUG";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+}  // namespace
+
+void ovsp4rt_log_message(int level, const char* format, ...) {
+  printf("OVSP4RT %s - ", get_level_name(level));
+  va_list args;
+  va_start(args, format);
+  vprintf(format, args);
+  va_end(args);
+  printf("\n");
+}

--- a/ovs-p4rt/sidecar/lib/ovsp4rt_logging.h
+++ b/ovs-p4rt/sidecar/lib/ovsp4rt_logging.h
@@ -1,0 +1,36 @@
+// Copyright 2024 Intel Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_LOGGING_H_
+#define OVSP4RT_LOGGING_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+  OVSP4RT_LEVEL_DEBUG,
+  OVSP4RT_LEVEL_INFO,
+  OVSP4RT_LEVEL_WARN,
+  OVSP4RT_LEVEL_ERROR,
+};
+
+#define ovsp4rt_log_debug(...) \
+  ovsp4rt_log_message(OVSP4RT_LEVEL_DEBUG, __VA_ARGS__)
+
+#define ovsp4rt_log_error(...) \
+  ovsp4rt_log_message(OVSP4RT_LEVEL_ERROR, __VA_ARGS__)
+
+#define ovsp4rt_log_info(...) \
+  ovsp4rt_log_message(OVSP4RT_LEVEL_INFO, __VA_ARGS__)
+
+#define ovsp4rt_log_warn(...) \
+  ovsp4rt_log_message(OVSP4RT_LEVEL_WARN, __VA_ARGS__)
+
+extern void ovsp4rt_log_message(int level, const char* format, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OVSP4RT_LOGGING_H_

--- a/ovs-p4rt/sidecar/lib/ovsp4rt_logutils.cc
+++ b/ovs-p4rt/sidecar/lib/ovsp4rt_logutils.cc
@@ -1,0 +1,43 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Logger utility functions.
+//
+
+#include "ovsp4rt_logutils.h"
+
+#include <cstdio>
+#include <string>
+
+#include "absl/strings/str_cat.h"
+#include "ovsp4rt_logging.h"
+
+namespace ovs_p4rt {
+
+const std::string FormatMacAddr(const uint8_t* mac_addr) {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%x:%x:%x:%x:%x:%x", mac_addr[0], mac_addr[1],
+           mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
+  return buf;
+}
+
+const std::string FormatTableError(bool inserting, const char* table) {
+  if (inserting) {
+    return absl::StrCat("Error adding entry to ", table);
+  } else {
+    return absl::StrCat("Error deleting entry from ", table);
+  }
+}
+
+void LogTableError(bool inserting, const char* table) {
+  ovsp4rt_log_error("%s", FormatTableError(inserting, table).c_str());
+}
+
+void LogTableErrorWithMacAddr(bool inserting, const char* table,
+                              const uint8_t* mac_addr) {
+  ovsp4rt_log_error(
+      "%s for %s", FormatTableError(inserting, table).c_str(),
+      FormatMacAddr(mac_addr).c_str());
+}
+
+}  // namespace ovs_p4rt

--- a/ovs-p4rt/sidecar/lib/ovsp4rt_logutils.h
+++ b/ovs-p4rt/sidecar/lib/ovsp4rt_logutils.h
@@ -1,0 +1,26 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Logger utility function prototypes.
+//
+
+#ifndef OVSP4RT_LOGUTILS_H_
+#define OVSP4RT_LOGUTILS_H_
+
+#include <cstdint>
+#include <string>
+
+namespace ovs_p4rt {
+
+const std::string FormatMacAddr(const uint8_t* mac_addr);
+
+const std::string FormatTableError(bool inserting, const char* table);
+
+void LogTableError(bool inserting, const char* table);
+
+void LogTableErrorWithMacAddr(bool inserting, const char* table,
+                              const uint8_t* mac_addr);
+
+}  // namespace ovs_p4rt
+
+#endif  // OVSP4RT_LOGUTILS_H_

--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -4,33 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-add_library(ovsp4rt_logging_o OBJECT
-  ${SIDECAR_SOURCE_DIR}/common/ovsp4rt_logutils.cc
-  ${SIDECAR_SOURCE_DIR}/common/ovsp4rt_logutils.h
-  ${SIDECAR_SOURCE_DIR}/lib/ovsp4rt_logging.cc
-  ${SIDECAR_SOURCE_DIR}/lib/ovsp4rt_logging.h
-)
-
-target_include_directories(ovsp4rt_logging_o PRIVATE
-  ${SIDECAR_SOURCE_DIR}
-  ${SDE_INSTALL_DIR}/include
-)
-
-add_library(ovsp4rt_logging SHARED $<TARGET_OBJECTS:ovsp4rt_logging_o>)
-
 add_executable(logging_test EXCLUDE_FROM_ALL
   logging_test.cc
 )
 
 target_include_directories(logging_test PUBLIC
   ${SIDECAR_SOURCE_DIR}
-  ${DEPEND_INSTALL_DIR}/include
-  ${SDE_INSTALL_DIR}/include
   ${OVSP4RT_INCLUDE_DIR}
 )
 
 target_link_libraries(logging_test PUBLIC
-  ovsp4rt_logging
-  absl::strings
+  ovsp4rt_logging_so
   sde::target_sys
 )

--- a/ovs-p4rt/sidecar/testing/logging_test.cc
+++ b/ovs-p4rt/sidecar/testing/logging_test.cc
@@ -11,8 +11,8 @@
 #include <iostream>
 #include <string>
 
-#include "common/ovsp4rt_logutils.h"
 #include "lib/ovsp4rt_logging.h"
+#include "lib/ovsp4rt_logutils.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 using namespace ovs_p4rt;
@@ -23,27 +23,24 @@ void log_messages() {
 
   ovsp4rt_log_info("Error adding to FDB Tunnel Table: entry already exists");
 
-  LogTableError(insert_entry, "FDB Tunnel Table");
+  LogTableErrorWithMacAddr(insert_entry, "FDB Tunnel Table", mac_addr);
 
   insert_entry = !insert_entry;
-  LogTableError(insert_entry, "L2 Tunnel Table");
+  LogTableErrorWithMacAddr(insert_entry, "L2 Tunnel Table", mac_addr);
 
   insert_entry = !insert_entry;
-  LogTableError(insert_entry, "FDB Source MAC Table");
+  LogTableErrorWithMacAddr(insert_entry, "FDB Source Mac Table", mac_addr);
 
   ovsp4rt_log_warn("Error adding to FDB Vlan Table: entry already exists");
 
   insert_entry = !insert_entry;
-  LogTableError(insert_entry, "FDB Rx Vlan Table");
+  LogTableErrorWithMacAddr(insert_entry, "FDB Tx Vlan Table", mac_addr);
 
   insert_entry = !insert_entry;
   LogTableError(insert_entry, "FDB Tx Vlan Table");
 
   insert_entry = !insert_entry;
-  ovsp4rt_log_debug(
-      "%s for %s",
-      TableErrorMessage(insert_entry, "FDB Source MAC Table").c_str(),
-      FormatMac(mac_addr).c_str());
+  LogTableErrorWithMacAddr(insert_entry, "FDB Source Mac Table", mac_addr);
 
   insert_entry = !insert_entry;
   LogTableError(insert_entry, "SRC_IP_MAC_MAP_TABLE");


### PR DESCRIPTION
- Implemented a rudimentary logger for OVSP4RT, together with some helper functions to handle the most common message patterns. The initial implementation simply prints to the console.

- Replaced printf() calls with calls to the logger or helper functions.