### PR TITLE
Fix VNI issue of setting only 1 byte

### DIFF
--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -336,7 +336,10 @@ void PrepareFdbTableEntryforV4VxlanTunnel(
           param->set_param_id(GetParamId(
               p4info, L2_FWD_TX_TABLE_ACTION_POP_VLAN_SET_VXLAN_UNDERLAY_V4,
               ACTION_PARAM_TUNNEL_ID));
-          param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
+          param->set_value(
+              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
+                              (learn_info.tnl_info.vni >> 8) & 0xFF,
+                              learn_info.tnl_info.vni & 0xFF));
         }
       } else {
         action->set_action_id(
@@ -346,7 +349,10 @@ void PrepareFdbTableEntryforV4VxlanTunnel(
           param->set_param_id(
               GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_SET_VXLAN_UNDERLAY_V4,
                          ACTION_PARAM_TUNNEL_ID));
-          param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
+          param->set_value(
+              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
+                              (learn_info.tnl_info.vni >> 8) & 0xFF,
+                              learn_info.tnl_info.vni & 0xFF));
         }
       }
     } else if (learn_info.tnl_info.local_ip.family == AF_INET6 &&
@@ -369,7 +375,10 @@ void PrepareFdbTableEntryforV4VxlanTunnel(
           param->set_param_id(
               GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_SET_VXLAN_UNDERLAY_V6,
                          ACTION_PARAM_TUNNEL_ID));
-          param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
+          param->set_value(
+              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
+                              (learn_info.tnl_info.vni >> 8) & 0xFF,
+                              learn_info.tnl_info.vni & 0xFF));
         }
       }
     }
@@ -436,7 +445,10 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
           param->set_param_id(GetParamId(
               p4info, L2_FWD_TX_TABLE_ACTION_POP_VLAN_SET_GENEVE_UNDERLAY_V4,
               ACTION_PARAM_TUNNEL_ID));
-          param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
+          param->set_value(
+              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
+                              (learn_info.tnl_info.vni >> 8) & 0xFF,
+                              learn_info.tnl_info.vni & 0xFF));
         }
       } else {
         action->set_action_id(
@@ -446,7 +458,10 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
           param->set_param_id(
               GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_SET_GENEVE_UNDERLAY_V4,
                          ACTION_PARAM_TUNNEL_ID));
-          param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
+          param->set_value(
+              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
+                              (learn_info.tnl_info.vni >> 8) & 0xFF,
+                              learn_info.tnl_info.vni & 0xFF));
         }
       }
     } else if (learn_info.tnl_info.local_ip.family == AF_INET6 &&
@@ -459,7 +474,10 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
           param->set_param_id(GetParamId(
               p4info, L2_FWD_TX_TABLE_ACTION_POP_VLAN_SET_GENEVE_UNDERLAY_V6,
               ACTION_PARAM_TUNNEL_ID));
-          param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
+          param->set_value(
+              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
+                              (learn_info.tnl_info.vni >> 8) & 0xFF,
+                              learn_info.tnl_info.vni & 0xFF));
         }
       } else {
         action->set_action_id(
@@ -469,7 +487,10 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
           param->set_param_id(
               GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_SET_GENEVE_UNDERLAY_V6,
                          ACTION_PARAM_TUNNEL_ID));
-          param->set_value(EncodeByteValue(1, learn_info.tnl_info.vni));
+          param->set_value(
+              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
+                              (learn_info.tnl_info.vni >> 8) & 0xFF,
+                              learn_info.tnl_info.vni & 0xFF));
         }
       }
     }
@@ -696,7 +717,9 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
   match->set_field_id(
       GetMatchFieldId(p4info, VXLAN_ENCAP_MOD_TABLE,
                       VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -738,7 +761,9 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(
           GetParamId(p4info, ACTION_VXLAN_ENCAP, ACTION_VXLAN_ENCAP_PARAM_VNI));
-      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                       (tunnel_info.vni >> 8) & 0xFF,
+                                       tunnel_info.vni & 0xFF));
     }
   }
 }
