### PR TITLE
[ovsp4rt] Fix byte-order bug in EncodeVniValue()

### DIFF
--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -48,6 +48,10 @@ std::string EncodeByteValue(int arg_count...) {
   return byte_value;
 }
 
+static inline std::string EncodeVniValue(uint16_t vni) {
+  return EncodeByteValue(3, 0, (vni >> 8) & 0xFF, vni & 0xFF);
+}
+
 std::string CanonicalizeIp(const uint32_t ipv4addr) {
   return EncodeByteValue(4, (ipv4addr & 0xff), ((ipv4addr >> 8) & 0xff),
                          ((ipv4addr >> 16) & 0xff), ((ipv4addr >> 24) & 0xff));
@@ -113,10 +117,6 @@ int GetMatchFieldId(const ::p4::config::v1::P4Info& p4info,
 static inline int32_t ValidIpAddr(uint32_t nw_addr) {
   return (nw_addr && nw_addr != INADDR_ANY && nw_addr != INADDR_LOOPBACK &&
           nw_addr != 0xffffffff);
-}
-
-static inline std::string EncodeVniValue(uint16_t vni) {
-  return EncodeByteValue(3, 0, vni & 0xFF, (vni >> 8) & 0xFF);
 }
 
 #if defined(ES2K_TARGET)

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_entry_test.cc
@@ -57,11 +57,11 @@ TEST_F(Ipv4TunnelTest, geneve_encap_v4_params_are_correct) {
     auto param_value = param.value();
 
     if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodeWordValue(param_value) & 0xffff;
+      src_port = DecodePortValue(param_value);
     } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodeWordValue(param_value) & 0xffff;
+      dst_port = DecodePortValue(param_value);
     } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeWordValue(param_value) & 0xffff;
+      vni = DecodeVniValue(param_value);
     }
   }
 

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
@@ -58,11 +58,11 @@ TEST_F(Ipv4TunnelTest, geneve_encap_v4_vlan_pop_params_are_correct) {
     auto param_value = param.value();
 
     if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodeWordValue(param_value) & 0xffff;
+      src_port = DecodePortValue(param_value);
     } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodeWordValue(param_value) & 0xffff;
+      dst_port = DecodePortValue(param_value);
     } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeWordValue(param_value) & 0xffff;
+      vni = DecodeVniValue(param_value);
     }
   }
 

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
@@ -58,11 +58,11 @@ TEST_F(Ipv6TunnelTest, geneve_encap_v6_params_are_correct) {
     auto param_value = param.value();
 
     if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodeWordValue(param_value) & 0xffff;
+      src_port = DecodePortValue(param_value);
     } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodeWordValue(param_value) & 0xffff;
+      dst_port = DecodePortValue(param_value);
     } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeWordValue(param_value) & 0xffff;
+      vni = DecodeVniValue(param_value);
     }
   }
 

--- a/ovs-p4rt/sidecar/testing/ipv4_tunnel_test.h
+++ b/ovs-p4rt/sidecar/testing/ipv4_tunnel_test.h
@@ -17,7 +17,7 @@ constexpr char IPV4_DST_ADDR[] = "192.168.17.5";
 constexpr int IPV4_PREFIX_LEN = 24;
 
 constexpr uint16_t SRC_PORT = 0x1066;
-constexpr uint16_t DST_PORT = 0x1984;
+constexpr uint16_t DST_PORT = 0x4224;
 constexpr uint16_t VNI = 0x1776;
 
 class Ipv4TunnelTest : public TableEntryTest {
@@ -35,9 +35,9 @@ class Ipv4TunnelTest : public TableEntryTest {
         << "Error converting " << IPV4_DST_ADDR;
     info.remote_ip.prefix_len = IPV4_PREFIX_LEN;
 
-    info.src_port = htons(SRC_PORT);
-    info.dst_port = htons(DST_PORT);
-    info.vni = htons(VNI);
+    info.src_port = SRC_PORT;
+    info.dst_port = DST_PORT;
+    info.vni = VNI;
   };
 };
 

--- a/ovs-p4rt/sidecar/testing/ipv6_tunnel_test.h
+++ b/ovs-p4rt/sidecar/testing/ipv6_tunnel_test.h
@@ -17,8 +17,8 @@ constexpr char IPV6_DST_ADDR[] = "fe80::215:192.168.17.5";
 constexpr int IPV6_PREFIX_LEN = 64;
 
 constexpr uint16_t SRC_PORT = 0x1984;
