### PR TITLE
[ovsp4rt] Revise geneve and vxlan encap tests

### DIFF
--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_entry_test.cc
@@ -11,72 +11,97 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 41319073U;
+constexpr uint32_t ACTION_ID = 25818889U;
+
+enum {
+  SRC_PORT_PARAM_ID = 3,
+  DST_PORT_PARAM_ID = 4,
+  VNI_PARAM_ID = 5,
+};
+
+class GeneveEncapV4TableEntryTest : public Ipv4TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    auto table_action = table_entry.action();
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // Test PrepareGeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, geneve_encap_v4_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 41319073U;
-  constexpr uint32_t ACTION_ID = 25818889U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 3,
-    DST_PORT_PARAM_ID = 4,
-    VNI_PARAM_ID = 5,
-  };
-
+TEST_F(GeneveEncapV4TableEntryTest, remove_entry) {
   // Arrange
   InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, insert_entry);
+  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
-  EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckNoAction();
+}
 
-  ASSERT_TRUE(table_entry.has_action());
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  EXPECT_EQ(action.action_id(), ACTION_ID);
+TEST_F(GeneveEncapV4TableEntryTest, insert_entry) {
+  // Arrange
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
@@ -11,73 +11,99 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 47977422U;
+constexpr uint32_t ACTION_ID = 26665268U;
+
+enum {
+  SRC_PORT_PARAM_ID = 3,
+  DST_PORT_PARAM_ID = 4,
+  VNI_PARAM_ID = 5,
+};
+
+class GeneveEncapV4VlanPopTest : public Ipv4TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    auto table_action = table_entry.action();
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // PrepareGeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, geneve_encap_v4_vlan_pop_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 47977422U;
-  constexpr uint32_t ACTION_ID = 26665268U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 3,
-    DST_PORT_PARAM_ID = 4,
-    VNI_PARAM_ID = 5,
-  };
-
+TEST_F(GeneveEncapV4VlanPopTest, remove_entry) {
   // Arrange
   InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
   // Act
   PrepareGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                         insert_entry);
+                                         REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
   EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckNoAction();
+}
 
