### PR TITLE
Continue ovsp4rt test development

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -70,7 +70,10 @@ target_include_directories(ovsp4rt_stubs PUBLIC
     ${OVSP4RT_INCLUDE_DIR}
 )
 
-target_link_libraries(ovsp4rt_stubs PRIVATE stratum_static)
+#-----------------------------------------------------------------------
+# libovsp4rt_capture.a
+#-----------------------------------------------------------------------
+add_subdirectory(capture)
 
 #-----------------------------------------------------------------------
 # libovsp4rt_spies.a

--- a/ovs-p4rt/sidecar/capture/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/capture/CMakeLists.txt
@@ -1,0 +1,16 @@
+# CMake build file for ovs-p4rt/sidecar/capture
+#
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+
+add_library(ovsp4rt_capture STATIC
+  capture_mac_learning_info.cc
+  ovsp4rt_capture.h
+)
+
+target_include_directories(ovsp4rt_capture PUBLIC
+  ${DEPEND_INSTALL_DIR}/include
+  ${OVSP4RT_INCLUDE_DIR}
+  ${SIDECAR_SOURCE_DIR}
+)

--- a/ovs-p4rt/sidecar/capture/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/capture/CMakeLists.txt
@@ -5,9 +5,12 @@
 #
 
 add_library(ovsp4rt_capture STATIC
+  capture_api_input.cc
+  capture_api_input.h
   capture_mac_learning_info.cc
   capture_src_port_info.cc
   ovsp4rt_capture.h
+  ovsp4rt_encode.h
 )
 
 target_include_directories(ovsp4rt_capture PUBLIC

--- a/ovs-p4rt/sidecar/capture/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/capture/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 add_library(ovsp4rt_capture STATIC
   capture_mac_learning_info.cc
+  capture_src_port_info.cc
   ovsp4rt_capture.h
 )
 

--- a/ovs-p4rt/sidecar/capture/capture_api_input.cc
+++ b/ovs-p4rt/sidecar/capture/capture_api_input.cc
@@ -1,0 +1,15 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "capture_api_input.h"
+
+#include "ovsp4rt_encode.h"
+
+namespace ovs_p4rt {
+
+void CaptureApiInput::encode(const char* func_name,
+                             const mac_learning_info& info, bool insert_entry) {
+  json_ = EncodeMacLearningInfo(func_name, info, insert_entry);
+}
+
+}  // namespace ovs_p4rt

--- a/ovs-p4rt/sidecar/capture/capture_api_input.h
+++ b/ovs-p4rt/sidecar/capture/capture_api_input.h
@@ -1,0 +1,49 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef CAPTURE_API_INPUT_H_
+#define CAPTURE_API_INPUT_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <nlohmann/json.hpp>
+
+#include "ovsp4rt/ovs-p4rt.h"
+
+#define CAPTURE_API_INPUT(_info, _insert_entry, _envoy) \
+  do {                                                  \
+    CaptureApiInput _input;                             \
+    _input.encode(__func__, _info, _insert_entry);      \
+    _envoy.captureInput(_input);                        \
+  } while (0)
+
+namespace ovs_p4rt {
+
+class CaptureApiInput {
+ public:
+  CaptureApiInput();
+
+  void encode(const char* func_name, const mac_learning_info& info,
+              bool insert_entry);
+
+  void encode(const char* func_name, const ip_mac_map_info& info,
+              bool insert_entry) {}
+
+  void encode(const char* func_name, const tunnel_info& info,
+              bool insert_entry) {}
+
+  void encode(const char* func_name, const src_port_info info,
+              bool insert_entry) {}
+
+  void encode(const char* func_name, uint16_t vlan_id, bool insert_entry) {}
+
+  nlohmann::json json() const { return json_; }
+
+ private:
+  nlohmann::json json_;
+};
+
+}  // namespace ovs_p4rt
+
+#endif  // CAPTURE_API_INPUT_H_

--- a/ovs-p4rt/sidecar/capture/capture_mac_learning_info.cc
+++ b/ovs-p4rt/sidecar/capture/capture_mac_learning_info.cc
@@ -15,7 +15,7 @@
 namespace ovs_p4rt {
 
 void CaptureMacLearningInfo(const char* func_name,
-                            struct mac_learning_info& learn_info,
+                            const struct mac_learning_info& learn_info,
                             bool insert_entry) {
   nlohmann::json json_info;
 

--- a/ovs-p4rt/sidecar/capture/capture_mac_learning_info.cc
+++ b/ovs-p4rt/sidecar/capture/capture_mac_learning_info.cc
@@ -71,7 +71,7 @@ void MacLearningInfoToJson(nlohmann::json& json,
   if (info.is_tunnel) {
     TunnelInfoToJson(json["tnl_info"], info.tnl_info);
   } else if (info.is_vlan) {
-    VlanInfoToJson(json["vlan_info"], info.vln_info);
+    VlanInfoToJson(json["vln_info"], info.vln_info);
   }
 }
 

--- a/ovs-p4rt/sidecar/capture/capture_mac_learning_info.cc
+++ b/ovs-p4rt/sidecar/capture/capture_mac_learning_info.cc
@@ -1,9 +1,6 @@
 /*
- * Copyright (c) 2024 Intel Corporation.
+ * Copyright 2024 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
- *
- * Test double (spy) for the ovsp4rt_config_fdb_entry API.
- * Dumps the input parameters in JSON.
  */
 
 #include <stdbool.h>
@@ -12,13 +9,17 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 
+#include "capture/ovsp4rt_capture.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
-void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
-                              bool insert_entry, const char* grpc_addr) {
+namespace ovs_p4rt {
+
+void CaptureMacLearningInfo(const char* func_name,
+                            struct mac_learning_info& learn_info,
+                            bool insert_entry) {
   nlohmann::json json_info;
 
-  json_info["name"] = "ovsp4rt_config_fdb_entry";
+  json_info["name"] = func_name;
   json_info["version"] = 1;
 
   // discrete fields
@@ -73,3 +74,5 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
 
   std::cout << std::endl << json_info.dump(2) << std::endl;
 }
+
+}  // namespace ovs_p4rt

--- a/ovs-p4rt/sidecar/capture/capture_mac_learning_info.cc
+++ b/ovs-p4rt/sidecar/capture/capture_mac_learning_info.cc
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 
 #include "capture/ovsp4rt_capture.h"
+#include "capture/ovsp4rt_encode.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace {
@@ -74,9 +75,9 @@ void MacLearningInfoToJson(nlohmann::json& json,
   }
 }
 
-void CaptureMacLearningInfo(const char* func_name,
-                            const struct mac_learning_info& learn_info,
-                            bool insert_entry) {
+nlohmann::json EncodeMacLearningInfo(const char* func_name,
+                                     const struct mac_learning_info& learn_info,
+                                     bool insert_entry) {
   nlohmann::json json;
 
   json["func_name"] = func_name;
@@ -87,7 +88,13 @@ void CaptureMacLearningInfo(const char* func_name,
   MacLearningInfoToJson(params["learn_info"], learn_info);
   params["insert_entry"] = insert_entry;
 
-  // Return json object?
+  return json;
+}
+
+void CaptureMacLearningInfo(const char* func_name,
+                            const struct mac_learning_info& learn_info,
+                            bool insert_entry) {
+  auto json = EncodeMacLearningInfo(func_name, learn_info, insert_entry);
   std::cout << std::endl << json.dump(2) << std::endl;
 }
 

--- a/ovs-p4rt/sidecar/capture/capture_src_port_info.cc
+++ b/ovs-p4rt/sidecar/capture/capture_src_port_info.cc
@@ -16,8 +16,7 @@ constexpr uint32_t PORT_INFO_SCHEMA = 1;
 
 namespace ovs_p4rt {
 
-void SrcPortInfoToJson(nlohmann::json& json,
-                       const struct src_port_info& info) {
+void SrcPortInfoToJson(nlohmann::json& json, const struct src_port_info& info) {
   json["bridge_id"] = info.bridge_id;
   json["vlan_id"] = info.vlan_id;
   json["src_port"] = info.src_port;

--- a/ovs-p4rt/sidecar/capture/capture_src_port_info.cc
+++ b/ovs-p4rt/sidecar/capture/capture_src_port_info.cc
@@ -1,0 +1,43 @@
+// Copyright 2024 Intel Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <iostream>
+#include <nlohmann/json.hpp>
+
+#include "capture/ovsp4rt_capture.h"
+#include "ovsp4rt/ovs-p4rt.h"
+
+namespace {
+constexpr uint32_t PORT_INFO_SCHEMA = 1;
+}
+
+namespace ovs_p4rt {
+
+void SrcPortInfoToJson(nlohmann::json& json,
+                       const struct src_port_info& info) {
+  json["bridge_id"] = info.bridge_id;
+  json["vlan_id"] = info.vlan_id;
+  json["src_port"] = info.src_port;
+}
+
+void CaptureSrcPortInfo(const char* func_name,
+                        const struct src_port_info& sp_info,
+                        bool insert_entry) {
+  nlohmann::json json;
+
+  json["func_name"] = func_name;
+  json["schema"] = PORT_INFO_SCHEMA;
+  json["struct_name"] = "src_port_info";
+
+  auto& params = json["params"];
+  SrcPortInfoToJson(params["port_info"], sp_info);
+  params["insert_entry"] = insert_entry;
+
+  // Return json object?
+  std::cout << std::endl << json.dump(2) << std::endl;
+}
+
+}  // namespace ovs_p4rt

--- a/ovs-p4rt/sidecar/capture/ovsp4rt_capture.h
+++ b/ovs-p4rt/sidecar/capture/ovsp4rt_capture.h
@@ -18,6 +18,6 @@ extern void CaptureSrcPortInfo(const char* func_name,
                                const struct src_port_info& sp_info,
                                bool insert_entry);
 
-}  // namespace ovs_p4rt
+} // namespace ovs_p4rt
 
 #endif  // OVSP4RT_CAPTURE_H

--- a/ovs-p4rt/sidecar/capture/ovsp4rt_capture.h
+++ b/ovs-p4rt/sidecar/capture/ovsp4rt_capture.h
@@ -11,7 +11,7 @@
 namespace ovs_p4rt {
 
 extern void CaptureMacLearningInfo(const char* func_name,
-                                   struct mac_learning_info& learn_info,
+                                   const struct mac_learning_info& learn_info,
                                    bool insert_entry);
 
 }  // namespace ovs_p4rt

--- a/ovs-p4rt/sidecar/capture/ovsp4rt_capture.h
+++ b/ovs-p4rt/sidecar/capture/ovsp4rt_capture.h
@@ -1,0 +1,19 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_CAPTURE_H
+#define OVSP4RT_CAPTURE_H
+
+#include <stdbool.h>
+
+#include "ovsp4rt/ovs-p4rt.h"
+
+namespace ovs_p4rt {
+
+extern void CaptureMacLearningInfo(const char* func_name,
+                                   struct mac_learning_info& learn_info,
+                                   bool insert_entry);
+
+}  // namespace ovs_p4rt
+
+#endif  // OVSP4RT_CAPTURE_H

--- a/ovs-p4rt/sidecar/capture/ovsp4rt_capture.h
+++ b/ovs-p4rt/sidecar/capture/ovsp4rt_capture.h
@@ -18,6 +18,6 @@ extern void CaptureSrcPortInfo(const char* func_name,
                                const struct src_port_info& sp_info,
                                bool insert_entry);
 
-} // namespace ovs_p4rt
+}  // namespace ovs_p4rt
 
 #endif  // OVSP4RT_CAPTURE_H

--- a/ovs-p4rt/sidecar/capture/ovsp4rt_capture.h
+++ b/ovs-p4rt/sidecar/capture/ovsp4rt_capture.h
@@ -14,6 +14,10 @@ extern void CaptureMacLearningInfo(const char* func_name,
                                    const struct mac_learning_info& learn_info,
                                    bool insert_entry);
 
+extern void CaptureSrcPortInfo(const char* func_name,
+                               const struct src_port_info& sp_info,
+                               bool insert_entry);
+
 }  // namespace ovs_p4rt
 
 #endif  // OVSP4RT_CAPTURE_H

--- a/ovs-p4rt/sidecar/capture/ovsp4rt_encode.h
+++ b/ovs-p4rt/sidecar/capture/ovsp4rt_encode.h
@@ -1,0 +1,19 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_ENCODE_H
+#define OVSP4RT_ENCODE_H
+
+#include <nlohmann/json.hpp>
+
+#include "ovsp4rt/ovs-p4rt.h"
+
+namespace ovs_p4rt {
+
+nlohmann::json EncodeMacLearningInfo(const char* func_name,
+                                     const struct mac_learning_info& learn_info,
+                                     bool insert_entry);
+
+} // namespace ovs_p4rt
+
+#endif  // OVSP4RT_ENCODE_H

--- a/ovs-p4rt/sidecar/capture/ovsp4rt_encode.h
+++ b/ovs-p4rt/sidecar/capture/ovsp4rt_encode.h
@@ -14,6 +14,6 @@ nlohmann::json EncodeMacLearningInfo(const char* func_name,
                                      const struct mac_learning_info& learn_info,
                                      bool insert_entry);
 
-} // namespace ovs_p4rt
+}  // namespace ovs_p4rt
 
 #endif  // OVSP4RT_ENCODE_H

