### PR TITLE
Extract ipv4_tunnel_test_defs.h and ipv6_tunnel_test_defs.h

### DIFF
--- a/ovs-p4rt/sidecar/testing/ipv4_tunnel_test_defs.h
+++ b/ovs-p4rt/sidecar/testing/ipv4_tunnel_test_defs.h
@@ -1,0 +1,40 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IPV4_TUNNEL_TEST_DEFS_H_
+#define IPV4_TUNNEL_TEST_DEFS_H_
+
+#include <arpa/inet.h>
+
+#include "gtest/gtest.h"
+#include "ovsp4rt/ovs-p4rt.h"
+
+namespace ovs_p4rt {
+
+constexpr char IPV4_SRC_ADDR[] = "10.0.0.1";
+constexpr char IPV4_DST_ADDR[] = "192.168.17.5";
+constexpr int IPV4_PREFIX_LEN = 24;
+
+constexpr uint16_t SRC_PORT = 4;
+constexpr uint16_t DST_PORT = 1984;
+constexpr uint16_t VNI = 0x101;
+
+//----------------------------------------------------------------------
+
+void InitV4TunnelInfo(tunnel_info& info) {
+  EXPECT_EQ(inet_pton(AF_INET, IPV4_SRC_ADDR, &info.local_ip.ip.v4addr.s_addr),
+            1);
+  info.local_ip.prefix_len = IPV4_PREFIX_LEN;
+
+  EXPECT_EQ(inet_pton(AF_INET, IPV4_DST_ADDR, &info.remote_ip.ip.v4addr.s_addr),
+            1);
+  info.remote_ip.prefix_len = IPV4_PREFIX_LEN;
+
+  info.src_port = htons(SRC_PORT);
+  info.dst_port = htons(DST_PORT);
+  info.vni = htons(VNI);
+}
+
+}  // namespace ovs_p4rt
+
+#endif  // IPV4_TUNNEL_TEST_DEFS_H_

--- a/ovs-p4rt/sidecar/testing/ipv6_tunnel_test_defs.h
+++ b/ovs-p4rt/sidecar/testing/ipv6_tunnel_test_defs.h
@@ -1,0 +1,44 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IPV6_TUNNEL_TEST_DEFS_H_
+#define IPV6_TUNNEL_TEST_DEFS_H_
+
+#include <arpa/inet.h>
+
+#include "gtest/gtest.h"
+#include "ovsp4rt/ovs-p4rt.h"
+
+namespace ovs_p4rt {
+
+constexpr char IPV6_SRC_ADDR[] = "fe80::215:5dff:fefa";
+constexpr char IPV6_DST_ADDR[] = "fe80::215:192.168.17.5";
+constexpr int IPV6_PREFIX_LEN = 64;
+
+constexpr uint16_t SRC_PORT = 42;
+constexpr uint16_t DST_PORT = 1066;
+constexpr uint16_t VNI = 0x202;
+
+//----------------------------------------------------------------------
+
+void InitV6TunnelInfo(tunnel_info& info) {
+  EXPECT_EQ(inet_pton(AF_INET6, IPV6_SRC_ADDR,
+                      &info.local_ip.ip.v6addr.__in6_u.__u6_addr32),
+            1)
+      << "Error converting " << IPV6_SRC_ADDR;
+  info.local_ip.prefix_len = IPV6_PREFIX_LEN;
+
+  EXPECT_EQ(inet_pton(AF_INET6, IPV6_DST_ADDR,
+                      &info.remote_ip.ip.v6addr.__in6_u.__u6_addr32),
+            1)
+      << "Error converting " << IPV6_DST_ADDR;
+  info.remote_ip.prefix_len = IPV6_PREFIX_LEN;
+
+  info.src_port = htons(SRC_PORT);
+  info.dst_port = htons(DST_PORT);
+  info.vni = htons(VNI);
+}
+
+}  // namespace ovs_p4rt
+
+#endif  // IPV6_TUNNEL_TEST_DEFS_H_


### PR DESCRIPTION
Extracted common definitions to `ipv4_tunnel_test_defs.h` and `ipv6_tunnel_test_defs.h` to reduce repetition.