-  ASSERT_TRUE(table_entry.has_action());
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  EXPECT_EQ(action.action_id(), ACTION_ID);
+TEST_F(GeneveEncapV4VlanPopTest, insert_entry) {
+  // Arrange
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                         INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
@@ -1,6 +1,12 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+// Unit test for PrepareGeneveEncapAndVlanPopTableEntry().
+
+// TODO(derek):
+// - Replace hard-coded IDs with p4info lookups.
+// - Make sure all action params are checked.
+
 #include <stdint.h>
 
 #include "absl/types/optional.h"
@@ -16,6 +22,10 @@ constexpr bool REMOVE_ENTRY = false;
 
 constexpr uint32_t TABLE_ID = 47977422U;
 constexpr uint32_t ACTION_ID = 26665268U;
+
+enum {
+  MF_MOD_BLOB_PTR = 1,
+};
 
 enum {
   SRC_PORT_PARAM_ID = 3,
@@ -69,9 +79,30 @@ class GeneveEncapV4VlanPopTest : public Ipv4TunnelTest {
     EXPECT_EQ(vni.value(), VNI);
   }
 
-  void CheckNoAction() const {
-    ASSERT_FALSE(table_entry.has_action());
+  void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }
+
+  void CheckMatches() const {
+    ASSERT_EQ(table_entry.match_size(), 1);
+
+    auto& match = table_entry.match()[0];
+    ASSERT_EQ(match.field_id(), MF_MOD_BLOB_PTR);
+
+    CheckVniMatch(match);
   }
+
+  void CheckVniMatch(const ::p4::v1::FieldMatch& match) const {
+    constexpr int VNI_SIZE = 3;
+
+    ASSERT_TRUE(match.has_exact());
+    const auto& match_value = match.exact().value();
+
+    ASSERT_EQ(match_value.size(), VNI_SIZE);
+
+    uint32_t vni_value = DecodeVniValue(match_value);
+    EXPECT_EQ(vni_value, tunnel_info.vni);
+  }
+
+  void CheckTableEntry() const { ASSERT_EQ(table_entry.table_id(), TABLE_ID); }
 };
 
 //----------------------------------------------------------------------
@@ -88,7 +119,8 @@ TEST_F(GeneveEncapV4VlanPopTest, remove_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
+  CheckMatches();
   CheckNoAction();
 }
 
@@ -102,7 +134,7 @@ TEST_F(GeneveEncapV4VlanPopTest, insert_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
   CheckAction();
 }
 

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
@@ -1,6 +1,12 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+// Unit test for PrepareV6GeneveEncapTableEntry().
+
+// TODO(derek):
+// - Replace hard-coded IDs with p4info lookups.
+// - Check all action params.
+
 #include <stdint.h>
 
 #include "absl/types/optional.h"
@@ -16,6 +22,10 @@ constexpr bool REMOVE_ENTRY = false;
 
 constexpr uint32_t TABLE_ID = 42283616U;
 constexpr uint32_t ACTION_ID = 29610186U;
+
+enum {
+  MF_MOD_BLOB_PTR = 1,
+};
 
 enum {
   SRC_PORT_PARAM_ID = 7,
@@ -69,9 +79,30 @@ class GeneveEncapV6TableEntryTest : public Ipv6TunnelTest {
     EXPECT_EQ(vni.value(), VNI);
   }
 
-  void CheckNoAction() const {
-    ASSERT_FALSE(table_entry.has_action());
+  void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }
+
+  void CheckMatches() const {
+    ASSERT_EQ(table_entry.match_size(), 1);
+
+    auto& match = table_entry.match()[0];
+    ASSERT_EQ(match.field_id(), MF_MOD_BLOB_PTR);
+
+    CheckVniMatch(match);
   }
+
+  void CheckVniMatch(const ::p4::v1::FieldMatch& match) const {
+    constexpr int VNI_SIZE = 3;
+
+    ASSERT_TRUE(match.has_exact());
+    const auto& match_value = match.exact().value();
+
+    ASSERT_EQ(match_value.size(), VNI_SIZE);
+
+    uint32_t vni_value = DecodeVniValue(match_value);
+    EXPECT_EQ(vni_value, tunnel_info.vni);
+  }
+
+  void CheckTableEntry() const { ASSERT_EQ(table_entry.table_id(), TABLE_ID); }
 };
 
 //----------------------------------------------------------------------
@@ -88,7 +119,8 @@ TEST_F(GeneveEncapV6TableEntryTest, remove_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
+  CheckMatches();
   CheckNoAction();
 }
 
@@ -102,7 +134,7 @@ TEST_F(GeneveEncapV6TableEntryTest, insert_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
   CheckAction();
 }
 

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
@@ -11,73 +11,99 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 42283616U;
+constexpr uint32_t ACTION_ID = 29610186U;
+
+enum {
+  SRC_PORT_PARAM_ID = 7,
+  DST_PORT_PARAM_ID = 8,
+  VNI_PARAM_ID = 9,
+};
+
+class GeneveEncapV6TableEntryTest : public Ipv6TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    auto table_action = table_entry.action();
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // PrepareV6GeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv6TunnelTest, geneve_encap_v6_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 42283616U;
-  constexpr uint32_t ACTION_ID = 29610186U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 7,
-    DST_PORT_PARAM_ID = 8,
-    VNI_PARAM_ID = 9,
-  };
-
+TEST_F(GeneveEncapV6TableEntryTest, remove_entry) {
   // Arrange
   InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
   // Act
   PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                 insert_entry);
+                                 REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
   ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckNoAction();
+}
 
-  ASSERT_TRUE(table_entry.has_action());
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  ASSERT_EQ(action.action_id(), ACTION_ID);
+TEST_F(GeneveEncapV6TableEntryTest, insert_entry) {
+  // Arrange
+  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
+                                 INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_entry_test.cc
@@ -11,73 +11,100 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 40763773U;
+constexpr uint32_t ACTION_ID = 20733968U;
+
+enum {
+  SRC_PORT_PARAM_ID = 3,
+  DST_PORT_PARAM_ID = 4,
+  VNI_PARAM_ID = 5,
+};
+
+class VxlanEncapV4TableEntryTest : public Ipv4TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+
+    auto table_action = table_entry.action();
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+  #if defined(ES2K_TARGET)
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+  #endif
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // PrepareVxlanEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, vxlan_encap_v4_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 40763773U;
-  constexpr uint32_t ACTION_ID = 20733968U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 3,
-    DST_PORT_PARAM_ID = 4,
-    VNI_PARAM_ID = 5,
-  };
-
+TEST_F(VxlanEncapV4TableEntryTest, remove_entry) {
   // Arrange
   InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, insert_entry);
+  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
   ASSERT_EQ(table_entry.table_id(), TABLE_ID);
