### PR TITLE
[ovsp4rt] Add comment headers to public functions

### DIFF
--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -2166,6 +2166,7 @@ absl::Status ConfigTunnelTermTableEntry(ovsp4rt::OvsP4rtSession* session,
 }
 
 #if defined(ES2K_TARGET)
+
 absl::Status ConfigDstIpMacMapTableEntry(ovsp4rt::OvsP4rtSession* session,
                                          struct ip_mac_map_info& ip_info,
                                          const ::p4::config::v1::P4Info& p4info,
@@ -2213,14 +2214,14 @@ absl::Status ConfigSrcIpMacMapTableEntry(ovsp4rt::OvsP4rtSession* session,
   }
   return status;
 }
+
 #endif  // ES2K_TARGET
 
 }  // namespace ovsp4rt
 
 //----------------------------------------------------------------------
-// Functions with C interfaces
+// ovsp4rt_str_to_tunnel_type (common)
 //----------------------------------------------------------------------
-
 enum ovs_tunnel_type ovsp4rt_str_to_tunnel_type(const char* tnl_type) {
   if (tnl_type) {
     if (strcmp(tnl_type, "vxlan") == 0) {
@@ -2233,6 +2234,9 @@ enum ovs_tunnel_type ovsp4rt_str_to_tunnel_type(const char* tnl_type) {
 }
 
 #if defined(ES2K_TARGET)
+//----------------------------------------------------------------------
+// ovsp4rt_config_fdb_entry (ES2K)
+//----------------------------------------------------------------------
 void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
                               bool insert_entry, const char* grpc_addr) {
   using namespace ovsp4rt;
@@ -2363,6 +2367,9 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
   }
 }
 
+//----------------------------------------------------------------------
+// ovsp4rt_config_rx_tunnel_src_entry (ES2K)
+//----------------------------------------------------------------------
 void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
                                         bool insert_entry,
                                         const char* grpc_addr) {
@@ -2377,6 +2384,8 @@ void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
   // Unwrap the session from the StatusOr object.
   std::unique_ptr<OvsP4rtSession> session =
       std::move(status_or_session).value();
+
+  // Fetch P4Info object from server.
   ::p4::config::v1::P4Info p4info;
   ::absl::Status status = GetForwardingPipelineConfig(session.get(), &p4info);
   if (!status.ok()) return;
@@ -2386,12 +2395,15 @@ void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
   if (!status.ok()) return;
 }
 
+//----------------------------------------------------------------------
+// ovsp4rt_config_tunnel_src_port_entry (ES2K)
+//----------------------------------------------------------------------
 void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
                                           bool insert_entry,
                                           const char* grpc_addr) {
   using namespace ovsp4rt;
 
-  p4::v1::WriteRequest write_request;
+  ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
   // Start a new client session.
@@ -2403,6 +2415,8 @@ void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
   // Unwrap the session from the StatusOr object.
   std::unique_ptr<OvsP4rtSession> session =
       std::move(status_or_session).value();
+
+  // Fetch P4Info object from server.
   ::p4::config::v1::P4Info p4info;
   ::absl::Status status = GetForwardingPipelineConfig(session.get(), &p4info);
   if (!status.ok()) return;
@@ -2423,12 +2437,12 @@ void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
   if (!status.ok()) return;
 }
 
