### PR TITLE
[ovsp4rt] Implement unit test base classes

### DIFF
--- a/ovs-p4rt/sidecar/testing/ipv4_tunnel_test.h
+++ b/ovs-p4rt/sidecar/testing/ipv4_tunnel_test.h
@@ -1,0 +1,46 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IPV4_TUNNEL_TEST_H_
+#define IPV4_TUNNEL_TEST_H_
+
+#include <arpa/inet.h>
+
+#include "gtest/gtest.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "testing/table_entry_test.h"
+
+namespace ovs_p4rt {
+
+constexpr char IPV4_SRC_ADDR[] = "10.0.0.1";
+constexpr char IPV4_DST_ADDR[] = "192.168.17.5";
+constexpr int IPV4_PREFIX_LEN = 24;
+
+constexpr uint16_t SRC_PORT = 4;
+constexpr uint16_t DST_PORT = 1984;
+constexpr uint16_t VNI = 0x101;
+
+class Ipv4TunnelTest : public TableEntryTest {
+ protected:
+  Ipv4TunnelTest() {}
+
+  void InitV4TunnelInfo(tunnel_info& info) {
+    EXPECT_EQ(
+        inet_pton(AF_INET, IPV4_SRC_ADDR, &info.local_ip.ip.v4addr.s_addr), 1)
+        << "Error converting " << IPV4_SRC_ADDR;
+    info.local_ip.prefix_len = IPV4_PREFIX_LEN;
+
+    EXPECT_EQ(
+        inet_pton(AF_INET, IPV4_DST_ADDR, &info.remote_ip.ip.v4addr.s_addr), 1)
+        << "Error converting " << IPV4_DST_ADDR;
+    info.remote_ip.prefix_len = IPV4_PREFIX_LEN;
+
+    info.src_port = htons(SRC_PORT);
+    info.dst_port = htons(DST_PORT);
+    info.vni = htons(VNI);
+  };
+};
+
+}  // namespace ovs_p4rt
+
+#endif  // IPV4_TUNNEL_TEST_H_

--- a/ovs-p4rt/sidecar/testing/ipv6_tunnel_test.h
+++ b/ovs-p4rt/sidecar/testing/ipv6_tunnel_test.h
@@ -1,0 +1,48 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IPV6_TUNNEL_TEST_H_
+#define IPV6_TUNNEL_TEST_H_
+
+#include <arpa/inet.h>
+
+#include "gtest/gtest.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "testing/table_entry_test.h"
+
+namespace ovs_p4rt {
+
+constexpr char IPV6_SRC_ADDR[] = "fe80::215:5dff:fefa";
+constexpr char IPV6_DST_ADDR[] = "fe80::215:192.168.17.5";
+constexpr int IPV6_PREFIX_LEN = 64;
+
+constexpr uint16_t SRC_PORT = 42;
+constexpr uint16_t DST_PORT = 1066;
+constexpr uint16_t VNI = 0x202;
+
+class Ipv6TunnelTest : public TableEntryTest {
+ protected:
+  Ipv6TunnelTest() {}
+
+  void InitV6TunnelInfo(tunnel_info& info) {
+    EXPECT_EQ(inet_pton(AF_INET6, IPV6_SRC_ADDR,
+                        &info.local_ip.ip.v6addr.__in6_u.__u6_addr32),
+              1)
+        << "Error converting " << IPV6_SRC_ADDR;
+    info.local_ip.prefix_len = IPV6_PREFIX_LEN;
+
+    EXPECT_EQ(inet_pton(AF_INET6, IPV6_DST_ADDR,
+                        &info.remote_ip.ip.v6addr.__in6_u.__u6_addr32),
+              1)
+        << "Error converting " << IPV6_DST_ADDR;
+    info.remote_ip.prefix_len = IPV6_PREFIX_LEN;
+
+    info.src_port = htons(SRC_PORT);
+    info.dst_port = htons(DST_PORT);
+    info.vni = htons(VNI);
+  };
+};
+
+}  // namespace ovs_p4rt
+
+#endif  // IPV6_TUNNEL_TEST_H_

--- a/ovs-p4rt/sidecar/testing/table_entry_test.h
+++ b/ovs-p4rt/sidecar/testing/table_entry_test.h
@@ -1,0 +1,70 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TABLE_ENTRY_TEST_H_
+#define TABLE_ENTRY_TEST_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <iostream>
+#include <string>
+
+#include "absl/flags/flag.h"
+#include "google/protobuf/util/json_util.h"
+#include "gtest/gtest.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "p4info_text.h"
+#include "stratum/lib/utils.h"
+
+ABSL_FLAG(bool, dump_json, false, "Dump output object in JSON");
+ABSL_FLAG(bool, check_src_port, false, "Verify src_port field");
+
+namespace ovs_p4rt {
+
+using google::protobuf::util::JsonPrintOptions;
+using google::protobuf::util::MessageToJsonString;
+using stratum::ParseProtoFromString;
+
+static ::p4::config::v1::P4Info p4info;
+
+class TableEntryTest : public ::testing::Test {
+ protected:
+  TableEntryTest() {
+    check_src_port_ = absl::GetFlag(FLAGS_check_src_port);
+    dump_json_ = absl::GetFlag(FLAGS_dump_json);
+  };
+
+  static void SetUpTestSuite() {
+    ::util::Status status = ParseProtoFromString(P4INFO_TEXT, &p4info);
+    if (!status.ok()) {
+      std::exit(EXIT_FAILURE);
+    }
+  }
+
+  static uint32_t DecodeWordValue(const std::string& string_value) {
+    uint32_t word_value = 0;
+    for (int i = 0; i < string_value.size(); i++) {
+      word_value = (word_value << 8) | (string_value[i] & 0xff);
+    }
+    return word_value;
+  }
+
+  void DumpTableEntry(const ::p4::v1::TableEntry& table_entry) {
+    if (dump_json_) {
+      JsonPrintOptions options;
+      options.add_whitespace = true;
+      options.preserve_proto_field_names = true;
+      std::string output;
+      ASSERT_TRUE(MessageToJsonString(table_entry, &output, options).ok());
+      std::cout << output << std::endl;
+    }
+  }
+
+  bool check_src_port_;
+  bool dump_json_;
+};
+
+}  // namespace ovs_p4rt
+
+#endif  // TABLE_ENTRY_TEST_H_


### PR DESCRIPTION
- Implemented `TableEntryTest`, `Ipv4TunnelTest`, and `Ipv6TunnelTest` classes, to simplify ovsp4rt unit tests.