-  ASSERT_TRUE(table_entry.has_action());
+  CheckNoAction();
+}
 
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  ASSERT_EQ(action.action_id(), ACTION_ID);
+TEST_F(VxlanEncapV4TableEntryTest, insert_entry) {
+  // Arrange
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-#if defined(ES2K_TARGET)
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-#endif
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_vlan_pop_test.cc
@@ -11,72 +11,100 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 39675860U;
+constexpr uint32_t ACTION_ID = 26114242U;
+
+enum {
+  SRC_PORT_PARAM_ID = 3,
+  DST_PORT_PARAM_ID = 4,
+  VNI_PARAM_ID = 5,
+};
+
+class VxlanEncapV4VlanPopTest : public Ipv4TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    auto table_action = table_entry.action();
+
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // PrepareVxlanEncapAndVlanPopTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, vxlan_encap_v4_vlan_pop_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 39675860U;
-  constexpr uint32_t ACTION_ID = 26114242U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 3,
-    DST_PORT_PARAM_ID = 4,
-    VNI_PARAM_ID = 5,
-  };
-
+TEST_F(VxlanEncapV4VlanPopTest, remove_entry) {
   // Arrange
   InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
   PrepareVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                        insert_entry);
+                                        REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
   ASSERT_EQ(table_entry.table_id(), TABLE_ID);
-  ASSERT_TRUE(table_entry.has_action());
+  CheckNoAction();
+}
 
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  ASSERT_EQ(action.action_id(), ACTION_ID);
+TEST_F(VxlanEncapV4VlanPopTest, insert_entry) {
+  // Arrange
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                        INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
@@ -11,72 +11,99 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 46225003U;
+constexpr uint32_t ACTION_ID = 30345128U;
+
+enum {
+  SRC_PORT_PARAM_ID = 7,
+  DST_PORT_PARAM_ID = 8,
+  VNI_PARAM_ID = 9,
+};
+
+class EncapV6TableEntryTest : public Ipv6TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    auto table_action = table_entry.action();
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // PrepareV6VxlanEncapTableEntry
 //----------------------------------------------------------------------
 
-TEST_F(Ipv6TunnelTest, vxlan_encap_v6_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 46225003U;
-  constexpr uint32_t ACTION_ID = 30345128U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 7,
-    DST_PORT_PARAM_ID = 8,
-    VNI_PARAM_ID = 9,
-  };
-
+TEST_F(EncapV6TableEntryTest, remove_entry) {
   // Arrange
   InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
   PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                insert_entry);
+                                REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
   ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckNoAction();
+}
 
