### PR TITLE
[ovsp4rt] Revise IPv4 and IPv6 test values

### DIFF
--- a/ovs-p4rt/sidecar/testing/ipv4_tunnel_test.h
+++ b/ovs-p4rt/sidecar/testing/ipv4_tunnel_test.h
@@ -18,7 +18,7 @@ constexpr int IPV4_PREFIX_LEN = 24;
 
 constexpr uint16_t SRC_PORT = 0x1066;
 constexpr uint16_t DST_PORT = 0x1984;
-constexpr uint16_t VNI = 0x2525;
+constexpr uint16_t VNI = 0x1776;
 
 class Ipv4TunnelTest : public TableEntryTest {
  protected:

--- a/ovs-p4rt/sidecar/testing/ipv4_tunnel_test.h
+++ b/ovs-p4rt/sidecar/testing/ipv4_tunnel_test.h
@@ -12,13 +12,13 @@
 
 namespace ovs_p4rt {
 
-constexpr char IPV4_SRC_ADDR[] = "10.0.0.1";
+constexpr char IPV4_SRC_ADDR[] = "10.20.30.40";
 constexpr char IPV4_DST_ADDR[] = "192.168.17.5";
 constexpr int IPV4_PREFIX_LEN = 24;
 
-constexpr uint16_t SRC_PORT = 4;
-constexpr uint16_t DST_PORT = 1984;
-constexpr uint16_t VNI = 0x101;
+constexpr uint16_t SRC_PORT = 0x1066;
+constexpr uint16_t DST_PORT = 0x1984;
+constexpr uint16_t VNI = 0x2525;
 
 class Ipv4TunnelTest : public TableEntryTest {
  protected:

--- a/ovs-p4rt/sidecar/testing/ipv6_tunnel_test.h
+++ b/ovs-p4rt/sidecar/testing/ipv6_tunnel_test.h
@@ -16,9 +16,9 @@ constexpr char IPV6_SRC_ADDR[] = "fe80::215:5dff:fefa";
 constexpr char IPV6_DST_ADDR[] = "fe80::215:192.168.17.5";
 constexpr int IPV6_PREFIX_LEN = 64;
 
-constexpr uint16_t SRC_PORT = 42;
-constexpr uint16_t DST_PORT = 1066;
-constexpr uint16_t VNI = 0x202;
+constexpr uint16_t SRC_PORT = 0x1984;
+constexpr uint16_t DST_PORT = 0x1066;
+constexpr uint16_t VNI = 0x1776;
 
 class Ipv6TunnelTest : public TableEntryTest {
  protected:


### PR DESCRIPTION
- Updated IPV4_SRC_ADDR so each octet is unique.

- Updated SRC_PORT, DST_PORT, and VNI so all values are 16 bits and each octet is unique.

This should help detect byte swap errors.