### PR TITLE
Document anomalous src_port param values

### DIFF
--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -729,8 +729,8 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
       // set the src_port param to (dst_port * 2).
       uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, ((src_port >> 8) & 0xff),
-                                       (src_port & 0xff)));
+      param->set_value(
+          EncodeByteValue(2, ((src_port >> 8) & 0xff), (src_port & 0xff)));
     }
 #endif
     {
@@ -790,8 +790,8 @@ void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
       // set the src_port param to (dst_port * 2).
       uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, ((src_port >> 8) & 0xff),
-                                       (src_port & 0xff)));
+      param->set_value(
+          EncodeByteValue(2, ((src_port >> 8) & 0xff), (src_port & 0xff)));
     }
     {
       auto param = action->add_params();
@@ -870,8 +870,8 @@ void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
       // set the src_port param to (dst_port * 2).
       uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, (src_port >> 8) & 0xff,
-                                       src_port & 0xff));
+      param->set_value(
+          EncodeByteValue(2, (src_port >> 8) & 0xff, src_port & 0xff));
     }
     {
       auto param = action->add_params();
@@ -929,8 +929,8 @@ void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
       // set the src_port param to (dst_port * 2).
       uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, (src_port >> 8) & 0xff,
-                                       src_port & 0xff));
+      param->set_value(
+          EncodeByteValue(2, (src_port >> 8) & 0xff, src_port & 0xff));
     }
     {
       auto param = action->add_params();
@@ -1005,8 +1005,8 @@ void PrepareVxlanEncapAndVlanPopTableEntry(
       // set the src_port param to (dst_port * 2).
       uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, ((src_port >> 8) & 0xff),
-                                       (src_port & 0xff)));
+      param->set_value(
+          EncodeByteValue(2, ((src_port >> 8) & 0xff), (src_port & 0xff)));
     }
     {
       auto param = action->add_params();
@@ -1068,8 +1068,8 @@ void PrepareGeneveEncapAndVlanPopTableEntry(
       // set the src_port param to (dst_port * 2).
       uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, ((src_port >> 8) & 0xff),
-                                       (src_port & 0xff)));
+      param->set_value(
+          EncodeByteValue(2, ((src_port >> 8) & 0xff), (src_port & 0xff)));
     }
     {
       auto param = action->add_params();
@@ -1146,8 +1146,8 @@ void PrepareV6VxlanEncapAndVlanPopTableEntry(
       // set the src_port param to (dst_port * 2).
       uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, (src_port >> 8) & 0xff,
-                                       src_port & 0xff));
+      param->set_value(
+          EncodeByteValue(2, (src_port >> 8) & 0xff, src_port & 0xff));
     }
     {
       auto param = action->add_params();
@@ -1209,8 +1209,8 @@ void PrepareV6GeneveEncapAndVlanPopTableEntry(
       // set the src_port param to (dst_port * 2).
       uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, (src_port >> 8) & 0xff,
-                                       src_port & 0xff));
+      param->set_value(
+          EncodeByteValue(2, (src_port >> 8) & 0xff, src_port & 0xff));
     }
     {
       auto param = action->add_params();

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -724,13 +724,13 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP,
                                      ACTION_VXLAN_ENCAP_PARAM_SRC_PORT));
 
-      // The src_port param is an arbitrary value that has nothing to do
-      // with what was specified in the tunnel_info structure. This is a
-      // workaround for a bug in the Linux Networking P4 program.
-      uint16_t src_port = htons(tunnel_info.dst_port);
+      // To work around a bug in the Linux Networking P4 program, we
+      // ignore the src_port value specified by the caller and instead
+      // set the src_port param to (dst_port * 2).
+      uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, (((src_port * 2) >> 8) & 0xff),
-                                       ((src_port * 2) & 0xff)));
+      param->set_value(EncodeByteValue(2, ((src_port >> 8) & 0xff),
+                                       (src_port & 0xff)));
     }
 #endif
     {
@@ -785,13 +785,13 @@ void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
       param->set_param_id(GetParamId(p4info, ACTION_GENEVE_ENCAP,
                                      ACTION_GENEVE_ENCAP_PARAM_SRC_PORT));
 
-      // The src_port param is an arbitrary value that has nothing to do
-      // with what was specified in the tunnel_info structure. This is a
-      // workaround for a bug in the Linux Networking P4 program.
-      uint16_t src_port = htons(tunnel_info.dst_port);
+      // To work around a bug in the Linux Networking P4 program, we
+      // ignore the src_port value specified by the caller and instead
+      // set the src_port param to (dst_port * 2).
+      uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, (((src_port * 2) >> 8) & 0xff),
-                                       ((src_port * 2) & 0xff)));
+      param->set_value(EncodeByteValue(2, ((src_port >> 8) & 0xff),
+                                       (src_port & 0xff)));
     }
     {
       auto param = action->add_params();
@@ -865,13 +865,13 @@ void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
                                      ACTION_VXLAN_ENCAP_V6_PARAM_SRC_PORT));
 