@@ -754,7 +779,9 @@ void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
   match->set_field_id(
       GetMatchFieldId(p4info, GENEVE_ENCAP_MOD_TABLE,
                       GENEVE_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -794,7 +821,9 @@ void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_GENEVE_ENCAP,
                                      ACTION_GENEVE_ENCAP_PARAM_VNI));
-      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                       (tunnel_info.vni >> 8) & 0xFF,
+                                       tunnel_info.vni & 0xFF));
     }
   }
 }
@@ -830,7 +859,9 @@ void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
   match->set_field_id(
       GetMatchFieldId(p4info, VXLAN_ENCAP_V6_MOD_TABLE,
                       VXLAN_ENCAP_V6_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -870,7 +901,9 @@ void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
                                      ACTION_VXLAN_ENCAP_V6_PARAM_VNI));
-      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                       (tunnel_info.vni >> 8) & 0xFF,
+                                       tunnel_info.vni & 0xFF));
     }
   }
 }
@@ -885,7 +918,9 @@ void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
   match->set_field_id(
       GetMatchFieldId(p4info, GENEVE_ENCAP_V6_MOD_TABLE,
                       GENEVE_ENCAP_V6_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -925,7 +960,9 @@ void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_GENEVE_ENCAP_V6,
                                      ACTION_GENEVE_ENCAP_V6_PARAM_VNI));
-      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                       (tunnel_info.vni >> 8) & 0xFF,
+                                       tunnel_info.vni & 0xFF));
     }
   }
 }
@@ -954,7 +991,9 @@ void PrepareVxlanEncapAndVlanPopTableEntry(
   match->set_field_id(GetMatchFieldId(
       p4info, VXLAN_ENCAP_VLAN_POP_MOD_TABLE,
       VXLAN_ENCAP_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -998,7 +1037,9 @@ void PrepareVxlanEncapAndVlanPopTableEntry(
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_VLAN_POP,
                                      ACTION_VXLAN_ENCAP_VLAN_POP_PARAM_VNI));
-      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                       (tunnel_info.vni >> 8) & 0xFF,
+                                       tunnel_info.vni & 0xFF));
     }
   }
 }
@@ -1013,7 +1054,9 @@ void PrepareGeneveEncapAndVlanPopTableEntry(
   match->set_field_id(GetMatchFieldId(
       p4info, GENEVE_ENCAP_VLAN_POP_MOD_TABLE,
       GENEVE_ENCAP_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1057,7 +1100,9 @@ void PrepareGeneveEncapAndVlanPopTableEntry(
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_GENEVE_ENCAP_VLAN_POP,
                                      ACTION_GENEVE_ENCAP_VLAN_POP_PARAM_VNI));
-      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                       (tunnel_info.vni >> 8) & 0xFF,
+                                       tunnel_info.vni & 0xFF));
     }
   }
 }
@@ -1087,7 +1132,9 @@ void PrepareV6VxlanEncapAndVlanPopTableEntry(
   match->set_field_id(GetMatchFieldId(
       p4info, VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE,
       VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1131,7 +1178,9 @@ void PrepareV6VxlanEncapAndVlanPopTableEntry(
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6_VLAN_POP,
                                      ACTION_VXLAN_ENCAP_V6_VLAN_POP_PARAM_VNI));
-      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                       (tunnel_info.vni >> 8) & 0xFF,
+                                       tunnel_info.vni & 0xFF));
     }
   }
 }
@@ -1146,7 +1195,9 @@ void PrepareV6GeneveEncapAndVlanPopTableEntry(
   match->set_field_id(GetMatchFieldId(
       p4info, GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE,
       GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1191,7 +1242,9 @@ void PrepareV6GeneveEncapAndVlanPopTableEntry(
       param->set_param_id(
           GetParamId(p4info, ACTION_GENEVE_ENCAP_V6_VLAN_POP,
                      ACTION_GENEVE_ENCAP_V6_VLAN_POP_PARAM_VNI));
-      param->set_value(EncodeByteValue(1, tunnel_info.vni));
+      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                       (tunnel_info.vni >> 8) & 0xFF,
+                                       tunnel_info.vni & 0xFF));
     }
   }
 }
