### PR TITLE
Define ovsp4rt-unit-tests build target

### DIFF
--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -61,6 +61,8 @@ target_link_libraries(encode_host_port_value_test PUBLIC
   GTest::gtest_main
 )
 
+list(APPEND unit_test_names encode_host_port_value_test)
+
 if(ES2K_TARGET)
 
 #-----------------------------------------------------------------------
@@ -76,6 +78,8 @@ target_link_libraries(geneve_encap_v4_table_entry_test PUBLIC
   ipv4_test_utils
 )
 
+list(APPEND unit_test_names geneve_encap_v4_table_entry_test)
+
 #-----------------------------------------------------------------------
 # geneve_encap_v6_table_entry_test (ES2K)
 #-----------------------------------------------------------------------
@@ -89,6 +93,8 @@ target_link_libraries(geneve_encap_v6_table_entry_test PUBLIC
   ipv6_test_utils
 )
 
+list(APPEND unit_test_names geneve_encap_v6_table_entry_test)
+
 #-----------------------------------------------------------------------
 # geneve_encap_v4_vlan_pop_test (ES2K)
 #-----------------------------------------------------------------------
@@ -101,6 +107,8 @@ set_test_properties(geneve_encap_v4_vlan_pop_test)
 target_link_libraries(geneve_encap_v4_vlan_pop_test PUBLIC
   ipv4_test_utils
 )
+
+list(APPEND unit_test_names geneve_encap_v4_vlan_pop_test)
 
 #-----------------------------------------------------------------------
 # prepare_l2_to_tunnel_test (ES2K)
@@ -117,6 +125,8 @@ target_link_libraries(prepare_l2_to_tunnel_test PUBLIC
   absl::flags_parse
 )
 
+list(APPEND unit_test_names prepare_l2_to_tunnel_test)
+
 endif(ES2K_TARGET)
 
 #-----------------------------------------------------------------------
@@ -131,6 +141,8 @@ set_test_properties(vxlan_encap_v4_table_entry_test)
 target_link_libraries(vxlan_encap_v4_table_entry_test PUBLIC
   ipv4_test_utils
 )
+
+list(APPEND unit_test_names vxlan_encap_v4_table_entry_test)
 
 if(ES2K_TARGET)
 
@@ -147,6 +159,8 @@ target_link_libraries(vxlan_encap_v6_table_entry_test PUBLIC
   ipv6_test_utils
 )
 
+list(APPEND unit_test_names vxlan_encap_v6_table_entry_test)
+
 #-----------------------------------------------------------------------
 # vxlan_encap_v4_vlan_pop_test (ES2K)
 #-----------------------------------------------------------------------
@@ -159,6 +173,8 @@ set_test_properties(vxlan_encap_v4_vlan_pop_test)
 target_link_libraries(vxlan_encap_v4_vlan_pop_test PUBLIC
   ipv4_test_utils
 )
+
+list(APPEND unit_test_names vxlan_encap_v4_vlan_pop_test)
 
 #-----------------------------------------------------------------------
 # vxlan_encap_v6_vlan_pop_test (ES2K)
@@ -173,4 +189,13 @@ target_link_libraries(vxlan_encap_v6_vlan_pop_test PUBLIC
   ipv6_test_utils
 )
 
+list(APPEND unit_test_names vxlan_encap_v6_vlan_pop_test)
+
 endif(ES2K_TARGET)
+
+#-----------------------------------------------------------------------
+# ovsp4rt-unit-tests
+#-----------------------------------------------------------------------
+add_custom_target(ovsp4rt-unit-tests
+  DEPENDS ${unit_test_names}
+)

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_entry_test.cc
@@ -64,6 +64,7 @@ TEST_F(Ipv4TunnelTest, vxlan_encap_v4_params_are_correct) {
     }
   }
 
+#if defined(ES2K_TARGET)
   ASSERT_TRUE(src_port.has_value());
 
   if (check_src_port_) {
@@ -72,6 +73,7 @@ TEST_F(Ipv4TunnelTest, vxlan_encap_v4_params_are_correct) {
     // set the src_port param to (dst_port * 2).
     EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
   }
+#endif
 
   ASSERT_TRUE(dst_port.has_value());
   EXPECT_EQ(dst_port.value(), DST_PORT);


### PR DESCRIPTION
- Implemented an `ovs-ovsp4rt-tests` target to build all the ovsp4rt unit tests.

- Modified `vxlan_encap_v4_table_entry_test` to check the src_port only when built for the ES2K target. The DPDK version of `PrepareVxlanEncapTableEntry()` does not encode this parameter.