-      // The src_port param is an arbitrary value that has nothing to do
-      // with what was specified in the tunnel_info structure. This is a
-      // workaround for a bug in the Linux Networking P4 program.
-      uint16_t src_port = htons(tunnel_info.dst_port);
+      // To work around a bug in the Linux Networking P4 program, we
+      // ignore the src_port value specified by the caller and instead
+      // set the src_port param to (dst_port * 2).
+      uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, ((src_port * 2) >> 8) & 0xff,
-                                       (src_port * 2) & 0xff));
+      param->set_value(EncodeByteValue(2, (src_port >> 8) & 0xff,
+                                       src_port & 0xff));
     }
     {
       auto param = action->add_params();
@@ -924,13 +924,13 @@ void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
       param->set_param_id(GetParamId(p4info, ACTION_GENEVE_ENCAP_V6,
                                      ACTION_GENEVE_ENCAP_V6_PARAM_SRC_PORT));
 
-      // The src_port param is an arbitrary value that has nothing to do
-      // with what was specified in the tunnel_info structure. This is a
-      // workaround for a bug in the Linux Networking P4 program.
-      uint16_t src_port = htons(tunnel_info.dst_port);
+      // To work around a bug in the Linux Networking P4 program, we
+      // ignore the src_port value specified by the caller and instead
+      // set the src_port param to (dst_port * 2).
+      uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, ((src_port * 2) >> 8) & 0xff,
-                                       (src_port * 2) & 0xff));
+      param->set_value(EncodeByteValue(2, (src_port >> 8) & 0xff,
+                                       src_port & 0xff));
     }
     {
       auto param = action->add_params();
@@ -1000,13 +1000,13 @@ void PrepareVxlanEncapAndVlanPopTableEntry(
           GetParamId(p4info, ACTION_VXLAN_ENCAP_VLAN_POP,
                      ACTION_VXLAN_ENCAP_VLAN_POP_PARAM_SRC_PORT));
 
-      // The src_port param is an arbitrary value that has nothing to do
-      // with what was specified in the tunnel_info structure. This is a
-      // workaround for a bug in the Linux Networking P4 program.
-      uint16_t src_port = htons(tunnel_info.dst_port);
+      // To work around a bug in the Linux Networking P4 program, we
+      // ignore the src_port value specified by the caller and instead
+      // set the src_port param to (dst_port * 2).
+      uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, (((src_port * 2) >> 8) & 0xff),
-                                       ((src_port * 2) & 0xff)));
+      param->set_value(EncodeByteValue(2, ((src_port >> 8) & 0xff),
+                                       (src_port & 0xff)));
     }
     {
       auto param = action->add_params();
@@ -1063,13 +1063,13 @@ void PrepareGeneveEncapAndVlanPopTableEntry(
           GetParamId(p4info, ACTION_GENEVE_ENCAP_VLAN_POP,
                      ACTION_GENEVE_ENCAP_VLAN_POP_PARAM_SRC_PORT));
 
-      // The src_port param is an arbitrary value that has nothing to do
-      // with what was specified in the tunnel_info structure. This is a
-      // workaround for a bug in the Linux Networking P4 program.
-      uint16_t src_port = htons(tunnel_info.dst_port);
+      // To work around a bug in the Linux Networking P4 program, we
+      // ignore the src_port value specified by the caller and instead
+      // set the src_port param to (dst_port * 2).
+      uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, (((src_port * 2) >> 8) & 0xff),
-                                       ((src_port * 2) & 0xff)));
+      param->set_value(EncodeByteValue(2, ((src_port >> 8) & 0xff),
+                                       (src_port & 0xff)));
     }
     {
       auto param = action->add_params();
@@ -1141,13 +1141,13 @@ void PrepareV6VxlanEncapAndVlanPopTableEntry(
           GetParamId(p4info, ACTION_VXLAN_ENCAP_V6_VLAN_POP,
                      ACTION_VXLAN_ENCAP_V6_VLAN_POP_PARAM_SRC_PORT));
 
-      // The src_port param is an arbitrary value that has nothing to do
-      // with what was specified in the tunnel_info structure. This is a
-      // workaround for a bug in the Linux Networking P4 program.
-      uint16_t src_port = htons(tunnel_info.dst_port);
+      // To work around a bug in the Linux Networking P4 program, we
+      // ignore the src_port value specified by the caller and instead
+      // set the src_port param to (dst_port * 2).
+      uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, ((src_port * 2) >> 8) & 0xff,
-                                       (src_port * 2) & 0xff));
+      param->set_value(EncodeByteValue(2, (src_port >> 8) & 0xff,
+                                       src_port & 0xff));
     }
     {
       auto param = action->add_params();
@@ -1204,13 +1204,13 @@ void PrepareV6GeneveEncapAndVlanPopTableEntry(
           GetParamId(p4info, ACTION_GENEVE_ENCAP_V6_VLAN_POP,
                      ACTION_GENEVE_ENCAP_V6_VLAN_POP_PARAM_SRC_PORT));
 
-      // The src_port param is an arbitrary value that has nothing to do
-      // with what was specified in the tunnel_info structure. This is a
-      // workaround for a bug in the Linux Networking P4 program.
-      uint16_t src_port = htons(tunnel_info.dst_port);
+      // To work around a bug in the Linux Networking P4 program, we
+      // ignore the src_port value specified by the caller and instead
+      // set the src_port param to (dst_port * 2).
+      uint16_t src_port = htons(tunnel_info.dst_port) * 2;
 
-      param->set_value(EncodeByteValue(2, ((src_port * 2) >> 8) & 0xff,
-                                       (src_port * 2) & 0xff));
+      param->set_value(EncodeByteValue(2, (src_port >> 8) & 0xff,
+                                       src_port & 0xff));
     }
     {
       auto param = action->add_params();

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -723,10 +723,13 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP,
                                      ACTION_VXLAN_ENCAP_PARAM_SRC_PORT));