@@ -1222,7 +1275,9 @@ void PrepareRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
   match->set_field_id(
       GetMatchFieldId(p4info, RX_IPV4_TUNNEL_SOURCE_PORT_TABLE,
                       RX_IPV4_TUNNEL_SOURCE_PORT_TABLE_KEY_VNI));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   auto match1 = table_entry->add_match();
   match1->set_field_id(
@@ -1258,7 +1313,9 @@ void PrepareV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
   match->set_field_id(
       GetMatchFieldId(p4info, RX_IPV6_TUNNEL_SOURCE_PORT_TABLE,
                       RX_IPV6_TUNNEL_SOURCE_PORT_TABLE_KEY_VNI));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   auto match1 = table_entry->add_match();
   match1->set_field_id(
@@ -1304,7 +1361,10 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
   auto match2 = table_entry->add_match();
   match2->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
                                        IPV4_TUNNEL_TERM_TABLE_KEY_VNI));
-  match2->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match2->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+
 #else
 
   table_entry->set_table_id(GetTableId(p4info, IPV4_TUNNEL_TERM_TABLE));
@@ -1344,7 +1404,10 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         param->set_param_id(
             GetParamId(p4info, ACTION_SET_VXLAN_DECAP_OUTER_HDR_AND_PUSH_VLAN,
                        ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(1, tunnel_info.vni));
+        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                         (tunnel_info.vni >> 8) & 0xFF,
+                                         tunnel_info.vni & 0xFF));
+
       } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
         action->set_action_id(GetActionId(
             p4info, ACTION_SET_GENEVE_DECAP_OUTER_HDR_AND_PUSH_VLAN));
@@ -1352,7 +1415,10 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         param->set_param_id(
             GetParamId(p4info, ACTION_SET_GENEVE_DECAP_OUTER_HDR_AND_PUSH_VLAN,
                        ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(1, tunnel_info.vni));
+        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                         (tunnel_info.vni >> 8) & 0xFF,
+                                         tunnel_info.vni & 0xFF));
+
       } else {
         std::cout << "Unsupported tunnel type" << std::endl;
       }
@@ -1363,14 +1429,20 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         auto param = action->add_params();
         param->set_param_id(GetParamId(p4info, ACTION_SET_VXLAN_DECAP_OUTER_HDR,
                                        ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(1, tunnel_info.vni));
+        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                         (tunnel_info.vni >> 8) & 0xFF,
+                                         tunnel_info.vni & 0xFF));
+
       } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
         action->set_action_id(
             GetActionId(p4info, ACTION_SET_GENEVE_DECAP_OUTER_HDR));
         auto param = action->add_params();
         param->set_param_id(GetParamId(
             p4info, ACTION_SET_GENEVE_DECAP_OUTER_HDR, ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(1, tunnel_info.vni));
+        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                         (tunnel_info.vni >> 8) & 0xFF,
+                                         tunnel_info.vni & 0xFF));
+
       } else {
         std::cout << "Unsupported tunnel type" << std::endl;
       }
@@ -1400,7 +1472,9 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
   auto match2 = table_entry->add_match();
   match2->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
                                        IPV6_TUNNEL_TERM_TABLE_KEY_VNI));
-  match2->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match2->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1413,7 +1487,10 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         param->set_param_id(
             GetParamId(p4info, ACTION_SET_VXLAN_DECAP_OUTER_HDR_AND_PUSH_VLAN,
                        ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(1, tunnel_info.vni));
+        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                         (tunnel_info.vni >> 8) & 0xFF,
+                                         tunnel_info.vni & 0xFF));
+
       } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
         action->set_action_id(GetActionId(
             p4info, ACTION_SET_GENEVE_DECAP_OUTER_HDR_AND_PUSH_VLAN));
