### PR TITLE
Define ovsp4rt_stubs library

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -6,10 +6,9 @@
 
 set(SIDECAR_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-#################
-# ovs_sidecar_o #
-#################
-
+#-----------------------------------------------------------------------
+# ovs_sidecar_o
+#-----------------------------------------------------------------------
 add_library(ovs_sidecar_o OBJECT
     ${OVSP4RT_INCLUDE_DIR}/ovsp4rt/ovs-p4rt.h
     ovsp4rt.cc
@@ -39,10 +38,9 @@ target_link_libraries(ovs_sidecar_o PUBLIC
     p4runtime_proto
 )
 
-#################
-# libovsp4rt.so #
-#################
-
+#-----------------------------------------------------------------------
+# libovsp4rt.so
+#-----------------------------------------------------------------------
 add_library(ovsp4rt SHARED
     $<TARGET_OBJECTS:ovs_sidecar_o>
     $<TARGET_OBJECTS:ovsp4rt_logging_o>
@@ -62,6 +60,19 @@ target_link_libraries(ovsp4rt PUBLIC
 set_install_rpath(ovsp4rt $ORIGIN ${DEP_ELEMENT})
 
 #-----------------------------------------------------------------------
+# libovsp4rt_stubs.a
+#-----------------------------------------------------------------------
+add_library(ovsp4rt_stubs STATIC
+    ovsp4rt_stubs.cc
+)
+
+target_include_directories(ovsp4rt_stubs PUBLIC
+    ${OVSP4RT_INCLUDE_DIR}
+)
+
+target_link_libraries(ovsp4rt_stubs PRIVATE stratum_static)
+
+#-----------------------------------------------------------------------
 # libovsp4rt_spies.a
 #-----------------------------------------------------------------------
 add_subdirectory(spies)
@@ -70,7 +81,7 @@ add_subdirectory(spies)
 # Install
 #-----------------------------------------------------------------------
 install(
-    TARGETS ovsp4rt ovsp4rt_spies
+    TARGETS ovsp4rt ovsp4rt_spies ovsp4rt_stubs
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
@@ -90,10 +101,14 @@ configure_file(cmake/libovsp4rt.pc.in ${ovsp4rt_cfg_file} @ONLY)
 set(ovsp4rt_spies_cfg_file ${CMAKE_CURRENT_BINARY_DIR}/libovsp4rt_spies.pc)
 configure_file(cmake/libovsp4rt_spies.pc.in ${ovsp4rt_spies_cfg_file} @ONLY)
 
+set(ovsp4rt_stubs_cfg_file ${CMAKE_CURRENT_BINARY_DIR}/libovsp4rt_stubs.pc)
+configure_file(cmake/libovsp4rt_stubs.pc.in ${ovsp4rt_stubs_cfg_file} @ONLY)
+
 install(
     FILES
         ${ovsp4rt_cfg_file}
         ${ovsp4rt_spies_cfg_file}
+        ${ovsp4rt_stubs_cfg_file}
     DESTINATION
         ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )

--- a/ovs-p4rt/sidecar/cmake/libovsp4rt_stubs.pc.in
+++ b/ovs-p4rt/sidecar/cmake/libovsp4rt_stubs.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libovsp4rt_stubs
+Description: Dummy P4Runtime client library for OVS
+URL: https://github.com/ipdk-io/networking-recipe.git
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -lovsp4rt_stubs
+Cflags: -I${includedir}

--- a/ovs-p4rt/sidecar/ovsp4rt_stubs.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_stubs.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022-2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "ovsp4rt/ovs-p4rt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
+                              bool insert_entry, const char* grpc_addr) {
+  return;
+}
+
+void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info learn_info,
+                                     bool insert_entry, const char* grpc_addr) {
+}
+
+void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
+                                        bool insert_entry,
+                                        const char* grpc_addr) {
+  return;
+}
+
+void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
+                                   bool insert_entry, const char* grpc_addr) {
+  return;
+}
+
+void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
+                                          bool insert_entry,
+                                          const char* grpc_addr) {
+  return;
+}
+
+void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
+                                 bool insert_entry, const char* grpc_addr) {
+  return;
+}
+
+void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
+                               const char* grpc_addr) {
+  return;
+}
+
+enum ovs_tunnel_type ovsp4rt_str_to_tunnel_type(const char* tnl_type) {
+  return OVS_TUNNEL_UNKNOWN;
+}
+
+#ifdef __cplusplus
+}  // "C"
+#endif


### PR DESCRIPTION
See issue https://github.com/ipdk-io/networking-recipe/issues/516 for background information.

- Created a dummy OVSP4T library that can be linked with ovs-vswitchd and ovs-testcontroller to allow the OVS test suite to be run against a P4 build of OVS.

----

This PR is part of preparing to upstream OVS. It was extracted from PR https://github.com/ipdk-io/networking-recipe/pull/515.

It's an orthogonal change. It adds a new library.