-      uint16_t dst_port = htons(tunnel_info.dst_port);
+      // The src_port param is an arbitrary value that has nothing to do
+      // with what was specified in the tunnel_info structure. This is a
+      // workaround for a bug in the Linux Networking P4 program.
+      uint16_t src_port = htons(tunnel_info.dst_port);
 
-      param->set_value(EncodeByteValue(2, (((dst_port * 2) >> 8) & 0xff),
-                                       ((dst_port * 2) & 0xff)));
+      param->set_value(EncodeByteValue(2, (((src_port * 2) >> 8) & 0xff),
+                                       ((src_port * 2) & 0xff)));
     }
 #endif
     {
@@ -780,10 +783,13 @@ void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_GENEVE_ENCAP,
                                      ACTION_GENEVE_ENCAP_PARAM_SRC_PORT));
-      uint16_t dst_port = htons(tunnel_info.dst_port);
+      // The src_port param is an arbitrary value that has nothing to do
+      // with what was specified in the tunnel_info structure. This is a
+      // workaround for a bug in the Linux Networking P4 program.
+      uint16_t src_port = htons(tunnel_info.dst_port);
 
-      param->set_value(EncodeByteValue(2, (((dst_port * 2) >> 8) & 0xff),
-                                       ((dst_port * 2) & 0xff)));
+      param->set_value(EncodeByteValue(2, (((src_port * 2) >> 8) & 0xff),
+                                       ((src_port * 2) & 0xff)));
     }
     {
       auto param = action->add_params();
@@ -856,10 +862,13 @@ void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
                                      ACTION_VXLAN_ENCAP_V6_PARAM_SRC_PORT));
-      uint16_t dst_port = htons(tunnel_info.dst_port);
+      // The src_port param is an arbitrary value that has nothing to do
+      // with what was specified in the tunnel_info structure. This is a
+      // workaround for a bug in the Linux Networking P4 program.
+      uint16_t src_port = htons(tunnel_info.dst_port);
 
-      param->set_value(EncodeByteValue(2, ((dst_port * 2) >> 8) & 0xff,
-                                       (dst_port * 2) & 0xff));
+      param->set_value(EncodeByteValue(2, ((src_port * 2) >> 8) & 0xff,
+                                       (src_port * 2) & 0xff));
     }
     {
       auto param = action->add_params();
@@ -911,10 +920,13 @@ void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_GENEVE_ENCAP_V6,
                                      ACTION_GENEVE_ENCAP_V6_PARAM_SRC_PORT));
