### PR TITLE
[ovsp4rt] Export list of unit tests to parent scope

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -9,6 +9,9 @@ option(BUILD_SPIES "Build ovs-p4rt with spies" OFF)
 
 set(SIDECAR_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
+# Initialize list of unit tests.
+set(UNIT_TEST_NAMES)
+
 #-----------------------------------------------------------------------
 # ovs_sidecar_o
 #-----------------------------------------------------------------------
@@ -115,3 +118,7 @@ install(
 if(BUILD_TESTING)
     add_subdirectory(testing)
 endif()
+
+add_custom_target(ovsp4rt-unit-tests
+  DEPENDS ${UNIT_TEST_NAMES}
+)

--- a/ovs-p4rt/sidecar/journal/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/journal/CMakeLists.txt
@@ -53,4 +53,9 @@ target_link_libraries(encode_addr_test PUBLIC
 
 add_test(NAME encode_addr_test COMMAND encode_addr_test)
 
+list(APPEND UNIT_TEST_NAMES encode_addr_test)
+
+# export updated list of unit tests.
+set(UNIT_TEST_NAMES "${UNIT_TEST_NAMES}" PARENT_SCOPE)
+
 endif(BUILD_TESTING)

--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -61,7 +61,7 @@ target_link_libraries(encode_host_port_value_test PUBLIC
   GTest::gtest_main
 )
 
-list(APPEND unit_test_names encode_host_port_value_test)
+list(APPEND UNIT_TEST_NAMES encode_host_port_value_test)
 
 if(ES2K_TARGET)
 
@@ -78,7 +78,7 @@ target_link_libraries(geneve_encap_v4_table_entry_test PUBLIC
   ipv4_test_utils
 )
 
-list(APPEND unit_test_names geneve_encap_v4_table_entry_test)
+list(APPEND UNIT_TEST_NAMES geneve_encap_v4_table_entry_test)
 
 #-----------------------------------------------------------------------
 # geneve_encap_v6_table_entry_test (ES2K)
@@ -93,7 +93,7 @@ target_link_libraries(geneve_encap_v6_table_entry_test PUBLIC
   ipv6_test_utils
 )
 
-list(APPEND unit_test_names geneve_encap_v6_table_entry_test)
+list(APPEND UNIT_TEST_NAMES geneve_encap_v6_table_entry_test)
 
 #-----------------------------------------------------------------------
 # geneve_encap_v4_vlan_pop_test (ES2K)
@@ -108,7 +108,7 @@ target_link_libraries(geneve_encap_v4_vlan_pop_test PUBLIC
   ipv4_test_utils
 )
 
-list(APPEND unit_test_names geneve_encap_v4_vlan_pop_test)
+list(APPEND UNIT_TEST_NAMES geneve_encap_v4_vlan_pop_test)
 
 #-----------------------------------------------------------------------
 # prepare_l2_to_tunnel_test (ES2K)
@@ -125,7 +125,7 @@ target_link_libraries(prepare_l2_to_tunnel_test PUBLIC
   absl::flags_parse
 )
 
-list(APPEND unit_test_names prepare_l2_to_tunnel_test)
+list(APPEND UNIT_TEST_NAMES prepare_l2_to_tunnel_test)
 
 endif(ES2K_TARGET)
 
@@ -142,7 +142,7 @@ target_link_libraries(vxlan_encap_v4_table_entry_test PUBLIC
   ipv4_test_utils
 )
 
-list(APPEND unit_test_names vxlan_encap_v4_table_entry_test)
+list(APPEND UNIT_TEST_NAMES vxlan_encap_v4_table_entry_test)
 
 if(ES2K_TARGET)
 
@@ -159,7 +159,7 @@ target_link_libraries(vxlan_encap_v6_table_entry_test PUBLIC
   ipv6_test_utils
 )
 
-list(APPEND unit_test_names vxlan_encap_v6_table_entry_test)
+list(APPEND UNIT_TEST_NAMES vxlan_encap_v6_table_entry_test)
 
 #-----------------------------------------------------------------------
 # vxlan_encap_v4_vlan_pop_test (ES2K)
@@ -174,7 +174,7 @@ target_link_libraries(vxlan_encap_v4_vlan_pop_test PUBLIC
   ipv4_test_utils
 )
 
-list(APPEND unit_test_names vxlan_encap_v4_vlan_pop_test)
+list(APPEND UNIT_TEST_NAMES vxlan_encap_v4_vlan_pop_test)
 
 #-----------------------------------------------------------------------
 # vxlan_encap_v6_vlan_pop_test (ES2K)
@@ -189,13 +189,9 @@ target_link_libraries(vxlan_encap_v6_vlan_pop_test PUBLIC
   ipv6_test_utils
 )
 
-list(APPEND unit_test_names vxlan_encap_v6_vlan_pop_test)
+list(APPEND UNIT_TEST_NAMES vxlan_encap_v6_vlan_pop_test)
 
 endif(ES2K_TARGET)
 
-#-----------------------------------------------------------------------
-# ovsp4rt-unit-tests
-#-----------------------------------------------------------------------
-add_custom_target(ovsp4rt-unit-tests
-  DEPENDS ${unit_test_names}
-)
+# Export updated list of unit tests.
+set(UNIT_TEST_NAMES "${UNIT_TEST_NAMES}" PARENT_SCOPE)


### PR DESCRIPTION
- Reworked the process of accumulating the list of unit tests to be built by the `ovsp4rt-unit-tests` target so it works across subdirectories.