### PR TITLE
[ovsp4rt] Update tests to use BaseTableTest class

### DIFF
--- a/ovs-p4rt/sidecar/testing/base_table_test.h
+++ b/ovs-p4rt/sidecar/testing/base_table_test.h
@@ -33,6 +33,9 @@ using google::protobuf::util::MessageToJsonString;
 #endif
 using stratum::ParseProtoFromString;
 
+constexpr uint32_t VNI_VALUE_MASK = 0x0000ffffU;
+constexpr uint32_t TUNNEL_ID_MASK = 0x00ffffffU;
+
 constexpr bool INSERT_ENTRY = true;
 constexpr bool REMOVE_ENTRY = false;
 
@@ -59,22 +62,24 @@ class BaseTableTest : public ::testing::Test {
   // Utility methods
   //----------------------------
 
+  // Decodes a port value and returns it as an unsigned integer.
   static uint16_t DecodePortValue(const std::string& string_value) {
     uint16_t port_value = DecodeWordValue(string_value) & 0xffff;
     // Port values are encoded low byte first.
     return ntohs(port_value);
   }
 
-  // Decodes a 24-bit parameter and returns its value as an unsigned integer.
+  // Decodes a tunnel_id value and returns it as an unsigned integer.
   static uint32_t DecodeTunnelId(const std::string& string_value) {
-    return DecodeWordValue(string_value) & 0xffffff;
+    return DecodeWordValue(string_value) & TUNNEL_ID_MASK;
   }
 
+  // Decodes a vni value and returns it as an unsigned integer.
   static uint16_t DecodeVniValue(const std::string& string_value) {
-    return DecodeWordValue(string_value) & 0xffff;
+    return DecodeWordValue(string_value) & VNI_VALUE_MASK;
   }
 
-  // Decodes a parameter and returns its value as an unsigned integer.
+  // Decodes a parameter value and returns it as an unsigned integer.
   static uint32_t DecodeWordValue(const std::string& string_value) {
     uint32_t word_value = 0;
     for (int i = 0; i < string_value.size(); i++) {

--- a/ovs-p4rt/sidecar/testing/rx_tunnel_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/rx_tunnel_v4_table_test.cc
@@ -9,52 +9,18 @@
 #include <iostream>
 #include <string>
 
+#include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
-#include "p4/config/v1/p4info.pb.h"
-#include "p4/v1/p4runtime.pb.h"
-#include "p4info_helper.h"
-#include "p4info_text.h"
-#include "stratum/lib/utils.h"
 
 namespace ovsp4rt {
 
-using stratum::ParseProtoFromString;
-
-constexpr bool INSERT_ENTRY = true;
-constexpr bool REMOVE_ENTRY = false;
-
-static ::p4::config::v1::P4Info p4info;
-
-class RxTunnelPortV4TableTest : public ::testing::Test {
+class RxTunnelPortV4TableTest : public BaseTableTest {
  protected:
-  RxTunnelPortV4TableTest() : helper(p4info) {}
-
-  static void SetUpTestSuite() {
-    ::util::Status status = ParseProtoFromString(P4INFO_TEXT, &p4info);
-    if (!status.ok()) {
-      std::exit(EXIT_FAILURE);
-    }
-  }
+  RxTunnelPortV4TableTest() {}
 
   void SetUp() { helper.SelectTable("rx_ipv4_tunnel_source_port"); }
-
-  //----------------------------
-  // Utility methods
-  //----------------------------
-
-  static uint16_t DecodeVniValue(const std::string& string_value) {
-    return DecodeWordValue(string_value) & 0xffff;
-  }
-
-  static uint32_t DecodeWordValue(const std::string& string_value) {
-    uint32_t word_value = 0;
-    for (int i = 0; i < string_value.size(); i++) {
-      word_value = (word_value << 8) | (string_value[i] & 0xff);
-    }
-    return word_value;
-  }
 
   //----------------------------
   // Initialization methods
@@ -164,11 +130,7 @@ class RxTunnelPortV4TableTest : public ::testing::Test {
   //----------------------------
   // Protected member data
   //----------------------------
-
-  P4InfoHelper helper;
-
   struct tunnel_info tunnel_info = {0};
-  ::p4::v1::TableEntry table_entry;
 };
 
 //----------------------------------------------------------------------

--- a/ovs-p4rt/sidecar/testing/rx_tunnel_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/rx_tunnel_v6_table_test.cc
@@ -9,34 +9,16 @@
 #include <iostream>
 #include <string>
 
+#include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
-#include "p4/config/v1/p4info.pb.h"
-#include "p4/v1/p4runtime.pb.h"
-#include "p4info_helper.h"
-#include "p4info_text.h"
-#include "stratum/lib/utils.h"
 
 namespace ovsp4rt {
 
-using stratum::ParseProtoFromString;
-
-constexpr bool INSERT_ENTRY = true;
-constexpr bool REMOVE_ENTRY = false;
-
-static ::p4::config::v1::P4Info p4info;
-
-class RxTunnelPortV6TableTest : public ::testing::Test {
+class RxTunnelPortV6TableTest : public BaseTableTest {
  protected:
-  RxTunnelPortV6TableTest() : helper(p4info) {}
-
-  static void SetUpTestSuite() {
-    ::util::Status status = ParseProtoFromString(P4INFO_TEXT, &p4info);
-    if (!status.ok()) {
-      std::exit(EXIT_FAILURE);
-    }
-  }
+  RxTunnelPortV6TableTest() {}
 
   void SetUp() { helper.SelectTable("rx_ipv6_tunnel_source_port"); }
 
@@ -58,18 +40,6 @@ class RxTunnelPortV6TableTest : public ::testing::Test {
       }
       ipv6_addr.push_back(ntohl(word_value));
     }
-  }
-
-  static uint16_t DecodeVniValue(const std::string& string_value) {
-    return DecodeWordValue(string_value) & 0xffff;
-  }
-
-  static uint32_t DecodeWordValue(const std::string& string_value) {
-    uint32_t word_value = 0;
-    for (int i = 0; i < string_value.size(); i++) {
-      word_value = (word_value << 8) | (string_value[i] & 0xff);
-    }
-    return word_value;
   }
 
   static inline uint32_t Ipv6AddrWord(const struct p4_ipaddr& ipaddr, int i) {
@@ -192,11 +162,7 @@ class RxTunnelPortV6TableTest : public ::testing::Test {
   //----------------------------
   // Protected member data
   //----------------------------
-
-  P4InfoHelper helper;
-
   struct tunnel_info tunnel_info = {0};
-  ::p4::v1::TableEntry table_entry;
 };
 
 //----------------------------------------------------------------------

--- a/ovs-p4rt/sidecar/testing/vxlan_decap_mod_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_decap_mod_entry_test.cc
@@ -8,94 +8,24 @@
 #include <iostream>
 #include <string>
 
+#include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
-#include "p4/config/v1/p4info.pb.h"
-#include "p4/v1/p4runtime.pb.h"
-#include "p4info_text.h"
-#include "stratum/lib/utils.h"
 
 namespace ovsp4rt {
 
-using stratum::ParseProtoFromString;
-
-constexpr bool INSERT_ENTRY = true;
-constexpr bool REMOVE_ENTRY = false;
-
-static ::p4::config::v1::P4Info p4info;
-
-class VxlanDecapModEntryTest : public ::testing::Test {
+class VxlanDecapModEntryTest : public BaseTableTest {
  protected:
   VxlanDecapModEntryTest() {}
 
-  static void SetUpTestSuite() {
-    ::util::Status status = ParseProtoFromString(P4INFO_TEXT, &p4info);
-    if (!status.ok()) {
-      std::exit(EXIT_FAILURE);
-    }
-  }
-
-  void SetUp() { SelectTable("vxlan_decap_mod_table"); }
-
-  //----------------------------
-  // P4Info lookup methods
-  //----------------------------
-
-  int GetMatchFieldId(const std::string& mf_name) const {
-    for (const auto& mf : TABLE->match_fields()) {
-      if (mf.name() == mf_name) {
-        return mf.id();
-      }
-    }
-    return -1;
-  }
-
-  void SelectAction(const std::string& action_name) {
-    for (const auto& action : p4info.actions()) {
-      const auto& pre = action.preamble();
-      if (pre.name() == action_name || pre.alias() == action_name) {
-        ACTION = &action;
-        ACTION_ID = pre.id();
-        return;
-      }
-    }
-    std::cerr << "Action '" << action_name << "' not found!\n";
-  }
-
-  void SelectTable(const std::string& table_name) {
-    for (const auto& table : p4info.tables()) {
-      const auto& pre = table.preamble();
-      if (pre.name() == table_name || pre.alias() == table_name) {
-        TABLE = &table;
-        TABLE_ID = pre.id();
-        return;
-      }
-    }
-    std::cerr << "Table '" << table_name << "' not found!\n";
-  }
-
-  //----------------------------
-  // Utility methods
-  //----------------------------
-
-  static uint32_t DecodeWordValue(const std::string& string_value) {
-    uint32_t word_value = 0;
-    for (int i = 0; i < string_value.size(); i++) {
-      word_value = (word_value << 8) | (string_value[i] & 0xff);
-    }
-    return word_value;
-  }
-
-  static uint16_t DecodeVniValue(const std::string& string_value) {
-    return DecodeWordValue(string_value) & 0xffff;
-  }
+  void SetUp() { helper.SelectTable("vxlan_decap_mod_table"); }
 
   //----------------------------
   // Initialization methods
   //----------------------------
 
-  void InitAction() { SelectAction("vxlan_decap_outer_hdr"); }
+  void InitAction() { helper.SelectAction("vxlan_decap_outer_hdr"); }
 
   void InitTunnelInfo() { tunnel_info.vni = 0x1776; }
 
@@ -104,20 +34,18 @@ class VxlanDecapModEntryTest : public ::testing::Test {
   //----------------------------
 
   void CheckAction() const {
-    ASSERT_NE(ACTION_ID, -1);
-
     ASSERT_TRUE(table_entry.has_action());
     auto table_action = table_entry.action();
 
     auto action = table_action.action();
-    EXPECT_EQ(action.action_id(), ACTION_ID);
+    EXPECT_EQ(action.action_id(), helper.action_id());
 
     EXPECT_EQ(action.params_size(), 0);
   }
 
   void CheckMatches() const {
     constexpr char MOD_BLOB_PTR[] = "vmeta.common.mod_blob_ptr";
-    const int MF_MOD_BLOB_PTR = GetMatchFieldId(MOD_BLOB_PTR);
+    const int MF_MOD_BLOB_PTR = helper.GetMatchFieldId(MOD_BLOB_PTR);
 
     ASSERT_EQ(table_entry.match_size(), 1);
 
@@ -130,8 +58,8 @@ class VxlanDecapModEntryTest : public ::testing::Test {
   void CheckNoAction() const { EXPECT_FALSE(table_entry.has_action()); }
 
   void CheckTableEntry() const {
-    ASSERT_FALSE(TABLE == nullptr);
-    EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+    ASSERT_TRUE(helper.has_table());
+    EXPECT_EQ(table_entry.table_id(), helper.table_id());
   }
 
   void CheckVniValue(const ::p4::v1::FieldMatch& match) const {
@@ -150,20 +78,7 @@ class VxlanDecapModEntryTest : public ::testing::Test {
   // Protected member data
   //----------------------------
 
-  // Working variables
   struct tunnel_info tunnel_info = {0};
-  ::p4::v1::TableEntry table_entry;
-
-  // Comparison variables
-  uint32_t TABLE_ID;
-  int ACTION_ID = -1;
-
- private:
-  //----------------------------
-  // Private member data
-  //----------------------------
-  const ::p4::config::v1::Action* ACTION = nullptr;
-  const ::p4::config::v1::Table* TABLE = nullptr;
 };
 
 //----------------------------------------------------------------------


### PR DESCRIPTION
- Modified several tests to use BaseTableTest as their parent class.

The immediate motivation is to eliminate local definitions of `DecodeVsiValue()`, in preparation for supporting 24-bit VSIs.