### PR TITLE
  Implemented vxlan_encap_v6_vlan_pop_test

### DIFF
--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -61,4 +61,21 @@ target_link_libraries(geneve_encap_table_entry_test PUBLIC
   absl::flags_parse
 )
 
+#-----------------------------------------------------------------------
+# vxlan_encap_v6_vlan_pop_test
+#-----------------------------------------------------------------------
+add_executable(vxlan_encap_v6_vlan_pop_test
+  vxlan_encap_v6_vlan_pop_test.cc
+  ipv6_tunnel_test_defs.h
+  p4info_text.h
+  table_entry_test.h
+  test_main.cc
+)
+
+set_test_properties(vxlan_encap_v6_vlan_pop_test)
+
+target_link_libraries(vxlan_encap_v6_vlan_pop_test PUBLIC
+  absl::flags_parse
+)
+
 endif(ES2K_TARGET)

--- a/ovs-p4rt/sidecar/testing/ipv4_tunnel_test_defs.h
+++ b/ovs-p4rt/sidecar/testing/ipv4_tunnel_test_defs.h
@@ -1,0 +1,40 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IPV4_TUNNEL_TEST_DEFS_H_
+#define IPV4_TUNNEL_TEST_DEFS_H_
+
+#include <arpa/inet.h>
+
+#include "gtest/gtest.h"
+#include "ovsp4rt/ovs-p4rt.h"
+
+namespace ovs_p4rt {
+
+constexpr char IPV4_SRC_ADDR[] = "10.0.0.1";
+constexpr char IPV4_DST_ADDR[] = "192.168.17.5";
+constexpr int IPV4_PREFIX_LEN = 24;
+
+constexpr uint16_t SRC_PORT = 4;
+constexpr uint16_t DST_PORT = 1984;
+constexpr uint16_t VNI = 0x101;
+
+//----------------------------------------------------------------------
+
+void InitV4TunnelInfo(tunnel_info& info) {
+  EXPECT_EQ(inet_pton(AF_INET, IPV4_SRC_ADDR, &info.local_ip.ip.v4addr.s_addr),
+            1);
+  info.local_ip.prefix_len = IPV4_PREFIX_LEN;
+
+  EXPECT_EQ(inet_pton(AF_INET, IPV4_DST_ADDR, &info.remote_ip.ip.v4addr.s_addr),
+            1);
+  info.remote_ip.prefix_len = IPV4_PREFIX_LEN;
+
+  info.src_port = htons(SRC_PORT);
+  info.dst_port = htons(DST_PORT);
+  info.vni = htons(VNI);
+}
+
+}  // namespace ovs_p4rt
+
+#endif  // IPV4_TUNNEL_TEST_DEFS_H_

--- a/ovs-p4rt/sidecar/testing/ipv6_tunnel_test_defs.h
+++ b/ovs-p4rt/sidecar/testing/ipv6_tunnel_test_defs.h
@@ -1,0 +1,44 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IPV6_TUNNEL_TEST_DEFS_H_
+#define IPV6_TUNNEL_TEST_DEFS_H_
+
+#include <arpa/inet.h>
+
+#include "gtest/gtest.h"
+#include "ovsp4rt/ovs-p4rt.h"
+
+namespace ovs_p4rt {
+
+constexpr char IPV6_SRC_ADDR[] = "fe80::215:5dff:fefa";
+constexpr char IPV6_DST_ADDR[] = "fe80::215:192.168.17.5";
+constexpr int IPV6_PREFIX_LEN = 64;
+
+constexpr uint16_t SRC_PORT = 42;
+constexpr uint16_t DST_PORT = 1066;
+constexpr uint16_t VNI = 0x202;
+
+//----------------------------------------------------------------------
+
+void InitV6TunnelInfo(tunnel_info& info) {
+  EXPECT_EQ(inet_pton(AF_INET6, IPV6_SRC_ADDR,
+                      &info.local_ip.ip.v6addr.__in6_u.__u6_addr32),
+            1)
+      << "Error converting " << IPV6_SRC_ADDR;
+  info.local_ip.prefix_len = IPV6_PREFIX_LEN;
+
+  EXPECT_EQ(inet_pton(AF_INET6, IPV6_DST_ADDR,
+                      &info.remote_ip.ip.v6addr.__in6_u.__u6_addr32),
+            1)
+      << "Error converting " << IPV6_DST_ADDR;
+  info.remote_ip.prefix_len = IPV6_PREFIX_LEN;
+
+  info.src_port = htons(SRC_PORT);
+  info.dst_port = htons(DST_PORT);
+  info.vni = htons(VNI);
+}
+
+}  // namespace ovs_p4rt
+
+#endif  // IPV6_TUNNEL_TEST_DEFS_H_

