### PR TITLE
[ovsp4rt] Rename unit tests for consistency

### DIFF
--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -121,23 +121,23 @@ if(ES2K_TARGET)
 # ES2K unit tests
 #-----------------------------------------------------------------------
 
-define_ovsp4rt_test(fdb_rx_vlan_entry_test)
-define_ovsp4rt_test(fdb_smac_entry_test)
-define_ovsp4rt_test(fdb_tx_vlan_entry_test)
+define_ovsp4rt_test(fdb_rx_vlan_table_test)
+define_ovsp4rt_test(fdb_smac_table_test)
+define_ovsp4rt_test(fdb_tx_vlan_table_test)
 
-define_ipv4_tunnel_test(geneve_encap_v4_table_entry_test)
-define_ipv6_tunnel_test(geneve_encap_v6_table_entry_test)
-define_ipv4_tunnel_test(geneve_encap_v4_vlan_pop_test)
+define_ipv4_tunnel_test(geneve_encap_v4_table_test)
+define_ipv6_tunnel_test(geneve_encap_v6_table_test)
+define_ipv4_tunnel_test(geneve_encap_vlan_pop_v4_table_test)
 
-define_ovsp4rt_test(l2_to_v4_tunnel_test)
-define_ovsp4rt_test(l2_to_v6_tunnel_test)
+define_ovsp4rt_test(l2_to_tunnel_v4_table_test)
+define_ovsp4rt_test(l2_to_tunnel_v6_table_test)
 
 define_ovsp4rt_test(vxlan_decap_mod_entry_test)
 
-define_ipv4_tunnel_test(vxlan_encap_v4_table_entry_test)
-define_ipv6_tunnel_test(vxlan_encap_v6_table_entry_test)
-define_ipv4_tunnel_test(vxlan_encap_v4_vlan_pop_test)
-define_ipv6_tunnel_test(vxlan_encap_v6_vlan_pop_test)
+define_ipv4_tunnel_test(vxlan_encap_v4_table_test)
+define_ipv6_tunnel_test(vxlan_encap_v6_table_test)
+define_ipv4_tunnel_test(vxlan_encap_vlan_pop_v4_table_test)
+define_ipv6_tunnel_test(vxlan_encap_vlan_pop_v6_table_test)
 
 endif(ES2K_TARGET)
 

--- a/ovs-p4rt/sidecar/testing/fdb_rx_vlan_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/fdb_rx_vlan_table_test.cc
@@ -1,14 +1,15 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbSmacTableEntry()
+// Unit test for PrepareFdbRxVlanTableEntry()
 
-#include <arpa/inet.h>
 #include <stdint.h>
 
 #include <iostream>
 #include <string>
 
+#include "absl/flags/flag.h"
+#include "google/protobuf/util/json_util.h"
 #include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
@@ -18,8 +19,12 @@
 #include "p4info_text.h"
 #include "stratum/lib/utils.h"
 