--- a/ovs-p4rt/sidecar/spies/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/spies/CMakeLists.txt
@@ -8,12 +8,14 @@
 # libovsp4rt_spies.a
 #-----------------------------------------------------------------------
 add_library(ovsp4rt_spies STATIC
-    ovsp4rt_config_fdb_entry_spy.cc
     ovsp4rt_spies.cc
 )
 
+target_link_libraries(ovsp4rt_spies PUBLIC
+  ovsp4rt_capture
+)
+
 target_include_directories(ovsp4rt_spies PUBLIC
-    ${DEPEND_INSTALL_DIR}/include
     ${OVSP4RT_INCLUDE_DIR}
 )
 

--- a/ovs-p4rt/sidecar/spies/ovsp4rt_spies.cc
+++ b/ovs-p4rt/sidecar/spies/ovsp4rt_spies.cc
@@ -9,13 +9,17 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <nlohmann/json.hpp>
-
+#include "capture/ovsp4rt_capture.h"
 #include "ovsp4rt/ovs-p4rt.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
+                              bool insert_entry, const char* grpc_addr) {
+  ::ovs_p4rt::CaptureMacLearningInfo(__func__, learn_info, insert_entry);
+}
 
 void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info learn_info,
                                      bool insert_entry, const char* grpc_addr) {

--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -38,8 +38,13 @@ if(ES2K_TARGET)
 #-----------------------------------------------------------------------
 add_executable(prepare_l2_to_tunnel_test
   prepare_l2_to_tunnel_test.cc
+  test_main.cc
 )
 
 set_test_properties(prepare_l2_to_tunnel_test)
+
+target_link_libraries(prepare_l2_to_tunnel_test PUBLIC
+  absl::flags_parse
+)
 
 endif(ES2K_TARGET)

--- a/ovs-p4rt/sidecar/testing/prepare_l2_to_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/testing/prepare_l2_to_tunnel_test.cc
@@ -44,9 +44,7 @@ class PrepareL2ToTunnelTest : public ::testing::Test {
     }
   }
 