-      uint16_t dst_port = htons(tunnel_info.dst_port);
+      // The src_port param is an arbitrary value that has nothing to do
+      // with what was specified in the tunnel_info structure. This is a
+      // workaround for a bug in the Linux Networking P4 program.
+      uint16_t src_port = htons(tunnel_info.dst_port);
 
-      param->set_value(EncodeByteValue(2, ((dst_port * 2) >> 8) & 0xff,
-                                       (dst_port * 2) & 0xff));
+      param->set_value(EncodeByteValue(2, ((src_port * 2) >> 8) & 0xff,
+                                       (src_port * 2) & 0xff));
     }
     {
       auto param = action->add_params();
@@ -983,10 +995,13 @@ void PrepareVxlanEncapAndVlanPopTableEntry(
       param->set_param_id(
           GetParamId(p4info, ACTION_VXLAN_ENCAP_VLAN_POP,
                      ACTION_VXLAN_ENCAP_VLAN_POP_PARAM_SRC_PORT));
-      uint16_t dst_port = htons(tunnel_info.dst_port);
+      // The src_port param is an arbitrary value that has nothing to do
+      // with what was specified in the tunnel_info structure. This is a
+      // workaround for a bug in the Linux Networking P4 program.
+      uint16_t src_port = htons(tunnel_info.dst_port);
 
-      param->set_value(EncodeByteValue(2, (((dst_port * 2) >> 8) & 0xff),
-                                       ((dst_port * 2) & 0xff)));
+      param->set_value(EncodeByteValue(2, (((src_port * 2) >> 8) & 0xff),
+                                       ((src_port * 2) & 0xff)));
     }
     {
       auto param = action->add_params();
@@ -1042,10 +1057,13 @@ void PrepareGeneveEncapAndVlanPopTableEntry(
       param->set_param_id(
           GetParamId(p4info, ACTION_GENEVE_ENCAP_VLAN_POP,
                      ACTION_GENEVE_ENCAP_VLAN_POP_PARAM_SRC_PORT));
-      uint16_t dst_port = htons(tunnel_info.dst_port);
+      // The src_port param is an arbitrary value that has nothing to do
+      // with what was specified in the tunnel_info structure. This is a
+      // workaround for a bug in the Linux Networking P4 program.
+      uint16_t src_port = htons(tunnel_info.dst_port);
 
-      param->set_value(EncodeByteValue(2, (((dst_port * 2) >> 8) & 0xff),
-                                       ((dst_port * 2) & 0xff)));
+      param->set_value(EncodeByteValue(2, (((src_port * 2) >> 8) & 0xff),
+                                       ((src_port * 2) & 0xff)));
     }
     {
       auto param = action->add_params();
@@ -1116,10 +1134,13 @@ void PrepareV6VxlanEncapAndVlanPopTableEntry(
       param->set_param_id(
           GetParamId(p4info, ACTION_VXLAN_ENCAP_V6_VLAN_POP,
                      ACTION_VXLAN_ENCAP_V6_VLAN_POP_PARAM_SRC_PORT));
-      uint16_t dst_port = htons(tunnel_info.dst_port);
+      // The src_port param is an arbitrary value that has nothing to do
+      // with what was specified in the tunnel_info structure. This is a
+      // workaround for a bug in the Linux Networking P4 program.
+      uint16_t src_port = htons(tunnel_info.dst_port);
 
-      param->set_value(EncodeByteValue(2, ((dst_port * 2) >> 8) & 0xff,
-                                       (dst_port * 2) & 0xff));
+      param->set_value(EncodeByteValue(2, ((src_port * 2) >> 8) & 0xff,
+                                       (src_port * 2) & 0xff));
     }
     {
       auto param = action->add_params();
@@ -1175,10 +1196,13 @@ void PrepareV6GeneveEncapAndVlanPopTableEntry(
       param->set_param_id(
           GetParamId(p4info, ACTION_GENEVE_ENCAP_V6_VLAN_POP,
                      ACTION_GENEVE_ENCAP_V6_VLAN_POP_PARAM_SRC_PORT));
-      uint16_t dst_port = htons(tunnel_info.dst_port);
+      // The src_port param is an arbitrary value that has nothing to do
+      // with what was specified in the tunnel_info structure. This is a
+      // workaround for a bug in the Linux Networking P4 program.
+      uint16_t src_port = htons(tunnel_info.dst_port);
 
-      param->set_value(EncodeByteValue(2, ((dst_port * 2) >> 8) & 0xff,
-                                       (dst_port * 2) & 0xff));
+      param->set_value(EncodeByteValue(2, ((src_port * 2) >> 8) & 0xff,
+                                       (src_port * 2) & 0xff));
     }
     {
       auto param = action->add_params();

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -723,6 +723,7 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP,
                                      ACTION_VXLAN_ENCAP_PARAM_SRC_PORT));
+
       // The src_port param is an arbitrary value that has nothing to do
       // with what was specified in the tunnel_info structure. This is a
       // workaround for a bug in the Linux Networking P4 program.
@@ -783,6 +784,7 @@ void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_GENEVE_ENCAP,
                                      ACTION_GENEVE_ENCAP_PARAM_SRC_PORT));
+
       // The src_port param is an arbitrary value that has nothing to do
       // with what was specified in the tunnel_info structure. This is a
       // workaround for a bug in the Linux Networking P4 program.
@@ -862,6 +864,7 @@ void PrepareV6VxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_VXLAN_ENCAP_V6,
                                      ACTION_VXLAN_ENCAP_V6_PARAM_SRC_PORT));
