### PR TITLE
Modify prepare_l2_to_tunnel_test to support --dump_json flag

### DIFF
--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -38,8 +38,13 @@ if(ES2K_TARGET)
 #-----------------------------------------------------------------------
 add_executable(prepare_l2_to_tunnel_test
   prepare_l2_to_tunnel_test.cc
+  test_main.cc
 )
 
 set_test_properties(prepare_l2_to_tunnel_test)
+
+target_link_libraries(prepare_l2_to_tunnel_test PUBLIC
+  absl::flags_parse
+)
 
 endif(ES2K_TARGET)

--- a/ovs-p4rt/sidecar/testing/prepare_l2_to_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/testing/prepare_l2_to_tunnel_test.cc
@@ -46,7 +46,7 @@ class PrepareL2ToTunnelTest : public ::testing::Test {
                            const struct mac_learning_info& learn_info,
                            bool insert_entry) {
     if (dump_json_) {
-//    CaptureMacLearningInfo(func_name, learn_info, insert_entry);
+      // CaptureMacLearningInfo(func_name, learn_info, insert_entry);
     }
   }
 

--- a/ovs-p4rt/sidecar/testing/prepare_l2_to_tunnel_test.cc
+++ b/ovs-p4rt/sidecar/testing/prepare_l2_to_tunnel_test.cc
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <string>
 
+#include "absl/flags/flag.h"
 #include "google/protobuf/util/json_util.h"
 #include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
@@ -15,8 +16,7 @@
 #include "p4info_file_path.h"
 #include "stratum/lib/utils.h"
 
-// Whether to dump TableEntry in JSON.
-#undef DUMP_JSON
+ABSL_FLAG(bool, dump_json, false, "Dump test input and output in JSON.");
 
 namespace ovs_p4rt {
 
@@ -40,14 +40,29 @@ class PrepareL2ToTunnelTest : public ::testing::Test {
     }
   }
 
-  void DumpMessageAsJson(const google::protobuf::Message& message) {
-    JsonPrintOptions options;
-    options.add_whitespace = true;
-    options.preserve_proto_field_names = true;
-    std::string output;
-    ASSERT_TRUE(MessageToJsonString(message, &output, options).ok());
-    std::cout << output << std::endl;
+  PrepareL2ToTunnelTest() { dump_json_ = absl::GetFlag(FLAGS_dump_json); }
+
+  void DumpMacLearningInfo(const char* func_name,
+                           const struct mac_learning_info& learn_info,
+                           bool insert_entry) {
+    if (dump_json_) {
+//    CaptureMacLearningInfo(func_name, learn_info, insert_entry);
+    }
   }
+
+  void DumpTableEntry(const ::p4::v1::TableEntry& table_entry) {
+    if (dump_json_) {
+      JsonPrintOptions options;
+      options.add_whitespace = true;
+      options.preserve_proto_field_names = true;
+      std::string output;
+      ASSERT_TRUE(MessageToJsonString(table_entry, &output, options).ok());
+      std::cout << output << std::endl;
+    }
+  }
+
+ private:
+  bool dump_json_;
 };
 
 uint32_t DecodeWordValue(const std::string string_value) {
@@ -78,14 +93,14 @@ TEST_F(PrepareL2ToTunnelTest, GetL2ToTunnelV4TableEntry) {
   // Arrange
   struct mac_learning_info fdb_info = {0};
   get_v4_fdb_info(fdb_info);
+  const bool insert_entry = true;
 
   // Act
+  DumpMacLearningInfo("GetL2ToTunnelV4TableEntry", fdb_info, insert_entry);
   ::p4::v1::TableEntry table_entry;
   DiagDetail detail;
-  PrepareL2ToTunnelV4(&table_entry, fdb_info, p4info, true, detail);
-#ifdef DUMP_JSON
-  DumpMessageAsJson(table_entry);
-#endif
+  PrepareL2ToTunnelV4(&table_entry, fdb_info, p4info, insert_entry, detail);
+  DumpTableEntry(table_entry);
 
   // Assert
   ASSERT_EQ(table_entry.table_id(), kTableIdV4);
@@ -147,14 +162,14 @@ TEST_F(PrepareL2ToTunnelTest, GetL2ToTunnelV6TableEntry) {
   // Arrange
   struct mac_learning_info fdb_info = {0};
   get_v6_fdb_info(fdb_info);
+  const bool insert_entry = true;
 
   // Act
+  DumpMacLearningInfo("GetL2ToTunnelV6TableEntry", fdb_info, insert_entry);
   ::p4::v1::TableEntry table_entry;
   DiagDetail detail;
-  PrepareL2ToTunnelV6(&table_entry, fdb_info, p4info, true, detail);
-#ifdef DUMP_JSON
-  DumpMessageAsJson(table_entry);
-#endif
+  PrepareL2ToTunnelV6(&table_entry, fdb_info, p4info, insert_entry, detail);
+  DumpTableEntry(table_entry);
 
   // Assert
   ASSERT_EQ(table_entry.table_id(), kTableIdV6);

--- a/ovs-p4rt/sidecar/testing/set_test_properties.cmake
+++ b/ovs-p4rt/sidecar/testing/set_test_properties.cmake
@@ -17,7 +17,6 @@ function(set_test_properties TARGET)
 
   target_link_libraries(${TARGET} PUBLIC
     GTest::gtest
-    GTest::gtest_main
     ovsp4rt
     p4runtime_proto
     stratum_utils

--- a/ovs-p4rt/sidecar/testing/test_main.cc
+++ b/ovs-p4rt/sidecar/testing/test_main.cc
@@ -1,0 +1,17 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "absl/flags/parse.h"
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv) {
+  // As part of initialization, this function parses the command line,
+  // removing any arguments that are specific to googletest.
+  testing::InitGoogleTest(&argc, argv);
+
+  // Parses the remaining command-line arguments for Abseil flags
+  // defined by the test program.
+  absl::ParseCommandLine(argc, argv);
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- Implemented `test_main.cc`, which allows googletest programs to define Abseil flags.
- Modified `prepare_l2_to_tunnel_test` to dump output under control of the `--dump_json` command-line flag.