+//----------------------------------------------------------------------
+// ovsp4rt_config_src_port_entry (ES2K)
+//----------------------------------------------------------------------
 void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
                                    bool insert_entry, const char* grpc_addr) {
   using namespace ovsp4rt;
-
-  p4::v1::WriteRequest write_request;
-  ::p4::v1::TableEntry* table_entry;
 
   // Start a new client session.
   auto status_or_session = OvsP4rtSession::Create(
@@ -2439,6 +2453,8 @@ void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
   // Unwrap the session from the StatusOr object.
   std::unique_ptr<OvsP4rtSession> session =
       std::move(status_or_session).value();
+
+  // Fetch P4Info object from server.
   ::p4::config::v1::P4Info p4info;
   ::absl::Status status = GetForwardingPipelineConfig(session.get(), &p4info);
   if (!status.ok()) return;
@@ -2481,12 +2497,12 @@ void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
   if (!status.ok()) return;
 }
 
+//----------------------------------------------------------------------
+// ovsp4rt_config_vlan_entry (ES2K)
+//----------------------------------------------------------------------
 void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
                                const char* grpc_addr) {
   using namespace ovsp4rt;
-
-  p4::v1::WriteRequest write_request;
-  ::p4::v1::TableEntry* table_entry;
 
   // Start a new client session.
   auto status_or_session = OvsP4rtSession::Create(
@@ -2497,6 +2513,8 @@ void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
   // Unwrap the session from the StatusOr object.
   std::unique_ptr<OvsP4rtSession> session =
       std::move(status_or_session).value();
+
+  // Fetch P4Info object from the server.
   ::p4::config::v1::P4Info p4info;
   ::absl::Status status = GetForwardingPipelineConfig(session.get(), &p4info);
   if (!status.ok()) return;
@@ -2511,7 +2529,9 @@ void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
 }
 #else
 
-// DPDK target
+//----------------------------------------------------------------------
+// ovsp4rt_config_fdb_entry (DPDK)
+//----------------------------------------------------------------------
 void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
                               bool insert_entry, const char* grpc_addr) {
   using namespace ovsp4rt;
@@ -2525,6 +2545,8 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
   // Unwrap the session from the StatusOr object.
   std::unique_ptr<ovsp4rt::OvsP4rtSession> session =
       std::move(status_or_session).value();
+
+  // Fetch P4Info object from the server.
   ::p4::config::v1::P4Info p4info;
   ::absl::Status status =
       ovsp4rt::GetForwardingPipelineConfig(session.get(), &p4info);
@@ -2544,34 +2566,32 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
   }
 }
 
+//----------------------------------------------------------------------
+// Unimplemented functions (DPDK)
+//----------------------------------------------------------------------
 void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
                                         bool insert_entry,
-                                        const char* grpc_addr) {
-  /* Unimplemented for DPDK target */
-}
+                                        const char* grpc_addr) {}
 
 void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
-                               const char* grpc_addr) {
-  /* Unimplemented for DPDK target */
-}
+                               const char* grpc_addr) {}
+
 void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
                                           bool insert_entry,
-                                          const char* grpc_addr) {
-  /* Unimplemented for DPDK target */
-}
+                                          const char* grpc_addr) {}
 
 void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
-                                   bool insert_entry, const char* grpc_addr) {
-  /* Unimplemented for DPDK target */
-}
+                                   bool insert_entry, const char* grpc_addr) {}
 
 void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
                                      bool insert_entry, const char* grpc_addr) {
-  /* Unimplemented for DPDK target */
 }
 
 #endif
 
+//----------------------------------------------------------------------
+// ovsp4rt_config_tunnel_entry (common)
+//----------------------------------------------------------------------
 void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
                                  bool insert_entry, const char* grpc_addr) {
   using namespace ovsp4rt;
@@ -2585,9 +2605,12 @@ void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
   // Unwrap the session from the StatusOr object.
   std::unique_ptr<OvsP4rtSession> session =
       std::move(status_or_session).value();
+
+  // Fetch P4Info object from the server.
   ::p4::config::v1::P4Info p4info;
   ::absl::Status status = GetForwardingPipelineConfig(session.get(), &p4info);
   if (!status.ok()) return;
+
   status =
       ConfigEncapTableEntry(session.get(), tunnel_info, p4info, insert_entry);
   if (!status.ok()) return;
@@ -2604,6 +2627,9 @@ void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
 }
 
 #if defined(ES2K_TARGET)
+//----------------------------------------------------------------------
+// ovsp4rt_config_ip_mac_map_entry (ES2K)
+//----------------------------------------------------------------------
 void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
                                      bool insert_entry, const char* grpc_addr) {
   using namespace ovsp4rt;
@@ -2617,6 +2643,8 @@ void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
   // Unwrap the session from the StatusOr object.
   std::unique_ptr<ovsp4rt::OvsP4rtSession> session =
       std::move(status_or_session).value();
+
+  // Fetch P4Info object from the server.
   ::p4::config::v1::P4Info p4info;
   ::absl::Status status =
       ovsp4rt::GetForwardingPipelineConfig(session.get(), &p4info);


### PR DESCRIPTION
- Added comment headers to make the public functions easier to identify.

- Separated stanzas that fetch the P4 pipeline configuration from the preceding stanzas.

- Deleted some unused local variables.