+
       // The src_port param is an arbitrary value that has nothing to do
       // with what was specified in the tunnel_info structure. This is a
       // workaround for a bug in the Linux Networking P4 program.
@@ -920,6 +923,7 @@ void PrepareV6GeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
       auto param = action->add_params();
       param->set_param_id(GetParamId(p4info, ACTION_GENEVE_ENCAP_V6,
                                      ACTION_GENEVE_ENCAP_V6_PARAM_SRC_PORT));
+
       // The src_port param is an arbitrary value that has nothing to do
       // with what was specified in the tunnel_info structure. This is a
       // workaround for a bug in the Linux Networking P4 program.
@@ -995,6 +999,7 @@ void PrepareVxlanEncapAndVlanPopTableEntry(
       param->set_param_id(
           GetParamId(p4info, ACTION_VXLAN_ENCAP_VLAN_POP,
                      ACTION_VXLAN_ENCAP_VLAN_POP_PARAM_SRC_PORT));
+
       // The src_port param is an arbitrary value that has nothing to do
       // with what was specified in the tunnel_info structure. This is a
       // workaround for a bug in the Linux Networking P4 program.
@@ -1057,6 +1062,7 @@ void PrepareGeneveEncapAndVlanPopTableEntry(
       param->set_param_id(
           GetParamId(p4info, ACTION_GENEVE_ENCAP_VLAN_POP,
                      ACTION_GENEVE_ENCAP_VLAN_POP_PARAM_SRC_PORT));
+
       // The src_port param is an arbitrary value that has nothing to do
       // with what was specified in the tunnel_info structure. This is a
       // workaround for a bug in the Linux Networking P4 program.
@@ -1134,6 +1140,7 @@ void PrepareV6VxlanEncapAndVlanPopTableEntry(
       param->set_param_id(
           GetParamId(p4info, ACTION_VXLAN_ENCAP_V6_VLAN_POP,
                      ACTION_VXLAN_ENCAP_V6_VLAN_POP_PARAM_SRC_PORT));
+
       // The src_port param is an arbitrary value that has nothing to do
       // with what was specified in the tunnel_info structure. This is a
       // workaround for a bug in the Linux Networking P4 program.
@@ -1196,6 +1203,7 @@ void PrepareV6GeneveEncapAndVlanPopTableEntry(
       param->set_param_id(
           GetParamId(p4info, ACTION_GENEVE_ENCAP_V6_VLAN_POP,
                      ACTION_GENEVE_ENCAP_V6_VLAN_POP_PARAM_SRC_PORT));
+
       // The src_port param is an arbitrary value that has nothing to do
       // with what was specified in the tunnel_info structure. This is a
       // workaround for a bug in the Linux Networking P4 program.


### PR DESCRIPTION
- Added an explanatory comment to each instance where the `src_port` param is set to the value of the `dst_port` input.

- Replaced the `dst_port` temporary variable with a `src_port` variable.

- Adjusted the value of `src_port` when initializing it, rather than in the call to `EncodeBytes()`.