-  PrepareL2ToTunnelTest() {
-    dump_json_ = absl::GetFlag(FLAGS_dump_json);
-  }
+  PrepareL2ToTunnelTest() { dump_json_ = absl::GetFlag(FLAGS_dump_json); }
 
   void DumpMacLearningInfo(const char* func_name,
                            const struct mac_learning_info& learn_info,

--- a/ovs-p4rt/sidecar/testing/set_test_properties.cmake
+++ b/ovs-p4rt/sidecar/testing/set_test_properties.cmake
@@ -19,6 +19,7 @@ function(set_test_properties TARGET)
     GTest::gtest
     GTest::gtest_main
     ovsp4rt
+    ovsp4rt_capture
     p4runtime_proto
     stratum_utils
   )

--- a/ovs-p4rt/sidecar/testing/set_test_properties.cmake
+++ b/ovs-p4rt/sidecar/testing/set_test_properties.cmake
@@ -17,7 +17,6 @@ function(set_test_properties TARGET)
 
   target_link_libraries(${TARGET} PUBLIC
     GTest::gtest
-    GTest::gtest_main
     ovsp4rt
     ovsp4rt_capture
     p4runtime_proto

--- a/ovs-p4rt/sidecar/testing/test_main.cc
+++ b/ovs-p4rt/sidecar/testing/test_main.cc
@@ -4,7 +4,7 @@
 #include "absl/flags/parse.h"
 #include "gtest/gtest.h"
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   absl::ParseCommandLine(argc, argv);
   return RUN_ALL_TESTS();

--- a/ovs-p4rt/sidecar/testing/test_main.cc
+++ b/ovs-p4rt/sidecar/testing/test_main.cc
@@ -5,7 +5,13 @@
 #include "gtest/gtest.h"
 
 int main(int argc, char** argv) {
+  // As part of initialization, this function parses the command line,
+  // removing any arguments that are specific to googletest.
   testing::InitGoogleTest(&argc, argv);
+
+  // Parses the remaining command-line arguments for Abseil flags
+  // defined by the test program.
   absl::ParseCommandLine(argc, argv);
+
   return RUN_ALL_TESTS();
 }

--- a/ovs-p4rt/sidecar/testing/test_main.cc
+++ b/ovs-p4rt/sidecar/testing/test_main.cc
@@ -1,0 +1,11 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "absl/flags/parse.h"
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  absl::ParseCommandLine(argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
### Changes

- Defined `ovsp4rt_capture` library.
- Extracted `CaptureMacLearningInfo()` and added it to capture library.
- Implemented `test_main.cc`, which allows googletest programs to define Abseil flags.
- Modified `prepare_l2_to_tunnel_test` to dump input to the UUT as well as output, under control of the `--dump_json` command-line flag.
- Defined `CaptureApiInput` class and `CAPTURE_API_INPUT` macro.

> [!NOTE]
> This PR is orthogonal to the rest of OVSP4RT.

### Objective

Capture the input to a public API function and the generated TableEntry, and output the pair so they can be used as a test case in an approval/characterization test.

### Plan

1. Write a library of functions to serialize the input structures as JSON objects.
2. Write a library of functions to serialize the inputs to each public API as JSON objects.
3. Write a function to render a generated TableEntry as a JSON object.
4. Create an object to encapsulate the logic that captures a test tuple and outputs it to a test file.
5. Integrate the mechanism into the OVSP4RT processing logic.

I'm currently working on a PoC implementation for the `ovsp4rt_config_fdb_entry()` API.

The intention is to use the `Envoy` class (PR https://github.com/ipdk-io/networking-recipe/pull/528) as the vehicle for capturing the test tuples.