-  ASSERT_TRUE(table_entry.has_action());
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  ASSERT_EQ(action.action_id(), ACTION_ID);
+TEST_F(EncapV6TableEntryTest, insert_entry) {
+  // Arrange
+  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,
+                                INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
@@ -1,6 +1,12 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+// Unit test for PrepareV6VxlanEncapTableEntry().
+
+// TODO(derek):
+// - Replace hard-coded IDs with p4info lookups.
+// - Check all action params.
+
 #include <stdint.h>
 
 #include "absl/types/optional.h"
@@ -16,6 +22,10 @@ constexpr bool REMOVE_ENTRY = false;
 
 constexpr uint32_t TABLE_ID = 46225003U;
 constexpr uint32_t ACTION_ID = 30345128U;
+
+enum {
+  MF_MOD_BLOB_PTR = 1,
+};
 
 enum {
   SRC_PORT_PARAM_ID = 7,
@@ -69,9 +79,30 @@ class EncapV6TableEntryTest : public Ipv6TunnelTest {
     EXPECT_EQ(vni.value(), VNI);
   }
 
-  void CheckNoAction() const {
-    ASSERT_FALSE(table_entry.has_action());
+  void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }
+
+  void CheckMatches() const {
+    ASSERT_EQ(table_entry.match_size(), 1);
+
+    auto& match = table_entry.match()[0];
+    ASSERT_EQ(match.field_id(), MF_MOD_BLOB_PTR);
+
+    CheckVniMatch(match);
   }
+
+  void CheckVniMatch(const ::p4::v1::FieldMatch& match) const {
+    constexpr int VNI_SIZE = 3;
+
+    ASSERT_TRUE(match.has_exact());
+    const auto& match_value = match.exact().value();
+
+    ASSERT_EQ(match_value.size(), VNI_SIZE);
+
+    uint32_t vni_value = DecodeVniValue(match_value);
+    EXPECT_EQ(vni_value, tunnel_info.vni);
+  }
+
+  void CheckTableEntry() const { ASSERT_EQ(table_entry.table_id(), TABLE_ID); }
 };
 
 //----------------------------------------------------------------------
@@ -88,7 +119,8 @@ TEST_F(EncapV6TableEntryTest, remove_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
+  CheckMatches();
   CheckNoAction();
 }
 
@@ -102,7 +134,7 @@ TEST_F(EncapV6TableEntryTest, insert_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
   CheckAction();
 }
 

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
@@ -1,6 +1,12 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+// Unit test for PrepareV6VxlanEncapAndVlanPopTableEntry().
+
+// TODO(derek):
+// - Replace hard-coded IDs with p4info lookups.
+// - Check all action params.
+
 #include <stdint.h>
 
 #include "absl/types/optional.h"
@@ -16,6 +22,10 @@ constexpr bool REMOVE_ENTRY = false;
 
 constexpr uint32_t TABLE_ID = 34318005U;
 constexpr uint32_t ACTION_ID = 28284062U;
+
+enum {
+  MF_MOD_BLOB_PTR = 1,
+};
 
 enum {
   SRC_PORT_PARAM_ID = 7,
@@ -69,9 +79,30 @@ class VxlanEncapV6VlanPopTest : public Ipv6TunnelTest {
     EXPECT_EQ(vni.value(), VNI);
   }
 
-  void CheckNoAction() const {
-    ASSERT_FALSE(table_entry.has_action());
+  void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }
+
+  void CheckMatches() const {
+    ASSERT_EQ(table_entry.match_size(), 1);
+
+    auto& match = table_entry.match()[0];
+    ASSERT_EQ(match.field_id(), MF_MOD_BLOB_PTR);
+
+    CheckVniMatch(match);
   }
+
+  void CheckVniMatch(const ::p4::v1::FieldMatch& match) const {
+    constexpr int VNI_SIZE = 3;
+
+    ASSERT_TRUE(match.has_exact());
+    const auto& match_value = match.exact().value();
+
+    ASSERT_EQ(match_value.size(), VNI_SIZE);
+
+    uint32_t vni_value = DecodeVniValue(match_value);
+    EXPECT_EQ(vni_value, tunnel_info.vni);
+  }
+
+  void CheckTableEntry() const { ASSERT_EQ(table_entry.table_id(), TABLE_ID); }
 };
 
 //----------------------------------------------------------------------
@@ -88,7 +119,8 @@ TEST_F(VxlanEncapV6VlanPopTest, remove_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
+  CheckMatches();
   CheckNoAction();
 }
 
@@ -102,7 +134,7 @@ TEST_F(VxlanEncapV6VlanPopTest, insert_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
   CheckAction();
 }
 

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
@@ -11,73 +11,99 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 34318005U;
+constexpr uint32_t ACTION_ID = 28284062U;
+
+enum {
+  SRC_PORT_PARAM_ID = 7,
+  DST_PORT_PARAM_ID = 8,
+  VNI_PARAM_ID = 9,
+};
+
+class VxlanEncapV6VlanPopTest : public Ipv6TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    auto table_action = table_entry.action();
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // PrepareV6VxlanEncapAndVlanPopTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv6TunnelTest, vxlan_encap_v6_vlan_pop_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 34318005U;
-  constexpr uint32_t ACTION_ID = 28284062U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 7,
-    DST_PORT_PARAM_ID = 8,
-    VNI_PARAM_ID = 9,
-  };
-
+TEST_F(VxlanEncapV6VlanPopTest, remove_entry) {
   // Arrange
   InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
   PrepareV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                          insert_entry);
+                                          REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
   EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckNoAction();
+}
 
-  ASSERT_TRUE(table_entry.has_action());
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  EXPECT_EQ(action.action_id(), ACTION_ID);
+TEST_F(VxlanEncapV6VlanPopTest, insert_entry) {
+  // Arrange
+  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                          INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt


### PR DESCRIPTION
1. Created a unique subclass for each encapsulation test, making it possible for the test to have multiple test cases.
2. Extracted the existing test code into a `CheckAction()` method in the test class. This makes the test bodies smaller and much easier to understand.
3. Defined a `CheckMatches()` method to verify the match fields. For these tests, they all match on the VNI.
4. Created `remove_entry` test cases to complement the existing `insert_entry` cases.

----

I made all the changes at the same time because I need the tests to verify the 24-bit VNI changes. This results in a rather unwieldy PR. I can break it into smaller PRs, if you would like.

The changes are actually simpler than they look. The problem is that the Extract Method refactoring resulted in a substantial portion of the original code being indented. The only difference is in the leading white space, but GitHub sees this as a large insertion and a large deletion occurring in the same area of the file. Pfui.