@@ -1421,7 +1498,10 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         param->set_param_id(
             GetParamId(p4info, ACTION_SET_GENEVE_DECAP_OUTER_HDR_AND_PUSH_VLAN,
                        ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(1, tunnel_info.vni));
+        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                         (tunnel_info.vni >> 8) & 0xFF,
+                                         tunnel_info.vni & 0xFF));
+
       } else {
         std::cout << "Unsupported tunnel type" << std::endl;
       }
@@ -1432,14 +1512,20 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         auto param = action->add_params();
         param->set_param_id(GetParamId(p4info, ACTION_SET_VXLAN_DECAP_OUTER_HDR,
                                        ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(1, tunnel_info.vni));
+        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                         (tunnel_info.vni >> 8) & 0xFF,
+                                         tunnel_info.vni & 0xFF));
+
       } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
         action->set_action_id(
             GetActionId(p4info, ACTION_SET_GENEVE_DECAP_OUTER_HDR));
         auto param = action->add_params();
         param->set_param_id(GetParamId(
             p4info, ACTION_SET_GENEVE_DECAP_OUTER_HDR, ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(1, tunnel_info.vni));
+        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                                         (tunnel_info.vni >> 8) & 0xFF,
+                                         tunnel_info.vni & 0xFF));
+
       } else {
         std::cout << "Unsupported tunnel type" << std::endl;
       }
@@ -1498,7 +1584,9 @@ void PrepareVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, VXLAN_DECAP_MOD_TABLE,
                                       VXLAN_DECAP_MOD_TABLE_KEY_MOD_BLOB_PTR));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1517,7 +1605,9 @@ void PrepareGeneveDecapModTableEntry(p4::v1::TableEntry* table_entry,
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, GENEVE_DECAP_MOD_TABLE,
                                       GENEVE_DECAP_MOD_TABLE_KEY_MOD_BLOB_PTR));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1552,7 +1642,9 @@ void PrepareVxlanDecapModAndVlanPushTableEntry(
   match->set_field_id(
       GetMatchFieldId(p4info, VXLAN_DECAP_AND_VLAN_PUSH_MOD_TABLE,
                       VXLAN_DECAP_AND_VLAN_PUSH_MOD_TABLE_KEY_MOD_BLOB_PTR));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1592,7 +1684,9 @@ void PrepareGeneveDecapModAndVlanPushTableEntry(
   match->set_field_id(
       GetMatchFieldId(p4info, GENEVE_DECAP_AND_VLAN_PUSH_MOD_TABLE,
                       GENEVE_DECAP_AND_VLAN_PUSH_MOD_TABLE_KEY_MOD_BLOB_PTR));
-  match->mutable_exact()->set_value(EncodeByteValue(1, tunnel_info.vni));
+  match->mutable_exact()->set_value(
+      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
+                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -1530,9 +1530,7 @@ void PrepareGeneveDecapModTableEntry(p4::v1::TableEntry* table_entry,
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, GENEVE_DECAP_MOD_TABLE,
                                       GENEVE_DECAP_MOD_TABLE_KEY_MOD_BLOB_PTR));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -115,6 +115,10 @@ static inline int32_t ValidIpAddr(uint32_t nw_addr) {
           nw_addr != 0xffffffff);
 }
 
+static inline std::string EncodeVniValue(uint16_t vni) {
+  return EncodeByteValue(3, 0, (vni >> 8) & 0xFF, vni & 0xFF);
+}
+
 #if defined(ES2K_TARGET)
 void PrepareFdbSmacTableEntry(p4::v1::TableEntry* table_entry,
                               const struct mac_learning_info& learn_info,
@@ -336,10 +340,7 @@ void PrepareFdbTableEntryforV4VxlanTunnel(
           param->set_param_id(GetParamId(
               p4info, L2_FWD_TX_TABLE_ACTION_POP_VLAN_SET_VXLAN_UNDERLAY_V4,
               ACTION_PARAM_TUNNEL_ID));
-          param->set_value(
-              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
-                              (learn_info.tnl_info.vni >> 8) & 0xFF,
-                              learn_info.tnl_info.vni & 0xFF));
+          param->set_value(EncodeVniValue(learn_info.tnl_info.vni));
         }
       } else {
         action->set_action_id(
@@ -349,10 +350,7 @@ void PrepareFdbTableEntryforV4VxlanTunnel(
           param->set_param_id(
               GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_SET_VXLAN_UNDERLAY_V4,
                          ACTION_PARAM_TUNNEL_ID));
-          param->set_value(
-              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
-                              (learn_info.tnl_info.vni >> 8) & 0xFF,
-                              learn_info.tnl_info.vni & 0xFF));
+          param->set_value(EncodeVniValue(learn_info.tnl_info.vni));
         }
       }
     } else if (learn_info.tnl_info.local_ip.family == AF_INET6 &&
@@ -375,10 +373,7 @@ void PrepareFdbTableEntryforV4VxlanTunnel(
           param->set_param_id(
               GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_SET_VXLAN_UNDERLAY_V6,
                          ACTION_PARAM_TUNNEL_ID));
-          param->set_value(
-              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
-                              (learn_info.tnl_info.vni >> 8) & 0xFF,
-                              learn_info.tnl_info.vni & 0xFF));
+          param->set_value(EncodeVniValue(learn_info.tnl_info.vni));
         }
       }
     }