+ABSL_FLAG(bool, dump_json, false, "Dump output table_entry in JSON");
+
 namespace ovsp4rt {
 
+using google::protobuf::util::JsonPrintOptions;
+using google::protobuf::util::MessageToJsonString;
 using stratum::ParseProtoFromString;
 
 constexpr bool INSERT_ENTRY = true;
@@ -27,9 +32,9 @@ constexpr bool REMOVE_ENTRY = false;
 
 static ::p4::config::v1::P4Info p4info;
 
-class FdbSmacEntryTest : public ::testing::Test {
+class FdbRxVlanTableTest : public ::testing::Test {
  protected:
-  FdbSmacEntryTest() {}
+  FdbRxVlanTableTest() { dump_json_ = absl::GetFlag(FLAGS_dump_json); }
 
   static void SetUpTestSuite() {
     ::util::Status status = ParseProtoFromString(P4INFO_TEXT, &p4info);
@@ -38,7 +43,7 @@ class FdbSmacEntryTest : public ::testing::Test {
     }
   }
 
-  void SetUp() { SelectTable("l2_fwd_smac_table"); }
+  void SetUp() { SelectTable("l2_fwd_rx_table"); }
 
   //----------------------------
   // P4Info lookup methods
@@ -65,6 +70,28 @@ class FdbSmacEntryTest : public ::testing::Test {
     return -1;
   }
 
+  int GetParamId(const std::string& param_name) const {
+    for (const auto& param : ACTION->params()) {
+      if (param.name() == param_name) {
+        return param.id();
+      }
+    }
+    std::cerr << "Action Param '" << param_name << "' not found!\n";
+    return -1;
+  }
+
+  void SelectAction(const std::string& action_name) {
+    for (const auto& action : p4info.actions()) {
+      const auto& pre = action.preamble();
+      if (pre.name() == action_name || pre.alias() == action_name) {
+        ACTION = &action;
+        ACTION_ID = pre.id();
+        return;
+      }
+    }
+    std::cerr << "Action '" << action_name << "' not found!\n";
+  }
+
   void SelectTable(const std::string& table_name) {
     for (const auto& table : p4info.tables()) {
       const auto& pre = table.preamble();
@@ -89,16 +116,31 @@ class FdbSmacEntryTest : public ::testing::Test {
     return word_value;
   }
 
+  void DumpTableEntry() {
+    if (dump_json_) {
+      JsonPrintOptions options;
+      options.add_whitespace = true;
+      options.preserve_proto_field_names = true;
+      std::string output;
+      ASSERT_TRUE(MessageToJsonString(table_entry, &output, options).ok());
+      std::cout << output << std::endl;
+    }
+  }
+
   //----------------------------
   // Initialization methods
   //----------------------------
 
+  void InitAction() { SelectAction("l2_fwd"); }
+
   void InitFdbInfo() {
     constexpr uint8_t MAC_ADDR[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
-    constexpr uint8_t BRIDGE_ID = 42;
+    constexpr uint8_t BRIDGE_ID = 99;
+    constexpr uint32_t SRC_PORT = 0x42;
 
     memcpy(fdb_info.mac_addr, MAC_ADDR, sizeof(fdb_info.mac_addr));
     fdb_info.bridge_id = BRIDGE_ID;
+    fdb_info.rx_src_port = SRC_PORT;
   }
 
   //----------------------------
@@ -106,10 +148,23 @@ class FdbSmacEntryTest : public ::testing::Test {
   //----------------------------
 
   void CheckAction() const {
+    const int PORT_PARAM = GetParamId("port");
+
+    ASSERT_NE(ACTION_ID, -1);
+
     ASSERT_TRUE(table_entry.has_action());
     const auto& table_action = table_entry.action();
+
     const auto& action = table_action.action();
-    EXPECT_EQ(action.action_id(), GetActionId("NoAction"));
+    EXPECT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    ASSERT_EQ(action.params_size(), 1);
+
+    auto param = params[0];
+    ASSERT_EQ(param.param_id(), PORT_PARAM);
+    uint32_t port = DecodeWordValue(param.value());
+    EXPECT_EQ(port, fdb_info.rx_src_port);
   }
 
   void CheckBridgeId(const ::p4::v1::FieldMatch& match) const {
@@ -123,9 +178,7 @@ class FdbSmacEntryTest : public ::testing::Test {
     ASSERT_EQ(uint32_t(match_value[0]), uint32_t(fdb_info.bridge_id));
   }
 
-  void CheckDetail() const {
-    EXPECT_EQ(detail.table_id, LOG_L2_FWD_SMAC_TABLE);
-  }
+  void CheckDetail() const { EXPECT_EQ(detail.table_id, LOG_L2_FWD_RX_TABLE); }
 
   void CheckMacAddr(const ::p4::v1::FieldMatch& match) const {
     constexpr int MAC_ADDR_SIZE = 6;
@@ -135,21 +188,24 @@ class FdbSmacEntryTest : public ::testing::Test {
     ASSERT_EQ(match_value.size(), MAC_ADDR_SIZE);
 
     for (int i = 0; i < MAC_ADDR_SIZE; i++) {
-      EXPECT_EQ(match_value[i] & 0xFF, fdb_info.mac_addr[i])
+      EXPECT_EQ(match_value[i], fdb_info.mac_addr[i])
           << "mac_addr[" << i << "] is incorrect";
     }
   }
 
   void CheckMatches() const {
-    constexpr int MFID_MAC_ADDR = 1;
-    constexpr int MFID_BRIDGE_ID = 2;
+    constexpr char BRIDGE_ID_KEY[] = "user_meta.pmeta.bridge_id";
+    constexpr char DST_MAC_KEY[] = "dst_mac";
+
+    const int MFID_BRIDGE_ID = GetMatchFieldId(BRIDGE_ID_KEY);
+    const int MFID_DST_MAC = GetMatchFieldId(DST_MAC_KEY);
 
     // number of match fields
     ASSERT_EQ(table_entry.match_size(), 2);
 
     for (const auto& match : table_entry.match()) {
       auto field_id = match.field_id();
-      if (field_id == MFID_MAC_ADDR) {
+      if (field_id == MFID_DST_MAC) {
         CheckMacAddr(match);
       } else if (field_id == MFID_BRIDGE_ID) {
         CheckBridgeId(match);
@@ -159,16 +215,8 @@ class FdbSmacEntryTest : public ::testing::Test {
     }
   }
 
-  void CheckNoAction() const {
-    // Table entry does not specify an action
-    EXPECT_FALSE(table_entry.has_action());
-  }
-
   void CheckTableEntry() const {
-    // Table is defined (sanity check)
     ASSERT_FALSE(TABLE == nullptr);
-
-    // Table ID is what we expect
     EXPECT_EQ(table_entry.table_id(), TABLE_ID);
   }
 
@@ -183,6 +231,7 @@ class FdbSmacEntryTest : public ::testing::Test {
 
   // Comparison variables
   uint32_t TABLE_ID;
+  int ACTION_ID = -1;
 
  private:
   //----------------------------
@@ -190,34 +239,39 @@ class FdbSmacEntryTest : public ::testing::Test {
   //----------------------------
 
   const ::p4::config::v1::Table* TABLE = nullptr;
+  const ::p4::config::v1::Action* ACTION = nullptr;
+
+  bool dump_json_ = false;
 };
 
 //----------------------------------------------------------------------
-// PrepareFdbSmacTableEntry
+// PrepareFdbRxVlanTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(FdbSmacEntryTest, remove_entry) {
+TEST_F(FdbRxVlanTableTest, remove_entry) {
   // Arrange
   InitFdbInfo();
 
   // Act
-  PrepareFdbSmacTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
-                           detail);
+  PrepareFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
+                             detail);
+  DumpTableEntry();
 
   // Assert
   CheckDetail();
   CheckTableEntry();
   CheckMatches();
-  CheckNoAction();
 }
 
-TEST_F(FdbSmacEntryTest, insert_entry) {
+TEST_F(FdbRxVlanTableTest, insert_entry) {
   // Arrange
   InitFdbInfo();
+  InitAction();
 
   // Act
-  PrepareFdbSmacTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                           detail);
+  PrepareFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
+                             detail);
+  DumpTableEntry();
 
   // Assert
   CheckAction();

--- a/ovs-p4rt/sidecar/testing/fdb_smac_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/fdb_smac_table_test.cc
@@ -1,15 +1,14 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareFdbRxVlanTableEntry()
+// Unit test for PrepareFdbSmacTableEntry()
 
+#include <arpa/inet.h>
 #include <stdint.h>
 
 #include <iostream>
 #include <string>
 
-#include "absl/flags/flag.h"
-#include "google/protobuf/util/json_util.h"
 #include "gtest/gtest.h"
 #include "logging/ovsp4rt_diag_detail.h"
 #include "ovsp4rt/ovs-p4rt.h"
@@ -19,12 +18,8 @@
 #include "p4info_text.h"
 #include "stratum/lib/utils.h"
 
-ABSL_FLAG(bool, dump_json, false, "Dump output table_entry in JSON");
-
 namespace ovsp4rt {
 
-using google::protobuf::util::JsonPrintOptions;
-using google::protobuf::util::MessageToJsonString;
 using stratum::ParseProtoFromString;
 
 constexpr bool INSERT_ENTRY = true;
@@ -32,9 +27,9 @@ constexpr bool REMOVE_ENTRY = false;
 
 static ::p4::config::v1::P4Info p4info;
 
-class FdbRxVlanEntryTest : public ::testing::Test {
+class FdbSmacTableTest : public ::testing::Test {
  protected:
-  FdbRxVlanEntryTest() { dump_json_ = absl::GetFlag(FLAGS_dump_json); }
+  FdbSmacTableTest() {}
 
   static void SetUpTestSuite() {
     ::util::Status status = ParseProtoFromString(P4INFO_TEXT, &p4info);
@@ -43,7 +38,7 @@ class FdbRxVlanEntryTest : public ::testing::Test {
     }
   }
 
-  void SetUp() { SelectTable("l2_fwd_rx_table"); }
+  void SetUp() { SelectTable("l2_fwd_smac_table"); }
 
   //----------------------------
   // P4Info lookup methods
@@ -70,28 +65,6 @@ class FdbRxVlanEntryTest : public ::testing::Test {
     return -1;
   }
 
-  int GetParamId(const std::string& param_name) const {
-    for (const auto& param : ACTION->params()) {
-      if (param.name() == param_name) {
-        return param.id();
-      }
-    }
-    std::cerr << "Action Param '" << param_name << "' not found!\n";
-    return -1;
-  }
-
-  void SelectAction(const std::string& action_name) {
-    for (const auto& action : p4info.actions()) {
-      const auto& pre = action.preamble();
-      if (pre.name() == action_name || pre.alias() == action_name) {
-        ACTION = &action;
-        ACTION_ID = pre.id();
-        return;
-      }
-    }
-    std::cerr << "Action '" << action_name << "' not found!\n";
-  }
-
   void SelectTable(const std::string& table_name) {
     for (const auto& table : p4info.tables()) {
       const auto& pre = table.preamble();
@@ -116,31 +89,16 @@ class FdbRxVlanEntryTest : public ::testing::Test {
     return word_value;
   }
 
-  void DumpTableEntry() {
-    if (dump_json_) {
-      JsonPrintOptions options;
-      options.add_whitespace = true;
-      options.preserve_proto_field_names = true;
-      std::string output;
-      ASSERT_TRUE(MessageToJsonString(table_entry, &output, options).ok());
-      std::cout << output << std::endl;
-    }
-  }
-
   //----------------------------
   // Initialization methods
   //----------------------------
 
-  void InitAction() { SelectAction("l2_fwd"); }
-
   void InitFdbInfo() {
     constexpr uint8_t MAC_ADDR[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
-    constexpr uint8_t BRIDGE_ID = 99;
-    constexpr uint32_t SRC_PORT = 0x42;
+    constexpr uint8_t BRIDGE_ID = 42;
 
     memcpy(fdb_info.mac_addr, MAC_ADDR, sizeof(fdb_info.mac_addr));
     fdb_info.bridge_id = BRIDGE_ID;
-    fdb_info.rx_src_port = SRC_PORT;
   }
 
   //----------------------------
@@ -148,23 +106,10 @@ class FdbRxVlanEntryTest : public ::testing::Test {
   //----------------------------
 
   void CheckAction() const {
-    const int PORT_PARAM = GetParamId("port");
-
-    ASSERT_NE(ACTION_ID, -1);
-
     ASSERT_TRUE(table_entry.has_action());
     const auto& table_action = table_entry.action();
-
     const auto& action = table_action.action();
-    EXPECT_EQ(action.action_id(), ACTION_ID);
-
-    auto params = action.params();
-    ASSERT_EQ(action.params_size(), 1);
-
-    auto param = params[0];
-    ASSERT_EQ(param.param_id(), PORT_PARAM);
-    uint32_t port = DecodeWordValue(param.value());
-    EXPECT_EQ(port, fdb_info.rx_src_port);
+    EXPECT_EQ(action.action_id(), GetActionId("NoAction"));
   }
 
   void CheckBridgeId(const ::p4::v1::FieldMatch& match) const {
@@ -178,7 +123,9 @@ class FdbRxVlanEntryTest : public ::testing::Test {
     ASSERT_EQ(uint32_t(match_value[0]), uint32_t(fdb_info.bridge_id));
   }
 
-  void CheckDetail() const { EXPECT_EQ(detail.table_id, LOG_L2_FWD_RX_TABLE); }
+  void CheckDetail() const {
+    EXPECT_EQ(detail.table_id, LOG_L2_FWD_SMAC_TABLE);
+  }
 
   void CheckMacAddr(const ::p4::v1::FieldMatch& match) const {
     constexpr int MAC_ADDR_SIZE = 6;
@@ -188,24 +135,21 @@ class FdbRxVlanEntryTest : public ::testing::Test {
     ASSERT_EQ(match_value.size(), MAC_ADDR_SIZE);
 
     for (int i = 0; i < MAC_ADDR_SIZE; i++) {
-      EXPECT_EQ(match_value[i], fdb_info.mac_addr[i])
+      EXPECT_EQ(match_value[i] & 0xFF, fdb_info.mac_addr[i])
           << "mac_addr[" << i << "] is incorrect";
     }
   }
 
   void CheckMatches() const {
-    constexpr char BRIDGE_ID_KEY[] = "user_meta.pmeta.bridge_id";
-    constexpr char DST_MAC_KEY[] = "dst_mac";
-
-    const int MFID_BRIDGE_ID = GetMatchFieldId(BRIDGE_ID_KEY);
-    const int MFID_DST_MAC = GetMatchFieldId(DST_MAC_KEY);
+    constexpr int MFID_MAC_ADDR = 1;
+    constexpr int MFID_BRIDGE_ID = 2;
 
     // number of match fields
     ASSERT_EQ(table_entry.match_size(), 2);
 
     for (const auto& match : table_entry.match()) {
       auto field_id = match.field_id();
-      if (field_id == MFID_DST_MAC) {
+      if (field_id == MFID_MAC_ADDR) {
         CheckMacAddr(match);
       } else if (field_id == MFID_BRIDGE_ID) {
         CheckBridgeId(match);
@@ -215,8 +159,16 @@ class FdbRxVlanEntryTest : public ::testing::Test {
     }
   }
 
+  void CheckNoAction() const {
+    // Table entry does not specify an action
+    EXPECT_FALSE(table_entry.has_action());
+  }
+
   void CheckTableEntry() const {
+    // Table is defined (sanity check)
     ASSERT_FALSE(TABLE == nullptr);
+
+    // Table ID is what we expect
     EXPECT_EQ(table_entry.table_id(), TABLE_ID);
   }
 
@@ -231,7 +183,6 @@ class FdbRxVlanEntryTest : public ::testing::Test {
 
   // Comparison variables
   uint32_t TABLE_ID;
-  int ACTION_ID = -1;
 
  private:
   //----------------------------
@@ -239,39 +190,34 @@ class FdbRxVlanEntryTest : public ::testing::Test {
   //----------------------------
 
   const ::p4::config::v1::Table* TABLE = nullptr;
-  const ::p4::config::v1::Action* ACTION = nullptr;
-
-  bool dump_json_ = false;
 };
 
 //----------------------------------------------------------------------
-// PrepareFdbRxVlanTableEntry()
+// PrepareFdbSmacTableEntry
 //----------------------------------------------------------------------
 
-TEST_F(FdbRxVlanEntryTest, remove_entry) {
+TEST_F(FdbSmacTableTest, remove_entry) {
   // Arrange
   InitFdbInfo();
 
   // Act
-  PrepareFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
-                             detail);
-  DumpTableEntry();
+  PrepareFdbSmacTableEntry(&table_entry, fdb_info, p4info, REMOVE_ENTRY,
+                           detail);
 
   // Assert
   CheckDetail();
   CheckTableEntry();
   CheckMatches();
+  CheckNoAction();
 }
 
-TEST_F(FdbRxVlanEntryTest, insert_entry) {
+TEST_F(FdbSmacTableTest, insert_entry) {
   // Arrange
   InitFdbInfo();
-  InitAction();
 
   // Act
-  PrepareFdbRxVlanTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
-                             detail);
-  DumpTableEntry();
+  PrepareFdbSmacTableEntry(&table_entry, fdb_info, p4info, INSERT_ENTRY,
+                           detail);
 
   // Assert
   CheckAction();

--- a/ovs-p4rt/sidecar/testing/fdb_tx_vlan_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/fdb_tx_vlan_table_test.cc
@@ -29,9 +29,9 @@ constexpr bool REMOVE_ENTRY = false;
 
 static ::p4::config::v1::P4Info p4info;
 
-class FdbTxVlanEntryTest : public ::testing::Test {
+class FdbTxVlanTableTest : public ::testing::Test {
  protected:
-  FdbTxVlanEntryTest() {}
+  FdbTxVlanTableTest() {}
 
   static void SetUpTestSuite() {
     ::util::Status status = ParseProtoFromString(P4INFO_TEXT, &p4info);
@@ -276,7 +276,7 @@ class FdbTxVlanEntryTest : public ::testing::Test {
 // PrepareFdbTxVlanTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(FdbTxVlanEntryTest, remove_entry) {
+TEST_F(FdbTxVlanTableTest, remove_entry) {
   // Arrange
   InitFdbInfo();
 
@@ -290,7 +290,7 @@ TEST_F(FdbTxVlanEntryTest, remove_entry) {
   CheckMatches();
 }
 
-TEST_F(FdbTxVlanEntryTest, insert_untagged_entry) {
+TEST_F(FdbTxVlanTableTest, insert_untagged_entry) {
   // Arrange
   InitFdbInfo();
   InitUntagged();
@@ -303,7 +303,7 @@ TEST_F(FdbTxVlanEntryTest, insert_untagged_entry) {
   CheckUntaggedAction();
 }
 
-TEST_F(FdbTxVlanEntryTest, insert_tagged_entry) {
+TEST_F(FdbTxVlanTableTest, insert_tagged_entry) {
   // Arrange
   InitFdbInfo();
   InitTagged();

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_test.cc
@@ -11,11 +11,13 @@
 
 namespace ovsp4rt {
 
+class GeneveEncapV4TableTest : public Ipv4TunnelTest {};
+
 //----------------------------------------------------------------------
 // Test PrepareGeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, GeneveEncapV4TableTest_minimal) {
+TEST_F(GeneveEncapV4TableTest, minimal) {
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
   constexpr bool insert_entry = true;

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_test.cc
@@ -12,16 +12,16 @@
 namespace ovsp4rt {
 
 //----------------------------------------------------------------------
-// PrepareGeneveEncapTableEntry()
+// Test PrepareGeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, geneve_encap_v4_vlan_pop_params_are_correct) {
+TEST_F(Ipv4TunnelTest, GeneveEncapV4TableTest_minimal) {
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
   constexpr bool insert_entry = true;
 
-  constexpr uint32_t TABLE_ID = 47977422U;
-  constexpr uint32_t ACTION_ID = 26665268U;
+  constexpr uint32_t TABLE_ID = 41319073U;
+  constexpr uint32_t ACTION_ID = 25818889U;
 
   enum {
     SRC_PORT_PARAM_ID = 3,
@@ -33,8 +33,7 @@ TEST_F(Ipv4TunnelTest, geneve_encap_v4_vlan_pop_params_are_correct) {
   InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                         insert_entry);
+  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, insert_entry);
   DumpTableEntry(table_entry);
 
   // Assert

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_test.cc
@@ -11,11 +11,13 @@
 
 namespace ovsp4rt {
 
+class GeneveEncapV6TableTest : public Ipv6TunnelTest {};
+
 //----------------------------------------------------------------------
 // PrepareV6GeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv6TunnelTest, GeneveEncapV6TableTest_minimal) {
+TEST_F(GeneveEncapV6TableTest, minimal) {
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
   constexpr bool insert_entry = true;

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_test.cc
@@ -15,7 +15,7 @@ namespace ovsp4rt {
 // PrepareV6GeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv6TunnelTest, geneve_encap_v6_params_are_correct) {
+TEST_F(Ipv6TunnelTest, GeneveEncapV6TableTest_minimal) {
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
   constexpr bool insert_entry = true;

--- a/ovs-p4rt/sidecar/testing/geneve_encap_vlan_pop_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_vlan_pop_v4_table_test.cc
@@ -11,11 +11,13 @@
 
 namespace ovsp4rt {
 
+class GeneveEncapVlanPopV4TableTest : public Ipv4TunnelTest {};
+
 //----------------------------------------------------------------------
 // PrepareGeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, GeneveEncapVlanPopV4TableTest_minimal) {
+TEST_F(GeneveEncapVlanPopV4TableTest, minimal) {
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
   constexpr bool insert_entry = true;

--- a/ovs-p4rt/sidecar/testing/l2_to_tunnel_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/l2_to_tunnel_v4_table_test.cc
@@ -1,7 +1,9 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareL2ToTunnelV6().
+// Unit test for PrepareL2ToTunnelV4().
+
+#include <arpa/inet.h>
 
 #include <iostream>
 #include <string>
@@ -16,7 +18,7 @@
 #include "p4info_text.h"
 #include "stratum/lib/utils.h"
 
-ABSL_FLAG(bool, dump_json, false, "Dump test output in JSON");
+ABSL_FLAG(bool, dump_json, false, "Dump output table_entry in JSON");
 
 namespace ovsp4rt {
 
@@ -29,9 +31,9 @@ using stratum::ParseProtoFromString;
 
 static ::p4::config::v1::P4Info p4info;
 
-class L2ToV6TunnelTest : public ::testing::Test {
+class L2ToTunnelV4TableTest : public ::testing::Test {
  protected:
-  L2ToV6TunnelTest() { dump_json_ = absl::GetFlag(FLAGS_dump_json); }
+  L2ToTunnelV4TableTest() { dump_json_ = absl::GetFlag(FLAGS_dump_json); }
 
   static void SetUpTestSuite() {
     ::util::Status status = stratum::ParseProtoFromString(P4INFO_TEXT, &p4info);
@@ -40,7 +42,7 @@ class L2ToV6TunnelTest : public ::testing::Test {
     }
   }
 
-  void SetUp() { SelectTable("l2_to_tunnel_v6"); }
+  void SetUp() { SelectTable("l2_to_tunnel_v4"); }
 
   //----------------------------
   // P4Info lookup methods
@@ -113,8 +115,27 @@ class L2ToV6TunnelTest : public ::testing::Test {
     }
   }
 
-  static inline uint32_t Ipv6AddrWord(const struct p4_ipaddr& ipaddr, int i) {
-    return ipaddr.ip.v6addr.__in6_u.__u6_addr32[i];
+  //----------------------------
+  // Initialization methods
+  //----------------------------
+
+  void InitFdbInfo() {
+    constexpr uint8_t MAC_ADDR[] = {0xde, 0xad, 0xbe, 0xef, 0x00, 0xe};
+    memcpy(fdb_info.mac_addr, MAC_ADDR, sizeof(fdb_info.mac_addr));
+  }
+
+  void InitTunnelInfo() {
+    constexpr char IPV4_DST_ADDR[] = "192.168.17.5";
+    constexpr int IPV4_PREFIX_LEN = 24;
+
+    EXPECT_EQ(inet_pton(AF_INET, IPV4_DST_ADDR,
+                        &fdb_info.tnl_info.remote_ip.ip.v4addr.s_addr),
+              1)
+        << "Error converting " << IPV4_DST_ADDR;
+    fdb_info.tnl_info.remote_ip.family = AF_INET;
+    fdb_info.tnl_info.remote_ip.prefix_len = IPV4_PREFIX_LEN;
+
+    SelectAction("set_tunnel_v4");
   }
 
   //----------------------------
@@ -122,56 +143,64 @@ class L2ToV6TunnelTest : public ::testing::Test {
   //----------------------------
 
   void CheckAction() const {
+    // ACTION_ID is defined (sanity check)
     ASSERT_NE(ACTION_ID, -1);
 
+    // Table entry specifies an action
     ASSERT_TRUE(table_entry.has_action());
     auto table_action = table_entry.action();
 
+    // Action ID is what we expect
     auto action = table_action.action();
     EXPECT_EQ(action.action_id(), ACTION_ID);
 
-    ASSERT_EQ(action.params_size(), 4);
+    // Only one parameter
+    ASSERT_EQ(action.params_size(), 1);
 
-    const struct p4_ipaddr& remote_ip = fdb_info.tnl_info.remote_ip;
+    // Param ID is what we expect
+    auto param = action.params()[0];
+    ASSERT_EQ(param.param_id(), GetParamId("dst_addr"));
 
-    // TODO(derek): look up param IDs by name.
-    // Allow for the possibility that params are not in order. (?)
-    for (int i = 0; i < action.params_size(); i++) {
-      auto param = action.params()[i];
-      ASSERT_EQ(param.param_id(), i + 1);
+    // Value has 4 bytes
+    auto param_value = param.value();
+    ASSERT_EQ(param_value.size(), 4);
 
-      auto param_value = param.value();
-      ASSERT_EQ(param_value.size(), 4);
-
-      auto word_value = ntohl(DecodeWordValue(param_value));
-      ASSERT_EQ(word_value, Ipv6AddrWord(remote_ip, i));
-    }
+    // Value is what we expect
+    auto word_value = ntohl(DecodeWordValue(param_value));
+    ASSERT_EQ(word_value, fdb_info.tnl_info.remote_ip.ip.v4addr.s_addr);
   }
 
   void CheckDetail() const {
-    EXPECT_EQ(detail.table_id, LOG_L2_TO_TUNNEL_V6_TABLE);
+    // LogTableId is correct for this table
+    EXPECT_EQ(detail.table_id, LOG_L2_TO_TUNNEL_V4_TABLE);
   }
 
   void CheckMatches() const {
-    constexpr char V6_KEY_DA[] = "hdrs.mac[vmeta.common.depth].da";
-    const int MFID_DA = GetMatchFieldId(V6_KEY_DA);
+    constexpr char V4_KEY_DA[] = "hdrs.mac[vmeta.common.depth].da";
+    const int MFID_DA = GetMatchFieldId(V4_KEY_DA);
 
-    // number of match fields
+    // Exactly one match field
     ASSERT_EQ(table_entry.match_size(), 1);
 
+    // Match Field ID is what we expect
     auto match = table_entry.match()[0];
     ASSERT_EQ(match.field_id(), MFID_DA);
 
+    // Value is what we expect
     CheckMacAddr(match);
   }
 
   void CheckMacAddr(const ::p4::v1::FieldMatch& match) const {
     constexpr int MAC_ADDR_SIZE = 6;
 
+    // This is an exact-match field
     ASSERT_TRUE(match.has_exact());
     const auto& match_value = match.exact().value();
+
+    // Value is correct for a mac address
     ASSERT_EQ(match_value.size(), MAC_ADDR_SIZE);
 
+    // Value is what we expect
     for (int i = 0; i < MAC_ADDR_SIZE; i++) {
       EXPECT_EQ(match_value[i] & 0xFF, fdb_info.mac_addr[i])
           << "mac_addr[" << i << "] is incorrect";
@@ -179,30 +208,16 @@ class L2ToV6TunnelTest : public ::testing::Test {
   }
 
   void CheckNoAction() const {
-    ASSERT_NE(ACTION_ID, -1);
+    // Table entry does not specify an action
     EXPECT_FALSE(table_entry.has_action());
   }
 
   void CheckTableEntry() const {
+    // Table is defined (sanity check)
     ASSERT_FALSE(TABLE == nullptr);
+
+    // Table ID is what we expect
     EXPECT_EQ(table_entry.table_id(), TABLE_ID);
-  }
-
-  void InitFdbInfo() {
-    constexpr uint8_t MAC_ADDR[] = {0xde, 0xad, 0xbe, 0xef, 0x00, 0xe};
-    constexpr uint32_t kIpAddrV6[] = {0, 66, 129, 512};
-    constexpr int kIpAddrV6Len = sizeof(kIpAddrV6) / sizeof(kIpAddrV6[0]);
-
-    memcpy(fdb_info.mac_addr, MAC_ADDR, sizeof(fdb_info.mac_addr));
-
-    fdb_info.tnl_info.remote_ip.family = AF_INET6;
-    // TODO(derek): replace this with pton()
-    for (int i = 0; i < kIpAddrV6Len; i++) {
-      fdb_info.tnl_info.remote_ip.ip.v6addr.__in6_u.__u6_addr32[i] =
-          kIpAddrV6[i];
-    }
-
-    SelectAction("set_tunnel_v6");
   }
 
   //----------------------------
@@ -229,14 +244,15 @@ class L2ToV6TunnelTest : public ::testing::Test {
 };
 
 //----------------------------------------------------------------------
-// L2ToV6TunnelTest()
+// L2ToTunnelV4TableTest
 //----------------------------------------------------------------------
-TEST_F(L2ToV6TunnelTest, remove_entry) {
+TEST_F(L2ToTunnelV4TableTest, remove_entry) {
   // Arrange
   InitFdbInfo();
+  InitTunnelInfo();
 
   // Act
-  PrepareL2ToTunnelV6(&table_entry, fdb_info, p4info, REMOVE_ENTRY, detail);
+  PrepareL2ToTunnelV4(&table_entry, fdb_info, p4info, REMOVE_ENTRY, detail);
   DumpTableEntry();
 
   // Assert
@@ -247,12 +263,13 @@ TEST_F(L2ToV6TunnelTest, remove_entry) {
   CheckNoAction();
 }
 
-TEST_F(L2ToV6TunnelTest, insert_entry) {
+TEST_F(L2ToTunnelV4TableTest, insert_entry) {
   // Arrange
   InitFdbInfo();
+  InitTunnelInfo();
 
   // Act
-  PrepareL2ToTunnelV6(&table_entry, fdb_info, p4info, INSERT_ENTRY, detail);
+  PrepareL2ToTunnelV4(&table_entry, fdb_info, p4info, INSERT_ENTRY, detail);
   DumpTableEntry();
 
   // Assert

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_test.cc
@@ -7,43 +7,44 @@
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
-#include "testing/ipv6_tunnel_test.h"
+#include "testing/ipv4_tunnel_test.h"
 
 namespace ovsp4rt {
 
+class VxlanEncapV4TableTest : public Ipv4TunnelTest {};
+
 //----------------------------------------------------------------------
-// PrepareV6VxlanEncapAndVlanPopTableEntry()
+// PrepareVxlanEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv6TunnelTest, vxlan_encap_v6_vlan_pop_params_are_correct) {
+TEST_F(VxlanEncapV4TableTest, minimal) {
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
   constexpr bool insert_entry = true;
 
-  constexpr uint32_t TABLE_ID = 34318005U;
-  constexpr uint32_t ACTION_ID = 28284062U;
+  constexpr uint32_t TABLE_ID = 40763773U;
+  constexpr uint32_t ACTION_ID = 20733968U;
 
   enum {
-    SRC_PORT_PARAM_ID = 7,
-    DST_PORT_PARAM_ID = 8,
-    VNI_PARAM_ID = 9,
+    SRC_PORT_PARAM_ID = 3,
+    DST_PORT_PARAM_ID = 4,
+    VNI_PARAM_ID = 5,
   };
 
   // Arrange
-  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                          insert_entry);
+  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, insert_entry);
   DumpTableEntry(table_entry);
 
   // Assert
-  EXPECT_EQ(table_entry.table_id(), TABLE_ID);
-
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
   ASSERT_TRUE(table_entry.has_action());
+
   auto table_action = table_entry.action();
   auto action = table_action.action();
-  EXPECT_EQ(action.action_id(), ACTION_ID);
+  ASSERT_EQ(action.action_id(), ACTION_ID);
 
   auto params = action.params();
   int num_params = action.params_size();
@@ -56,7 +57,6 @@ TEST_F(Ipv6TunnelTest, vxlan_encap_v6_vlan_pop_params_are_correct) {
     auto param = params[i];
     int param_id = param.param_id();
     auto param_value = param.value();
-
     if (param_id == SRC_PORT_PARAM_ID) {
       src_port = DecodePortValue(param_value);
     } else if (param_id == DST_PORT_PARAM_ID) {
@@ -66,6 +66,7 @@ TEST_F(Ipv6TunnelTest, vxlan_encap_v6_vlan_pop_params_are_correct) {
     }
   }
 
+#if defined(ES2K_TARGET)
   ASSERT_TRUE(src_port.has_value());
 
   if (check_src_port_) {
@@ -74,6 +75,7 @@ TEST_F(Ipv6TunnelTest, vxlan_encap_v6_vlan_pop_params_are_correct) {
     // set the src_port param to (dst_port * 2).
     EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
   }
+#endif
 
   ASSERT_TRUE(dst_port.has_value());
   EXPECT_EQ(dst_port.value(), DST_PORT);

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_test.cc
@@ -7,42 +7,45 @@
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
-#include "testing/ipv4_tunnel_test.h"
+#include "testing/ipv6_tunnel_test.h"
 
 namespace ovsp4rt {
 
+class VxlanEncapV6TableTest : public Ipv6TunnelTest {};
+
 //----------------------------------------------------------------------
-// Test PrepareGeneveEncapTableEntry()
+// PrepareV6VxlanEncapTableEntry
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, geneve_encap_v4_params_are_correct) {
+TEST_F(VxlanEncapV6TableTest, minimal) {
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
   constexpr bool insert_entry = true;
 
-  constexpr uint32_t TABLE_ID = 41319073U;
-  constexpr uint32_t ACTION_ID = 25818889U;
+  constexpr uint32_t TABLE_ID = 46225003U;
+  constexpr uint32_t ACTION_ID = 30345128U;
 
   enum {
-    SRC_PORT_PARAM_ID = 3,
-    DST_PORT_PARAM_ID = 4,
-    VNI_PARAM_ID = 5,
+    SRC_PORT_PARAM_ID = 7,
+    DST_PORT_PARAM_ID = 8,
+    VNI_PARAM_ID = 9,
   };
 
   // Arrange
-  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
+  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, insert_entry);
+  PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,
+                                insert_entry);
   DumpTableEntry(table_entry);
 
   // Assert
-  EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
 
   ASSERT_TRUE(table_entry.has_action());
   auto table_action = table_entry.action();
   auto action = table_action.action();
-  EXPECT_EQ(action.action_id(), ACTION_ID);
+  ASSERT_EQ(action.action_id(), ACTION_ID);
 
   auto params = action.params();
   int num_params = action.params_size();
@@ -55,7 +58,6 @@ TEST_F(Ipv4TunnelTest, geneve_encap_v4_params_are_correct) {
     auto param = params[i];
     int param_id = param.param_id();
     auto param_value = param.value();
-
     if (param_id == SRC_PORT_PARAM_ID) {
       src_port = DecodePortValue(param_value);
     } else if (param_id == DST_PORT_PARAM_ID) {

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_vlan_pop_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_vlan_pop_v4_table_test.cc
@@ -11,11 +11,13 @@
 
 namespace ovsp4rt {
 
+class VxlanEncapVlanPopV4TableTest : public Ipv4TunnelTest {};
+
 //----------------------------------------------------------------------
 // PrepareVxlanEncapAndVlanPopTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, vxlan_encap_v4_vlan_pop_params_are_correct) {
+TEST_F(VxlanEncapVlanPopV4TableTest, minimal) {
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
   constexpr bool insert_entry = true;

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_vlan_pop_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_vlan_pop_v6_table_test.cc
@@ -11,17 +11,19 @@
 
 namespace ovsp4rt {
 
+class VxlanEncapVlanPopV6TableTest : public Ipv6TunnelTest {};
+
 //----------------------------------------------------------------------
-// PrepareV6VxlanEncapTableEntry
+// PrepareV6VxlanEncapAndVlanPopTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv6TunnelTest, vxlan_encap_v6_params_are_correct) {
+TEST_F(VxlanEncapVlanPopV6TableTest, minimal) {
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
   constexpr bool insert_entry = true;
 
-  constexpr uint32_t TABLE_ID = 46225003U;
-  constexpr uint32_t ACTION_ID = 30345128U;
+  constexpr uint32_t TABLE_ID = 34318005U;
+  constexpr uint32_t ACTION_ID = 28284062U;
 
   enum {
     SRC_PORT_PARAM_ID = 7,
@@ -33,17 +35,17 @@ TEST_F(Ipv6TunnelTest, vxlan_encap_v6_params_are_correct) {
   InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                insert_entry);
+  PrepareV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                          insert_entry);
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  EXPECT_EQ(table_entry.table_id(), TABLE_ID);
 
   ASSERT_TRUE(table_entry.has_action());
   auto table_action = table_entry.action();
   auto action = table_action.action();
-  ASSERT_EQ(action.action_id(), ACTION_ID);
+  EXPECT_EQ(action.action_id(), ACTION_ID);
 
   auto params = action.params();
   int num_params = action.params_size();
@@ -56,6 +58,7 @@ TEST_F(Ipv6TunnelTest, vxlan_encap_v6_params_are_correct) {
     auto param = params[i];
     int param_id = param.param_id();
     auto param_value = param.value();
+
     if (param_id == SRC_PORT_PARAM_ID) {
       src_port = DecodePortValue(param_value);
     } else if (param_id == DST_PORT_PARAM_ID) {


### PR DESCRIPTION
- Renamed so everything's a `_table_test`, `_v4_table_test`, or `_v6_table_test`.

- Defined subclasses for the minimal vxlan and geneve tests, and renamed the test case to `minimal`.