--- a/ovs-p4rt/sidecar/testing/table_entry_test.h
+++ b/ovs-p4rt/sidecar/testing/table_entry_test.h
@@ -1,0 +1,63 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TABLE_ENTRY_TEST_H_
+#define TABLE_ENTRY_TEST_H_
+
+#include <stdint.h>
+
+#include <iostream>
+#include <string>
+
+#include "absl/flags/flag.h"
+#include "google/protobuf/util/json_util.h"
+#include "gtest/gtest.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4info_text.h"
+#include "stratum/lib/utils.h"
+
+ABSL_FLAG(bool, dump_json, false, "Dump output object in JSON");
+ABSL_FLAG(bool, check_src_port, false, "Verify src_port field");
+
+namespace ovs_p4rt {
+
+using google::protobuf::util::JsonPrintOptions;
+using google::protobuf::util::MessageToJsonString;
+using stratum::ParseProtoFromString;
+
+static ::p4::config::v1::P4Info p4info;
+
+class TableEntryTest : public ::testing::Test {
+ protected:
+  TableEntryTest() { dump_json_ = absl::GetFlag(FLAGS_dump_json); };
+  static void SetUpTestSuite() {
+    ::util::Status status = ParseProtoFromString(P4INFO_TEXT, &p4info);
+    if (!status.ok()) {
+      std::exit(EXIT_FAILURE);
+    }
+  }
+
+  void DumpTableEntry(const ::p4::v1::TableEntry& table_entry) {
+    if (dump_json_) {
+      JsonPrintOptions options;
+      options.add_whitespace = true;
+      options.preserve_proto_field_names = true;
+      std::string output;
+      ASSERT_TRUE(MessageToJsonString(table_entry, &output, options).ok());
+      std::cout << output << std::endl;
+    }
+  }
+  bool dump_json_;
+};
+
+uint32_t DecodeWordValue(const std::string& string_value) {
+  uint32_t word_value = 0;
+  for (int i = 0; i < string_value.size(); i++) {
+    word_value = (word_value << 8) | (string_value[i] & 0xff);
+  }
+  return word_value;
+}
+
+}  // namespace ovs_p4rt
+
+#endif  // TABLE_ENTRY_TEST_H_

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
@@ -19,7 +19,7 @@ namespace ovs_p4rt {
 // PrepareV6VxlanEncapAndVlanPopTableEntry()
 //----------------------------------------------------------------------
 
-//constexpr uint32_t VXLAN_ENCAP_V6_MOD_TABLE_ID = 46225003U;
+// constexpr uint32_t VXLAN_ENCAP_V6_MOD_TABLE_ID = 46225003U;
 constexpr uint32_t VXLAN_ENCAP_V6_ACTION_ID = 30345128U;
 
 enum {

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
@@ -1,0 +1,89 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include <string>
+
+#include "absl/flags/flag.h"
+#include "absl/types/optional.h"
+#include "gtest/gtest.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "ovsp4rt_private.h"
+#include "testing/ipv6_tunnel_test_defs.h"
+#include "testing/table_entry_test.h"
+
+namespace ovs_p4rt {
+
+//----------------------------------------------------------------------
+// PrepareV6VxlanEncapAndVlanPopTableEntry()
+//----------------------------------------------------------------------
+
+//constexpr uint32_t VXLAN_ENCAP_V6_MOD_TABLE_ID = 46225003U;
+constexpr uint32_t VXLAN_ENCAP_V6_ACTION_ID = 30345128U;
+
+enum {
+  SRC_PORT_PARAM_ID = 7,
+  DST_PORT_PARAM_ID = 8,
+  VNI_PARAM_ID = 9,
+};
+
+//----------------------------------------------------------------------
+
+TEST_F(TableEntryTest, vxlan_encap_v6_vlan_pop_params_are_correct) {
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+  constexpr bool insert_entry = true;
+
+  // Arrange
+  InitV6TunnelInfo(tunnel_info);
+
+  // Act
+  PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,
+                                insert_entry);
+  DumpTableEntry(table_entry);
+
+  // Assert
+  ASSERT_TRUE(table_entry.has_action());
+
+  auto table_action = table_entry.action();
+  auto action = table_action.action();
+  ASSERT_EQ(action.action_id(), VXLAN_ENCAP_V6_ACTION_ID);
+
+  auto params = action.params();
+  int num_params = action.params_size();
+
+  absl::optional<uint16_t> src_port;
+  absl::optional<uint16_t> dst_port;
+  absl::optional<uint16_t> vni;
+
+  for (int i = 0; i < num_params; ++i) {
+    auto param = params[i];
+    int param_id = param.param_id();
+    auto param_value = param.value();
+    if (param_id == SRC_PORT_PARAM_ID) {
+      src_port = DecodeWordValue(param_value) & 0xffff;
+    } else if (param_id == DST_PORT_PARAM_ID) {
+      dst_port = DecodeWordValue(param_value) & 0xffff;
+    } else if (param_id == VNI_PARAM_ID) {
+      vni = DecodeWordValue(param_value) & 0xffff;
+    }
+  }
+
+  if (absl::GetFlag(FLAGS_check_src_port)) {
+    // The src_port field contains an arbitrary value that has nothing
+    // to do with what was specified in the tunnel_info structure.
+    // It is a workaround for a long-standing bug in the Linux
+    // Networking P4 program.
+    ASSERT_TRUE(src_port.has_value());
+    EXPECT_EQ(src_port.value(), SRC_PORT);
+  }
+
+  ASSERT_TRUE(dst_port.has_value());
+  EXPECT_EQ(dst_port.value(), DST_PORT);
+
+  ASSERT_TRUE(vni.has_value());
+  EXPECT_EQ(vni.value(), VNI);
+}
+
+}  // namespace ovs_p4rt

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
@@ -19,8 +19,8 @@ namespace ovs_p4rt {
 // PrepareV6VxlanEncapAndVlanPopTableEntry()
 //----------------------------------------------------------------------
 
-// constexpr uint32_t VXLAN_ENCAP_V6_MOD_TABLE_ID = 46225003U;
-constexpr uint32_t VXLAN_ENCAP_V6_ACTION_ID = 30345128U;
+// constexpr uint32_t VXLAN_ENCAP_V6_VLAN_POP_MOD_TABLE_ID = 34318005U;
+constexpr uint32_t VXLAN_ENCAP_V6_VLAN_POP_ACTION_ID = 28284062U;
 
 enum {
   SRC_PORT_PARAM_ID = 7,
@@ -39,8 +39,8 @@ TEST_F(TableEntryTest, vxlan_encap_v6_vlan_pop_params_are_correct) {
   InitV6TunnelInfo(tunnel_info);
 
   // Act
-  PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                insert_entry);
+  PrepareV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                          insert_entry);
   DumpTableEntry(table_entry);
 
   // Assert
@@ -48,7 +48,7 @@ TEST_F(TableEntryTest, vxlan_encap_v6_vlan_pop_params_are_correct) {
 
   auto table_action = table_entry.action();
   auto action = table_action.action();
-  ASSERT_EQ(action.action_id(), VXLAN_ENCAP_V6_ACTION_ID);
+  ASSERT_EQ(action.action_id(), VXLAN_ENCAP_V6_VLAN_POP_ACTION_ID);
 
   auto params = action.params();
   int num_params = action.params_size();


### PR DESCRIPTION
- Unit test for `PrepareV6VxlanEncapAndVlanPopTableEntry()`.

> [!NOTE]
> The header files are from PRs https://github.com/ipdk-io/networking-recipe/pull/548 and https://github.com/ipdk-io/networking-recipe/pull/549. They can be ignored in this PR.