### PR TITLE
Implement ovsp4rt::Envoy class

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(ovs_sidecar_o OBJECT
     ovsp4rt.cc
     ovsp4rt_credentials.cc
     ovsp4rt_credentials.h
+    ovsp4rt_envoy.cc
+    ovsp4rt_envoy.h
     ovsp4rt_private.h
     ovsp4rt_session.cc
     ovsp4rt_session.h

--- a/ovs-p4rt/sidecar/ovsp4rt_envoy.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_envoy.cc
@@ -1,0 +1,67 @@
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ovsp4rt_envoy.h"
+
+#include "absl/flags/flag.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "ovsp4rt_credentials.h"
+#include "ovsp4rt_session.h"
+
+#define DEFAULT_OVS_P4RT_ROLE_NAME "ovs-p4rt"
+
+ABSL_FLAG(uint64_t, device_id, 1, "P4Runtime device ID.");
+
+ABSL_FLAG(std::string, role_name, DEFAULT_OVS_P4RT_ROLE_NAME,
+          "P4 config role name.");
+
+namespace ovs_p4rt {
+
+absl::Status Envoy::connect(const char* grpc_addr) {
+  // Start a new client session.
+  auto result = ovs_p4rt::OvsP4rtSession::Create(
+      grpc_addr, GenerateClientCredentials(), absl::GetFlag(FLAGS_device_id),
+      absl::GetFlag(FLAGS_role_name));
+  if (!result.ok()) {
+    return result.status();
+  }
+
+  // Unwrap the session from the StatusOr object.
+  session_ = std::move(result).value();
+  return absl::OkStatus();
+}
+
+absl::Status Envoy::getPipelineConfig(::p4::config::v1::P4Info* p4info) {
+  return GetForwardingPipelineConfig(session_.get(), p4info);
+}
+
+::p4::v1::TableEntry* Envoy::initReadRequest(::p4::v1::ReadRequest* request) {
+  return SetupTableEntryToRead(session_.get(), request);
+}
+
+absl::StatusOr<::p4::v1::ReadResponse> Envoy::sendReadRequest(
+    const p4::v1::ReadRequest& request) {
+  return SendReadRequest(session_.get(), request);
+}
+
+::p4::v1::TableEntry* Envoy::initInsertRequest(
+    ::p4::v1::WriteRequest* request) {
+  return SetupTableEntryToInsert(session_.get(), request);
+}
+
+::p4::v1::TableEntry* Envoy::initModifyRequest(
+    ::p4::v1::WriteRequest* request) {
+  return SetupTableEntryToModify(session_.get(), request);
+}
+
+::p4::v1::TableEntry* Envoy::initDeleteRequest(
+    ::p4::v1::WriteRequest* request) {
+  return SetupTableEntryToDelete(session_.get(), request);
+}
+
+absl::Status Envoy::sendWriteRequest(const p4::v1::WriteRequest& request) {
+  return SendWriteRequest(session_.get(), request);
+}
+
+}  // namespace ovs_p4rt

--- a/ovs-p4rt/sidecar/ovsp4rt_envoy.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_envoy.h
@@ -1,0 +1,62 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_ENVOY_H_
+#define OVSP4RT_ENVOY_H_
+
+#include <stdint.h>
+
+#include <string>
+
+#include "absl/flags/declare.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "ovsp4rt_session.h"
+#include "p4/v1/p4runtime.pb.h"
+
+ABSL_DECLARE_FLAG(uint64_t, device_id);
+ABSL_DECLARE_FLAG(std::string, role_name);
+
+namespace ovs_p4rt {
+
+// Abstracts the interface to the P4Runtime session.
+class Envoy {
+ public:
+  Envoy() {}
+
+  absl::Status connect(const char* grpc_addr);
+
+  OvsP4rtSession* session() const { return session_.get(); }
+
+  absl::Status getPipelineConfig(::p4::config::v1::P4Info* p4info);
+
+  // Read requests
+  ::p4::v1::TableEntry* initReadRequest(::p4::v1::ReadRequest* request);
+
+  absl::StatusOr<p4::v1::ReadResponse> sendReadRequest(
+      const p4::v1::ReadRequest& request);
+
+  // Write requests
+  ::p4::v1::TableEntry* initInsertRequest(::p4::v1::WriteRequest* request);
+  ::p4::v1::TableEntry* initModifyRequest(::p4::v1::WriteRequest* request);
+  ::p4::v1::TableEntry* initDeleteRequest(::p4::v1::WriteRequest* request);
+
+  ::p4::v1::TableEntry* initWriteRequest(::p4::v1::WriteRequest* request,
+                                         bool insert_entry) {
+    if (insert_entry) {
+      return initInsertRequest(request);
+    } else {
+      return initDeleteRequest(request);
+    }
+  }
+
+  absl::Status sendWriteRequest(const p4::v1::WriteRequest& request);
+
+ private:
+  // P4Runtime session.
+  std::unique_ptr<ovs_p4rt::OvsP4rtSession> session_;
+};
+
+}  // namespace ovs_p4rt
+
+#endif  // OVSP4RT_ENVOY_H_


### PR DESCRIPTION
### Changes

- Defined a class that abstracts the interface to the P4Runtime session.

- Modified `ovsp4rt_config_fdb_entry()` and its dependencies to use the Envoy class. Also modified `ovsp4rt_config_src_port_entry()`, which some of the same dependencies.

### Objectives

1. Abstract out the interface between the public APIs and the P4Runtime session.
2. Reduce the amount of repeated boilerplate code by encapsulating it in the interface object.
3. Make it possible to create a test double (mock) for the interface, making it easier to create tests for the API functions.
4. Make it easier to capture the input and output of an API for use in approval testing.