### PR TITLE
[ovsp4rt] Define ipv4_test_utils and ipv6_test_utils

### DIFF
--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -20,6 +20,34 @@ option(TEST_COVERAGE OFF "Measure unit test code coverage")
 set_property(DIRECTORY PROPERTY LABELS ovsp4rt)
 
 #-----------------------------------------------------------------------
+# ipv4_test_utils
+#-----------------------------------------------------------------------
+add_library(ipv4_test_utils STATIC
+  ipv4_tunnel_test.h
+  p4info_text.h
+  table_entry_test.h
+  test_main.cc
+)
+
+target_link_libraries(ipv4_test_utils PUBLIC
+  absl::flags_parse
+)
+
+#-----------------------------------------------------------------------
+# ipv6_test_utils
+#-----------------------------------------------------------------------
+add_library(ipv6_test_utils STATIC
+  ipv6_tunnel_test.h
+  p4info_text.h
+  table_entry_test.h
+  test_main.cc
+)
+
+target_link_libraries(ipv6_test_utils PUBLIC
+  absl::flags_parse
+)
+
+#-----------------------------------------------------------------------
 # encode_host_port_value_test
 #-----------------------------------------------------------------------
 add_executable(encode_host_port_value_test
@@ -55,14 +83,12 @@ target_link_libraries(prepare_l2_to_tunnel_test PUBLIC
 #-----------------------------------------------------------------------
 add_executable(geneve_encap_table_entry_test
   geneve_encap_table_entry_test.cc
-  p4info_text.h
-  test_main.cc
 )
 
 set_test_properties(geneve_encap_table_entry_test)
 
 target_link_libraries(geneve_encap_table_entry_test PUBLIC
-  absl::flags_parse
+  ipv4_test_utils
 )
 
 endif(ES2K_TARGET)


### PR DESCRIPTION
- Created static libraries to consolidate shared dependencies.