@@ -445,10 +440,7 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
           param->set_param_id(GetParamId(
               p4info, L2_FWD_TX_TABLE_ACTION_POP_VLAN_SET_GENEVE_UNDERLAY_V4,
               ACTION_PARAM_TUNNEL_ID));
-          param->set_value(
-              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
-                              (learn_info.tnl_info.vni >> 8) & 0xFF,
-                              learn_info.tnl_info.vni & 0xFF));
+          param->set_value(EncodeVniValue(learn_info.tnl_info.vni));
         }
       } else {
         action->set_action_id(
@@ -458,10 +450,7 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
           param->set_param_id(
               GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_SET_GENEVE_UNDERLAY_V4,
                          ACTION_PARAM_TUNNEL_ID));
-          param->set_value(
-              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
-                              (learn_info.tnl_info.vni >> 8) & 0xFF,
-                              learn_info.tnl_info.vni & 0xFF));
+          param->set_value(EncodeVniValue(learn_info.tnl_info.vni));
         }
       }
     } else if (learn_info.tnl_info.local_ip.family == AF_INET6 &&
@@ -474,10 +463,7 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
           param->set_param_id(GetParamId(
               p4info, L2_FWD_TX_TABLE_ACTION_POP_VLAN_SET_GENEVE_UNDERLAY_V6,
               ACTION_PARAM_TUNNEL_ID));
-          param->set_value(
-              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
-                              (learn_info.tnl_info.vni >> 8) & 0xFF,
-                              learn_info.tnl_info.vni & 0xFF));
+          param->set_value(EncodeVniValue(learn_info.tnl_info.vni));
         }
       } else {
         action->set_action_id(
@@ -487,10 +473,7 @@ void PrepareFdbTableEntryforV4GeneveTunnel(
           param->set_param_id(
               GetParamId(p4info, L2_FWD_TX_TABLE_ACTION_SET_GENEVE_UNDERLAY_V6,
                          ACTION_PARAM_TUNNEL_ID));
-          param->set_value(
-              EncodeByteValue(3, (learn_info.tnl_info.vni >> 16) & 0xFF,
-                              (learn_info.tnl_info.vni >> 8) & 0xFF,
-                              learn_info.tnl_info.vni & 0xFF));
+          param->set_value(EncodeVniValue(learn_info.tnl_info.vni));
         }
       }
     }
@@ -717,9 +700,7 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
   match->set_field_id(
       GetMatchFieldId(p4info, VXLAN_ENCAP_MOD_TABLE,
                       VXLAN_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -761,9 +742,7 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(
           GetParamId(p4info, ACTION_VXLAN_ENCAP, ACTION_VXLAN_ENCAP_PARAM_VNI));
-      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                       (tunnel_info.vni >> 8) & 0xFF,
-                                       tunnel_info.vni & 0xFF));
+      param->set_value(EncodeVniValue(tunnel_info.vni));
     }
   }
 }
