### PR TITLE
Set ovsp4rt label on ovsp4rt unit tests

### DIFF
--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -15,6 +15,10 @@ include(set_test_properties.cmake)
 
 option(TEST_COVERAGE OFF "Measure unit test code coverage")
 
+# Set the "ovsp4rt" label on all tests in this directory.
+# We can use this with ctest to filter the tests to be run.
+set_property(DIRECTORY PROPERTY LABELS ovsp4rt)
+
 #-----------------------------------------------------------------------
 # encode_host_port_value_test
 #-----------------------------------------------------------------------


### PR DESCRIPTION
- The label can be used with ctest to determine the tests to be run or excluded.

```text
dfoster@dgfoster-mobl1:~/work/ovsp4rt$ (cd build; ctest -L ovsp4rt)
Test project /home/dfoster/work/ovsp4rt/build
    Start 6: encode_host_port_value_test
1/3 Test #6: encode_host_port_value_test ......   Passed    0.03 sec
    Start 7: prepare_l2_to_tunnel_test
2/3 Test #7: prepare_l2_to_tunnel_test ........   Passed    0.03 sec
    Start 8: geneve_encap_table_entry_test
3/3 Test #8: geneve_encap_table_entry_test ....   Passed    0.03 sec

100% tests passed, 0 tests failed out of 3

Label Time Summary:
ovsp4rt    =   0.09 sec*proc (3 tests)

Total Test time (real) =   0.09 sec
```