### PR TITLE
[ovsp4rt] Specify tunnel type in unit tests

### DIFF
--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_entry_test.cc
@@ -30,7 +30,7 @@ TEST_F(Ipv4TunnelTest, geneve_encap_v4_params_are_correct) {
   };
 
   // Arrange
-  InitV4TunnelInfo(tunnel_info);
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
   // Act
   PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, insert_entry);

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
@@ -30,7 +30,7 @@ TEST_F(Ipv4TunnelTest, geneve_encap_v4_vlan_pop_params_are_correct) {
   };
 
   // Arrange
-  InitV4TunnelInfo(tunnel_info);
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
   // Act
   PrepareGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
@@ -30,7 +30,7 @@ TEST_F(Ipv6TunnelTest, geneve_encap_v6_params_are_correct) {
   };
 
   // Arrange
-  InitV6TunnelInfo(tunnel_info);
+  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
   // Act
   PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,

--- a/ovs-p4rt/sidecar/testing/ipv4_tunnel_test.h
+++ b/ovs-p4rt/sidecar/testing/ipv4_tunnel_test.h
@@ -24,7 +24,7 @@ class Ipv4TunnelTest : public TableEntryTest {
  protected:
   Ipv4TunnelTest() {}
 
-  void InitV4TunnelInfo(tunnel_info& info) {
+  void InitV4TunnelInfo(tunnel_info& info, uint8_t tunnel_type) {
     EXPECT_EQ(
         inet_pton(AF_INET, IPV4_SRC_ADDR, &info.local_ip.ip.v4addr.s_addr), 1)
         << "Error converting " << IPV4_SRC_ADDR;
@@ -38,6 +38,7 @@ class Ipv4TunnelTest : public TableEntryTest {
     info.src_port = SRC_PORT;
     info.dst_port = DST_PORT;
     info.vni = VNI;
+    info.tunnel_type = tunnel_type;
   };
 };
 

--- a/ovs-p4rt/sidecar/testing/ipv6_tunnel_test.h
+++ b/ovs-p4rt/sidecar/testing/ipv6_tunnel_test.h
@@ -24,7 +24,7 @@ class Ipv6TunnelTest : public TableEntryTest {
  protected:
   Ipv6TunnelTest() {}
 
-  void InitV6TunnelInfo(tunnel_info& info) {
+  void InitV6TunnelInfo(tunnel_info& info, uint8_t tunnel_type) {
     EXPECT_EQ(inet_pton(AF_INET6, IPV6_SRC_ADDR,
                         &info.local_ip.ip.v6addr.__in6_u.__u6_addr32),
               1)
@@ -40,6 +40,7 @@ class Ipv6TunnelTest : public TableEntryTest {
     info.src_port = SRC_PORT;
     info.dst_port = DST_PORT;
     info.vni = VNI;
+    info.tunnel_type = tunnel_type;
   };
 };
 

--- a/ovs-p4rt/sidecar/testing/table_entry_test.h
+++ b/ovs-p4rt/sidecar/testing/table_entry_test.h
@@ -44,8 +44,7 @@ class TableEntryTest : public ::testing::Test {
 
   static uint16_t DecodePortValue(const std::string& string_value) {
     uint16_t port_value = DecodeWordValue(string_value) & 0xffff;
-    // I have no idea why the port value should be byte-swapped, but
-    // that's what the functions in ovsp4rt.cc do.
+    // Port values are encoded low byte first.
     return ntohs(port_value);
   }
 

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_entry_test.cc
@@ -30,7 +30,7 @@ TEST_F(Ipv4TunnelTest, vxlan_encap_v4_params_are_correct) {
   };
 
   // Arrange
-  InitV4TunnelInfo(tunnel_info);
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
   PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, insert_entry);

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_vlan_pop_test.cc
@@ -30,7 +30,7 @@ TEST_F(Ipv4TunnelTest, vxlan_encap_v4_vlan_pop_params_are_correct) {
   };
 
   // Arrange
-  InitV4TunnelInfo(tunnel_info);
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
   PrepareVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
@@ -30,7 +30,7 @@ TEST_F(Ipv6TunnelTest, vxlan_encap_v6_params_are_correct) {
   };
 
   // Arrange
-  InitV6TunnelInfo(tunnel_info);
+  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
   PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
@@ -30,7 +30,7 @@ TEST_F(Ipv6TunnelTest, vxlan_encap_v6_vlan_pop_params_are_correct) {
   };
 
   // Arrange
-  InitV6TunnelInfo(tunnel_info);
+  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
   PrepareV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,


### PR DESCRIPTION
- Modified vxlan and geneve encapsulation unit tests to specify the tunnel type when initializing the tunnel_info structure.