@@ -779,9 +758,7 @@ void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
   match->set_field_id(
       GetMatchFieldId(p4info, GENEVE_ENCAP_MOD_TABLE,
                       GENEVE_ENCAP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -821,9 +798,7 @@ void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_GENEVE_ENCAP,
                                      ACTION_GENEVE_ENCAP_PARAM_VNI));
-      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                       (tunnel_info.vni >> 8) & 0xFF,
-                                       tunnel_info.vni & 0xFF));
+      param->set_value(EncodeVniValue(tunnel_info.vni));
     }
   }
 }
@@ -859,9 +834,7 @@ void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
   match->set_field_id(
       GetMatchFieldId(p4info, VXLAN_ENCAP_V6_MOD_TABLE,
                       VXLAN_ENCAP_V6_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -901,9 +874,7 @@ void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
                                      ACTION_VXLAN_ENCAP_V6_PARAM_VNI));
-      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                       (tunnel_info.vni >> 8) & 0xFF,
-                                       tunnel_info.vni & 0xFF));
+      param->set_value(EncodeVniValue(tunnel_info.vni));
     }
   }
 }
@@ -918,9 +889,7 @@ void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
   match->set_field_id(
       GetMatchFieldId(p4info, GENEVE_ENCAP_V6_MOD_TABLE,
                       GENEVE_ENCAP_V6_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -960,9 +929,7 @@ void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_GENEVE_ENCAP_V6,
                                      ACTION_GENEVE_ENCAP_V6_PARAM_VNI));
-      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                       (tunnel_info.vni >> 8) & 0xFF,
-                                       tunnel_info.vni & 0xFF));
+      param->set_value(EncodeVniValue(tunnel_info.vni));
     }
   }
 }
@@ -991,9 +958,7 @@ void PrepareVxlanEncapAndVlanPopTableEntry(
   match->set_field_id(GetMatchFieldId(
       p4info, VXLAN_ENCAP_VLAN_POP_MOD_TABLE,
       VXLAN_ENCAP_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1037,9 +1002,7 @@ void PrepareVxlanEncapAndVlanPopTableEntry(
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_VLAN_POP,
                                      ACTION_VXLAN_ENCAP_VLAN_POP_PARAM_VNI));
-      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                       (tunnel_info.vni >> 8) & 0xFF,
-                                       tunnel_info.vni & 0xFF));
+      param->set_value(EncodeVniValue(tunnel_info.vni));
     }
   }
 }
@@ -1054,9 +1017,7 @@ void PrepareGeneveEncapAndVlanPopTableEntry(
   match->set_field_id(GetMatchFieldId(
       p4info, GENEVE_ENCAP_VLAN_POP_MOD_TABLE,
       GENEVE_ENCAP_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1100,9 +1061,7 @@ void PrepareGeneveEncapAndVlanPopTableEntry(
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_GENEVE_ENCAP_VLAN_POP,
                                      ACTION_GENEVE_ENCAP_VLAN_POP_PARAM_VNI));
-      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                       (tunnel_info.vni >> 8) & 0xFF,
-                                       tunnel_info.vni & 0xFF));
+      param->set_value(EncodeVniValue(tunnel_info.vni));
     }
   }
 }
@@ -1132,9 +1091,7 @@ void PrepareV6VxlanEncapAndVlanPopTableEntry(
   match->set_field_id(GetMatchFieldId(
       p4info, VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE,
       VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1178,9 +1135,7 @@ void PrepareV6VxlanEncapAndVlanPopTableEntry(
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6_VLAN_POP,
                                      ACTION_VXLAN_ENCAP_V6_VLAN_POP_PARAM_VNI));
-      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                       (tunnel_info.vni >> 8) & 0xFF,
-                                       tunnel_info.vni & 0xFF));
+      param->set_value(EncodeVniValue(tunnel_info.vni));
     }
   }
 }