-constexpr uint16_t DST_PORT = 0x1066;
-constexpr uint16_t VNI = 0x1776;
+constexpr uint16_t DST_PORT = 0x4224;
+constexpr uint16_t VNI = 0x1066;
 
 class Ipv6TunnelTest : public TableEntryTest {
  protected:
@@ -37,9 +37,9 @@ class Ipv6TunnelTest : public TableEntryTest {
         << "Error converting " << IPV6_DST_ADDR;
     info.remote_ip.prefix_len = IPV6_PREFIX_LEN;
 
-    info.src_port = htons(SRC_PORT);
-    info.dst_port = htons(DST_PORT);
-    info.vni = htons(VNI);
+    info.src_port = SRC_PORT;
+    info.dst_port = DST_PORT;
+    info.vni = VNI;
   };
 };
 

--- a/ovs-p4rt/sidecar/testing/table_entry_test.h
+++ b/ovs-p4rt/sidecar/testing/table_entry_test.h
@@ -42,6 +42,17 @@ class TableEntryTest : public ::testing::Test {
     }
   }
 
+  static uint16_t DecodePortValue(const std::string& string_value) {
+    uint16_t port_value = DecodeWordValue(string_value) & 0xffff;
+    // I have no idea why the port value should be byte-swapped, but
+    // that's what the functions in ovsp4rt.cc do.
+    return ntohs(port_value);
+  }
+
+  static uint16_t DecodeVniValue(const std::string& string_value) {
+    return DecodeWordValue(string_value) & 0xffff;
+  }
+
   static uint32_t DecodeWordValue(const std::string& string_value) {
     uint32_t word_value = 0;
     for (int i = 0; i < string_value.size(); i++) {

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_entry_test.cc
@@ -56,11 +56,11 @@ TEST_F(Ipv4TunnelTest, vxlan_encap_v4_params_are_correct) {
     int param_id = param.param_id();
     auto param_value = param.value();
     if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodeWordValue(param_value) & 0xffff;
+      src_port = DecodePortValue(param_value);
     } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodeWordValue(param_value) & 0xffff;
+      dst_port = DecodePortValue(param_value);
     } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeWordValue(param_value) & 0xffff;
+      vni = DecodeVniValue(param_value);
     }
   }
 

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_vlan_pop_test.cc
@@ -57,11 +57,11 @@ TEST_F(Ipv4TunnelTest, vxlan_encap_v4_vlan_pop_params_are_correct) {
     int param_id = param.param_id();
     auto param_value = param.value();
     if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodeWordValue(param_value) & 0xffff;
+      src_port = DecodePortValue(param_value);
     } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodeWordValue(param_value) & 0xffff;
+      dst_port = DecodePortValue(param_value);
     } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeWordValue(param_value) & 0xffff;
+      vni = DecodeVniValue(param_value);
     }
   }
 

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
@@ -57,11 +57,11 @@ TEST_F(Ipv6TunnelTest, vxlan_encap_v6_params_are_correct) {
     int param_id = param.param_id();
     auto param_value = param.value();
     if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodeWordValue(param_value) & 0xffff;
+      src_port = DecodePortValue(param_value);
     } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodeWordValue(param_value) & 0xffff;
+      dst_port = DecodePortValue(param_value);
     } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeWordValue(param_value) & 0xffff;
+      vni = DecodeVniValue(param_value);
     }
   }
 

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
@@ -58,11 +58,11 @@ TEST_F(Ipv6TunnelTest, vxlan_encap_v6_vlan_pop_params_are_correct) {
     auto param_value = param.value();
 
     if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodeWordValue(param_value) & 0xffff;
+      src_port = DecodePortValue(param_value);
     } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodeWordValue(param_value) & 0xffff;
+      dst_port = DecodePortValue(param_value);
     } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeWordValue(param_value) & 0xffff;
+      vni = DecodeVniValue(param_value);
     }
   }
 


### PR DESCRIPTION
- Corrected a byte-order but in EncodeVniValue().

- Fixed error InitV4TunnelInfo() and InitV6TunnelInfo(). The src_addr, dst_addr, and vni fields should be in host byte order.

- Implemented DecodePortValue() and DecodeVniValue() methods to make it easier to change algorithms in the future.