### PR TITLE
Cherry-Pick PR #510 from mev-ts-1.6 branch to main

### DIFF
--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -2286,6 +2286,8 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
           GetL2ToTunnelV6TableEntry(session.get(), learn_info, p4info);
       if (status_or_read_response.ok()) {
         learn_info.is_tunnel = true;
+        learn_info.tnl_info.local_ip.family = AF_INET6;
+        learn_info.tnl_info.remote_ip.family = AF_INET6;
       }
     }
   }


### PR DESCRIPTION
This PR cherry-picks #510 from `mev-ts-1.6` branch to `main` branch.

==
Fix l2_to_tunnel_v6 table delete (#510)

When a MAC delete happens, we will not have info regarding this MAC belongs to an Ipv4/IPv6 client. Also, we will not know if this MAC is learned on tunnel interface or regular interface.

On a FDB delete, we check l2_to_tunnel_v4 and l2_to_tunnel_v6 tables to see if this is a v4 or v6 tunnel.

If V6 tunnel, we should also set AF_INET6 flags for both local and remote IP as this info is used in ConfigL2TunnelTableEntry API. Earlier this AF_INET6 family type was not set, so even for IPv6 entry we try to delete from l2_to_tunnel_v4 instead of l2_to_tunnel_v6 table.