@@ -1195,9 +1150,7 @@ void PrepareV6GeneveEncapAndVlanPopTableEntry(
   match->set_field_id(GetMatchFieldId(
       p4info, GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE,
       GENEVE_ENCAP_V6_VLAN_POP_MOD_TABLE_KEY_VENDORMETA_MOD_DATA_PTR));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1242,9 +1195,7 @@ void PrepareV6GeneveEncapAndVlanPopTableEntry(
       param->set_param_id(
           GetParamId(p4info, ACTION_GENEVE_ENCAP_V6_VLAN_POP,
                      ACTION_GENEVE_ENCAP_V6_VLAN_POP_PARAM_VNI));
-      param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                       (tunnel_info.vni >> 8) & 0xFF,
-                                       tunnel_info.vni & 0xFF));
+      param->set_value(EncodeVniValue(tunnel_info.vni));
     }
   }
 }
@@ -1275,9 +1226,7 @@ void PrepareRxTunnelTableEntry(p4::v1::TableEntry* table_entry,
   match->set_field_id(
       GetMatchFieldId(p4info, RX_IPV4_TUNNEL_SOURCE_PORT_TABLE,
                       RX_IPV4_TUNNEL_SOURCE_PORT_TABLE_KEY_VNI));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   auto match1 = table_entry->add_match();
   match1->set_field_id(
@@ -1313,9 +1262,7 @@ void PrepareV6RxTunnelTableEntry(p4::v1::TableEntry* table_entry,
   match->set_field_id(
       GetMatchFieldId(p4info, RX_IPV6_TUNNEL_SOURCE_PORT_TABLE,
                       RX_IPV6_TUNNEL_SOURCE_PORT_TABLE_KEY_VNI));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   auto match1 = table_entry->add_match();
   match1->set_field_id(
@@ -1361,9 +1308,7 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
   auto match2 = table_entry->add_match();
   match2->set_field_id(GetMatchFieldId(p4info, IPV4_TUNNEL_TERM_TABLE,
                                        IPV4_TUNNEL_TERM_TABLE_KEY_VNI));
-  match2->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match2->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
 #else
 
@@ -1404,9 +1349,7 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         param->set_param_id(
             GetParamId(p4info, ACTION_SET_VXLAN_DECAP_OUTER_HDR_AND_PUSH_VLAN,
                        ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                         (tunnel_info.vni >> 8) & 0xFF,
-                                         tunnel_info.vni & 0xFF));
+        param->set_value(EncodeVniValue(tunnel_info.vni));
 
       } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
         action->set_action_id(GetActionId(
@@ -1415,9 +1358,7 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         param->set_param_id(
             GetParamId(p4info, ACTION_SET_GENEVE_DECAP_OUTER_HDR_AND_PUSH_VLAN,
                        ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                         (tunnel_info.vni >> 8) & 0xFF,
-                                         tunnel_info.vni & 0xFF));
+        param->set_value(EncodeVniValue(tunnel_info.vni));
 
       } else {
         std::cout << "Unsupported tunnel type" << std::endl;
@@ -1429,9 +1370,7 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         auto param = action->add_params();
         param->set_param_id(GetParamId(p4info, ACTION_SET_VXLAN_DECAP_OUTER_HDR,
                                        ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                         (tunnel_info.vni >> 8) & 0xFF,
-                                         tunnel_info.vni & 0xFF));
+        param->set_value(EncodeVniValue(tunnel_info.vni));
 
       } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
         action->set_action_id(
@@ -1439,9 +1378,7 @@ void PrepareTunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         auto param = action->add_params();
         param->set_param_id(GetParamId(
             p4info, ACTION_SET_GENEVE_DECAP_OUTER_HDR, ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                         (tunnel_info.vni >> 8) & 0xFF,
-                                         tunnel_info.vni & 0xFF));
+        param->set_value(EncodeVniValue(tunnel_info.vni));
 
       } else {
         std::cout << "Unsupported tunnel type" << std::endl;
@@ -1472,9 +1409,7 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
   auto match2 = table_entry->add_match();
   match2->set_field_id(GetMatchFieldId(p4info, IPV6_TUNNEL_TERM_TABLE,
                                        IPV6_TUNNEL_TERM_TABLE_KEY_VNI));
-  match2->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match2->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1487,9 +1422,7 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         param->set_param_id(
             GetParamId(p4info, ACTION_SET_VXLAN_DECAP_OUTER_HDR_AND_PUSH_VLAN,
                        ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                         (tunnel_info.vni >> 8) & 0xFF,
-                                         tunnel_info.vni & 0xFF));
+        param->set_value(EncodeVniValue(tunnel_info.vni));
 
       } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
         action->set_action_id(GetActionId(
@@ -1498,9 +1431,7 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         param->set_param_id(
             GetParamId(p4info, ACTION_SET_GENEVE_DECAP_OUTER_HDR_AND_PUSH_VLAN,
                        ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                         (tunnel_info.vni >> 8) & 0xFF,
-                                         tunnel_info.vni & 0xFF));
+        param->set_value(EncodeVniValue(tunnel_info.vni));
 
       } else {
         std::cout << "Unsupported tunnel type" << std::endl;
@@ -1512,9 +1443,7 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         auto param = action->add_params();
         param->set_param_id(GetParamId(p4info, ACTION_SET_VXLAN_DECAP_OUTER_HDR,
                                        ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                         (tunnel_info.vni >> 8) & 0xFF,
-                                         tunnel_info.vni & 0xFF));
+        param->set_value(EncodeVniValue(tunnel_info.vni));
 
       } else if (tunnel_info.tunnel_type == OVS_TUNNEL_GENEVE) {
         action->set_action_id(
@@ -1522,9 +1451,7 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
         auto param = action->add_params();
         param->set_param_id(GetParamId(
             p4info, ACTION_SET_GENEVE_DECAP_OUTER_HDR, ACTION_PARAM_TUNNEL_ID));
-        param->set_value(EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                                         (tunnel_info.vni >> 8) & 0xFF,
-                                         tunnel_info.vni & 0xFF));
+        param->set_value(EncodeVniValue(tunnel_info.vni));
 
       } else {
         std::cout << "Unsupported tunnel type" << std::endl;
@@ -1584,9 +1511,7 @@ void PrepareVxlanDecapModTableEntry(p4::v1::TableEntry* table_entry,
   auto match = table_entry->add_match();
   match->set_field_id(GetMatchFieldId(p4info, VXLAN_DECAP_MOD_TABLE,
                                       VXLAN_DECAP_MOD_TABLE_KEY_MOD_BLOB_PTR));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1642,9 +1567,7 @@ void PrepareVxlanDecapModAndVlanPushTableEntry(
   match->set_field_id(
       GetMatchFieldId(p4info, VXLAN_DECAP_AND_VLAN_PUSH_MOD_TABLE,
                       VXLAN_DECAP_AND_VLAN_PUSH_MOD_TABLE_KEY_MOD_BLOB_PTR));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();
@@ -1684,9 +1607,7 @@ void PrepareGeneveDecapModAndVlanPushTableEntry(
   match->set_field_id(
       GetMatchFieldId(p4info, GENEVE_DECAP_AND_VLAN_PUSH_MOD_TABLE,
                       GENEVE_DECAP_AND_VLAN_PUSH_MOD_TABLE_KEY_MOD_BLOB_PTR));
-  match->mutable_exact()->set_value(
-      EncodeByteValue(3, (tunnel_info.vni >> 16) & 0xFF,
-                      (tunnel_info.vni >> 8) & 0xFF, tunnel_info.vni & 0xFF));
+  match->mutable_exact()->set_value(EncodeVniValue(tunnel_info.vni));
 
   if (insert_entry) {
     auto table_action = table_entry->mutable_action();


### PR DESCRIPTION
A bug was reported that VNI values were not programmed correctly and only 1 byte was copied over. This fixes the reported issue for ES2K target