### PR TITLE
[ovsp4rt] Support 24-bit VNIs in unit tests

### DIFF
--- a/ovs-p4rt/sidecar/testing/base_table_test.h
+++ b/ovs-p4rt/sidecar/testing/base_table_test.h
@@ -75,7 +75,7 @@ class BaseTableTest : public ::testing::Test {
   }
 
   // Decodes a vni value and returns it as an unsigned integer.
-  static uint16_t DecodeVniValue(const std::string& string_value) {
+  static uint32_t DecodeVniValue(const std::string& string_value) {
     return DecodeWordValue(string_value) & VNI_VALUE_MASK;
   }
 

--- a/ovs-p4rt/sidecar/testing/base_table_test.h
+++ b/ovs-p4rt/sidecar/testing/base_table_test.h
@@ -33,6 +33,9 @@ using google::protobuf::util::MessageToJsonString;
 #endif
 using stratum::ParseProtoFromString;
 
+constexpr uint32_t VNI_VALUE_MASK = 0x0000ffffU;
+constexpr uint32_t TUNNEL_ID_MASK = 0x00ffffffU;
+
 constexpr bool INSERT_ENTRY = true;
 constexpr bool REMOVE_ENTRY = false;
 
@@ -59,22 +62,24 @@ class BaseTableTest : public ::testing::Test {
   // Utility methods
   //----------------------------
 
+  // Decodes a port value and returns it as an unsigned integer.
   static uint16_t DecodePortValue(const std::string& string_value) {
     uint16_t port_value = DecodeWordValue(string_value) & 0xffff;
     // Port values are encoded low byte first.
     return ntohs(port_value);
   }
 
-  // Decodes a 24-bit parameter and returns its value as an unsigned integer.
+  // Decodes a tunnel_id value and returns it as an unsigned integer.
   static uint32_t DecodeTunnelId(const std::string& string_value) {
-    return DecodeWordValue(string_value) & 0xffffff;
+    return DecodeWordValue(string_value) & TUNNEL_ID_MASK;
   }
 
+  // Decodes a vni value and returns it as an unsigned integer.
   static uint16_t DecodeVniValue(const std::string& string_value) {
-    return DecodeWordValue(string_value) & 0xffff;
+    return DecodeWordValue(string_value) & VNI_VALUE_MASK;
   }
 
-  // Decodes a parameter and returns its value as an unsigned integer.
+  // Decodes a parameter value and returns it as an unsigned integer.
   static uint32_t DecodeWordValue(const std::string& string_value) {
     uint32_t word_value = 0;
     for (int i = 0; i < string_value.size(); i++) {

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_entry_test.cc
@@ -11,72 +11,97 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 41319073U;
+constexpr uint32_t ACTION_ID = 25818889U;
+
+enum {
+  SRC_PORT_PARAM_ID = 3,
+  DST_PORT_PARAM_ID = 4,
+  VNI_PARAM_ID = 5,
+};
+
+class GeneveEncapV4TableEntryTest : public Ipv4TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    auto table_action = table_entry.action();
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // Test PrepareGeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, geneve_encap_v4_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 41319073U;
-  constexpr uint32_t ACTION_ID = 25818889U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 3,
-    DST_PORT_PARAM_ID = 4,
-    VNI_PARAM_ID = 5,
-  };
-
+TEST_F(GeneveEncapV4TableEntryTest, remove_entry) {
   // Arrange
   InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, insert_entry);
+  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
-  EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckNoAction();
+}
 
-  ASSERT_TRUE(table_entry.has_action());
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  EXPECT_EQ(action.action_id(), ACTION_ID);
+TEST_F(GeneveEncapV4TableEntryTest, insert_entry) {
+  // Arrange
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareGeneveEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_entry_test.cc
@@ -49,7 +49,7 @@ class GeneveEncapV4TableEntryTest : public Ipv4TunnelTest {
 
     absl::optional<uint16_t> src_port;
     absl::optional<uint16_t> dst_port;
-    absl::optional<uint16_t> vni;
+    absl::optional<uint32_t> vni;
 
     for (int i = 0; i < num_params; ++i) {
       auto param = params[i];
@@ -76,7 +76,7 @@ class GeneveEncapV4TableEntryTest : public Ipv4TunnelTest {
     EXPECT_EQ(dst_port.value(), DST_PORT);
 
     ASSERT_TRUE(vni.has_value());
-    EXPECT_EQ(vni.value(), VNI);
+    EXPECT_EQ(vni.value(), tunnel_info.vni);
   }
 
   void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
@@ -49,7 +49,7 @@ class GeneveEncapV4VlanPopTest : public Ipv4TunnelTest {
 
     absl::optional<uint16_t> src_port;
     absl::optional<uint16_t> dst_port;
-    absl::optional<uint16_t> vni;
+    absl::optional<uint32_t> vni;
 
     for (int i = 0; i < num_params; ++i) {
       auto param = params[i];
@@ -76,7 +76,7 @@ class GeneveEncapV4VlanPopTest : public Ipv4TunnelTest {
     EXPECT_EQ(dst_port.value(), DST_PORT);
 
     ASSERT_TRUE(vni.has_value());
-    EXPECT_EQ(vni.value(), VNI);
+    EXPECT_EQ(vni.value(), tunnel_info.vni);
   }
 
   void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
@@ -11,73 +11,99 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 47977422U;
+constexpr uint32_t ACTION_ID = 26665268U;
+
+enum {
+  SRC_PORT_PARAM_ID = 3,
+  DST_PORT_PARAM_ID = 4,
+  VNI_PARAM_ID = 5,
+};
+
+class GeneveEncapV4VlanPopTest : public Ipv4TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    auto table_action = table_entry.action();
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // PrepareGeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, geneve_encap_v4_vlan_pop_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 47977422U;
-  constexpr uint32_t ACTION_ID = 26665268U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 3,
-    DST_PORT_PARAM_ID = 4,
-    VNI_PARAM_ID = 5,
-  };
-
+TEST_F(GeneveEncapV4VlanPopTest, remove_entry) {
   // Arrange
   InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
   // Act
   PrepareGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                         insert_entry);
+                                         REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
   EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckNoAction();
+}
 
-  ASSERT_TRUE(table_entry.has_action());
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  EXPECT_EQ(action.action_id(), ACTION_ID);
+TEST_F(GeneveEncapV4VlanPopTest, insert_entry) {
+  // Arrange
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                         INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
@@ -1,6 +1,12 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+// Unit test for PrepareGeneveEncapAndVlanPopTableEntry().
+
+// TODO(derek):
+// - Replace hard-coded IDs with p4info lookups.
+// - Make sure all action params are checked.
+
 #include <stdint.h>
 
 #include "absl/types/optional.h"
@@ -16,6 +22,10 @@ constexpr bool REMOVE_ENTRY = false;
 
 constexpr uint32_t TABLE_ID = 47977422U;
 constexpr uint32_t ACTION_ID = 26665268U;
+
+enum {
+  MF_MOD_BLOB_PTR = 1,
+};
 
 enum {
   SRC_PORT_PARAM_ID = 3,
@@ -69,9 +79,30 @@ class GeneveEncapV4VlanPopTest : public Ipv4TunnelTest {
     EXPECT_EQ(vni.value(), VNI);
   }
 
-  void CheckNoAction() const {
-    ASSERT_FALSE(table_entry.has_action());
+  void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }
+
+  void CheckMatches() const {
+    ASSERT_EQ(table_entry.match_size(), 1);
+
+    auto& match = table_entry.match()[0];
+    ASSERT_EQ(match.field_id(), MF_MOD_BLOB_PTR);
+
+    CheckVniMatch(match);
   }
+
+  void CheckVniMatch(const ::p4::v1::FieldMatch& match) const {
+    constexpr int VNI_SIZE = 3;
+
+    ASSERT_TRUE(match.has_exact());
+    const auto& match_value = match.exact().value();
+
+    ASSERT_EQ(match_value.size(), VNI_SIZE);
+
+    uint32_t vni_value = DecodeVniValue(match_value);
+    EXPECT_EQ(vni_value, tunnel_info.vni);
+  }
+
+  void CheckTableEntry() const { ASSERT_EQ(table_entry.table_id(), TABLE_ID); }
 };
 
 //----------------------------------------------------------------------
@@ -88,7 +119,8 @@ TEST_F(GeneveEncapV4VlanPopTest, remove_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
+  CheckMatches();
   CheckNoAction();
 }
 
@@ -102,7 +134,7 @@ TEST_F(GeneveEncapV4VlanPopTest, insert_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
   CheckAction();
 }
 

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
@@ -1,6 +1,12 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+// Unit test for PrepareV6GeneveEncapTableEntry().
+
+// TODO(derek):
+// - Replace hard-coded IDs with p4info lookups.
+// - Check all action params.
+
 #include <stdint.h>
 
 #include "absl/types/optional.h"
@@ -16,6 +22,10 @@ constexpr bool REMOVE_ENTRY = false;
 
 constexpr uint32_t TABLE_ID = 42283616U;
 constexpr uint32_t ACTION_ID = 29610186U;
+
+enum {
+  MF_MOD_BLOB_PTR = 1,
+};
 
 enum {
   SRC_PORT_PARAM_ID = 7,
@@ -69,9 +79,30 @@ class GeneveEncapV6TableEntryTest : public Ipv6TunnelTest {
     EXPECT_EQ(vni.value(), VNI);
   }
 
-  void CheckNoAction() const {
-    ASSERT_FALSE(table_entry.has_action());
+  void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }
+
+  void CheckMatches() const {
+    ASSERT_EQ(table_entry.match_size(), 1);
+
+    auto& match = table_entry.match()[0];
+    ASSERT_EQ(match.field_id(), MF_MOD_BLOB_PTR);
+
+    CheckVniMatch(match);
   }
+
+  void CheckVniMatch(const ::p4::v1::FieldMatch& match) const {
+    constexpr int VNI_SIZE = 3;
+
+    ASSERT_TRUE(match.has_exact());
+    const auto& match_value = match.exact().value();
+
+    ASSERT_EQ(match_value.size(), VNI_SIZE);
+
+    uint32_t vni_value = DecodeVniValue(match_value);
+    EXPECT_EQ(vni_value, tunnel_info.vni);
+  }
+
+  void CheckTableEntry() const { ASSERT_EQ(table_entry.table_id(), TABLE_ID); }
 };
 
 //----------------------------------------------------------------------
@@ -88,7 +119,8 @@ TEST_F(GeneveEncapV6TableEntryTest, remove_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
+  CheckMatches();
   CheckNoAction();
 }
 
@@ -102,7 +134,7 @@ TEST_F(GeneveEncapV6TableEntryTest, insert_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
   CheckAction();
 }
 

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
@@ -49,7 +49,7 @@ class GeneveEncapV6TableEntryTest : public Ipv6TunnelTest {
 
     absl::optional<uint16_t> src_port;
     absl::optional<uint16_t> dst_port;
-    absl::optional<uint16_t> vni;
+    absl::optional<uint32_t> vni;
 
     for (int i = 0; i < num_params; ++i) {
       auto param = params[i];
@@ -76,7 +76,7 @@ class GeneveEncapV6TableEntryTest : public Ipv6TunnelTest {
     EXPECT_EQ(dst_port.value(), DST_PORT);
 
     ASSERT_TRUE(vni.has_value());
-    EXPECT_EQ(vni.value(), VNI);
+    EXPECT_EQ(vni.value(), tunnel_info.vni);
   }
 
   void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_entry_test.cc
@@ -11,73 +11,99 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 42283616U;
+constexpr uint32_t ACTION_ID = 29610186U;
+
+enum {
+  SRC_PORT_PARAM_ID = 7,
+  DST_PORT_PARAM_ID = 8,
+  VNI_PARAM_ID = 9,
+};
+
+class GeneveEncapV6TableEntryTest : public Ipv6TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    auto table_action = table_entry.action();
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // PrepareV6GeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv6TunnelTest, geneve_encap_v6_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 42283616U;
-  constexpr uint32_t ACTION_ID = 29610186U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 7,
-    DST_PORT_PARAM_ID = 8,
-    VNI_PARAM_ID = 9,
-  };
-
+TEST_F(GeneveEncapV6TableEntryTest, remove_entry) {
   // Arrange
   InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
   // Act
   PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                 insert_entry);
+                                 REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
   ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckNoAction();
+}
 
-  ASSERT_TRUE(table_entry.has_action());
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  ASSERT_EQ(action.action_id(), ACTION_ID);
+TEST_F(GeneveEncapV6TableEntryTest, insert_entry) {
+  // Arrange
+  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
+                                 INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/rx_tunnel_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/rx_tunnel_v4_table_test.cc
@@ -9,52 +9,18 @@
 #include <iostream>
 #include <string>
 
+#include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
-#include "p4/config/v1/p4info.pb.h"
-#include "p4/v1/p4runtime.pb.h"
-#include "p4info_helper.h"
-#include "p4info_text.h"
-#include "stratum/lib/utils.h"
 
 namespace ovsp4rt {
 
-using stratum::ParseProtoFromString;
-
-constexpr bool INSERT_ENTRY = true;
-constexpr bool REMOVE_ENTRY = false;
-
-static ::p4::config::v1::P4Info p4info;
-
-class RxTunnelPortV4TableTest : public ::testing::Test {
+class RxTunnelPortV4TableTest : public BaseTableTest {
  protected:
-  RxTunnelPortV4TableTest() : helper(p4info) {}
-
-  static void SetUpTestSuite() {
-    ::util::Status status = ParseProtoFromString(P4INFO_TEXT, &p4info);
-    if (!status.ok()) {
-      std::exit(EXIT_FAILURE);
-    }
-  }
+  RxTunnelPortV4TableTest() {}
 
   void SetUp() { helper.SelectTable("rx_ipv4_tunnel_source_port"); }
-
-  //----------------------------
-  // Utility methods
-  //----------------------------
-
-  static uint16_t DecodeVniValue(const std::string& string_value) {
-    return DecodeWordValue(string_value) & 0xffff;
-  }
-
-  static uint32_t DecodeWordValue(const std::string& string_value) {
-    uint32_t word_value = 0;
-    for (int i = 0; i < string_value.size(); i++) {
-      word_value = (word_value << 8) | (string_value[i] & 0xff);
-    }
-    return word_value;
-  }
 
   //----------------------------
   // Initialization methods
@@ -164,11 +130,7 @@ class RxTunnelPortV4TableTest : public ::testing::Test {
   //----------------------------
   // Protected member data
   //----------------------------
-
-  P4InfoHelper helper;
-
   struct tunnel_info tunnel_info = {0};
-  ::p4::v1::TableEntry table_entry;
 };
 
 //----------------------------------------------------------------------

--- a/ovs-p4rt/sidecar/testing/rx_tunnel_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/rx_tunnel_v6_table_test.cc
@@ -9,34 +9,16 @@
 #include <iostream>
 #include <string>
 
+#include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
-#include "p4/config/v1/p4info.pb.h"
-#include "p4/v1/p4runtime.pb.h"
-#include "p4info_helper.h"
-#include "p4info_text.h"
-#include "stratum/lib/utils.h"
 
 namespace ovsp4rt {
 
-using stratum::ParseProtoFromString;
-
-constexpr bool INSERT_ENTRY = true;
-constexpr bool REMOVE_ENTRY = false;
-
-static ::p4::config::v1::P4Info p4info;
-
-class RxTunnelPortV6TableTest : public ::testing::Test {
+class RxTunnelPortV6TableTest : public BaseTableTest {
  protected:
-  RxTunnelPortV6TableTest() : helper(p4info) {}
-
-  static void SetUpTestSuite() {
-    ::util::Status status = ParseProtoFromString(P4INFO_TEXT, &p4info);
-    if (!status.ok()) {
-      std::exit(EXIT_FAILURE);
-    }
-  }
+  RxTunnelPortV6TableTest() {}
 
   void SetUp() { helper.SelectTable("rx_ipv6_tunnel_source_port"); }
 
@@ -58,18 +40,6 @@ class RxTunnelPortV6TableTest : public ::testing::Test {
       }
       ipv6_addr.push_back(ntohl(word_value));
     }
-  }
-
-  static uint16_t DecodeVniValue(const std::string& string_value) {
-    return DecodeWordValue(string_value) & 0xffff;
-  }
-
-  static uint32_t DecodeWordValue(const std::string& string_value) {
-    uint32_t word_value = 0;
-    for (int i = 0; i < string_value.size(); i++) {
-      word_value = (word_value << 8) | (string_value[i] & 0xff);
-    }
-    return word_value;
   }
 
   static inline uint32_t Ipv6AddrWord(const struct p4_ipaddr& ipaddr, int i) {
@@ -192,11 +162,7 @@ class RxTunnelPortV6TableTest : public ::testing::Test {
   //----------------------------
   // Protected member data
   //----------------------------
-
-  P4InfoHelper helper;
-
   struct tunnel_info tunnel_info = {0};
-  ::p4::v1::TableEntry table_entry;
 };
 
 //----------------------------------------------------------------------

--- a/ovs-p4rt/sidecar/testing/table_entry_test.h
+++ b/ovs-p4rt/sidecar/testing/table_entry_test.h
@@ -25,6 +25,8 @@ using google::protobuf::util::JsonPrintOptions;
 using google::protobuf::util::MessageToJsonString;
 using stratum::ParseProtoFromString;
 
+constexpr uint32_t VNI_VALUE_MASK = 0x00ffffffU;
+
 static ::p4::config::v1::P4Info p4info;
 
 class TableEntryTest : public ::testing::Test {
@@ -44,8 +46,8 @@ class TableEntryTest : public ::testing::Test {
     return ntohs(port_value);
   }
 
-  static uint16_t DecodeVniValue(const std::string& string_value) {
-    return DecodeWordValue(string_value) & 0xffff;
+  static uint32_t DecodeVniValue(const std::string& string_value) {
+    return DecodeWordValue(string_value) & VNI_VALUE_MASK;
   }
 
   static uint32_t DecodeWordValue(const std::string& string_value) {

--- a/ovs-p4rt/sidecar/testing/vxlan_decap_mod_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_decap_mod_entry_test.cc
@@ -8,94 +8,24 @@
 #include <iostream>
 #include <string>
 
+#include "base_table_test.h"
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
-#include "p4/config/v1/p4info.pb.h"
-#include "p4/v1/p4runtime.pb.h"
-#include "p4info_text.h"
-#include "stratum/lib/utils.h"
 
 namespace ovsp4rt {
 
-using stratum::ParseProtoFromString;
-
-constexpr bool INSERT_ENTRY = true;
-constexpr bool REMOVE_ENTRY = false;
-
-static ::p4::config::v1::P4Info p4info;
-
-class VxlanDecapModEntryTest : public ::testing::Test {
+class VxlanDecapModEntryTest : public BaseTableTest {
  protected:
   VxlanDecapModEntryTest() {}
 
-  static void SetUpTestSuite() {
-    ::util::Status status = ParseProtoFromString(P4INFO_TEXT, &p4info);
-    if (!status.ok()) {
-      std::exit(EXIT_FAILURE);
-    }
-  }
-
-  void SetUp() { SelectTable("vxlan_decap_mod_table"); }
-
-  //----------------------------
-  // P4Info lookup methods
-  //----------------------------
-
-  int GetMatchFieldId(const std::string& mf_name) const {
-    for (const auto& mf : TABLE->match_fields()) {
-      if (mf.name() == mf_name) {
-        return mf.id();
-      }
-    }
-    return -1;
-  }
-
-  void SelectAction(const std::string& action_name) {
-    for (const auto& action : p4info.actions()) {
-      const auto& pre = action.preamble();
-      if (pre.name() == action_name || pre.alias() == action_name) {
-        ACTION = &action;
-        ACTION_ID = pre.id();
-        return;
-      }
-    }
-    std::cerr << "Action '" << action_name << "' not found!\n";
-  }
-
-  void SelectTable(const std::string& table_name) {
-    for (const auto& table : p4info.tables()) {
-      const auto& pre = table.preamble();
-      if (pre.name() == table_name || pre.alias() == table_name) {
-        TABLE = &table;
-        TABLE_ID = pre.id();
-        return;
-      }
-    }
-    std::cerr << "Table '" << table_name << "' not found!\n";
-  }
-
-  //----------------------------
-  // Utility methods
-  //----------------------------
-
-  static uint32_t DecodeWordValue(const std::string& string_value) {
-    uint32_t word_value = 0;
-    for (int i = 0; i < string_value.size(); i++) {
-      word_value = (word_value << 8) | (string_value[i] & 0xff);
-    }
-    return word_value;
-  }
-
-  static uint16_t DecodeVniValue(const std::string& string_value) {
-    return DecodeWordValue(string_value) & 0xffff;
-  }
+  void SetUp() { helper.SelectTable("vxlan_decap_mod_table"); }
 
   //----------------------------
   // Initialization methods
   //----------------------------
 
-  void InitAction() { SelectAction("vxlan_decap_outer_hdr"); }
+  void InitAction() { helper.SelectAction("vxlan_decap_outer_hdr"); }
 
   void InitTunnelInfo() { tunnel_info.vni = 0x1776; }
 
@@ -104,20 +34,18 @@ class VxlanDecapModEntryTest : public ::testing::Test {
   //----------------------------
 
   void CheckAction() const {
-    ASSERT_NE(ACTION_ID, -1);
-
     ASSERT_TRUE(table_entry.has_action());
     auto table_action = table_entry.action();
 
     auto action = table_action.action();
-    EXPECT_EQ(action.action_id(), ACTION_ID);
+    EXPECT_EQ(action.action_id(), helper.action_id());
 
     EXPECT_EQ(action.params_size(), 0);
   }
 
   void CheckMatches() const {
     constexpr char MOD_BLOB_PTR[] = "vmeta.common.mod_blob_ptr";
-    const int MF_MOD_BLOB_PTR = GetMatchFieldId(MOD_BLOB_PTR);
+    const int MF_MOD_BLOB_PTR = helper.GetMatchFieldId(MOD_BLOB_PTR);
 
     ASSERT_EQ(table_entry.match_size(), 1);
 
@@ -130,8 +58,8 @@ class VxlanDecapModEntryTest : public ::testing::Test {
   void CheckNoAction() const { EXPECT_FALSE(table_entry.has_action()); }
 
   void CheckTableEntry() const {
-    ASSERT_FALSE(TABLE == nullptr);
-    EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+    ASSERT_TRUE(helper.has_table());
+    EXPECT_EQ(table_entry.table_id(), helper.table_id());
   }
 
   void CheckVniValue(const ::p4::v1::FieldMatch& match) const {
@@ -150,20 +78,7 @@ class VxlanDecapModEntryTest : public ::testing::Test {
   // Protected member data
   //----------------------------
 
-  // Working variables
   struct tunnel_info tunnel_info = {0};
-  ::p4::v1::TableEntry table_entry;
-
-  // Comparison variables
-  uint32_t TABLE_ID;
-  int ACTION_ID = -1;
-
- private:
-  //----------------------------
-  // Private member data
-  //----------------------------
-  const ::p4::config::v1::Action* ACTION = nullptr;
-  const ::p4::config::v1::Table* TABLE = nullptr;
 };
 
 //----------------------------------------------------------------------

--- a/ovs-p4rt/sidecar/testing/vxlan_decap_mod_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_decap_mod_entry_test.cc
@@ -52,7 +52,7 @@ class VxlanDecapModEntryTest : public BaseTableTest {
     auto& match = table_entry.match()[0];
     ASSERT_EQ(match.field_id(), MF_MOD_BLOB_PTR);
 
-    CheckVniValue(match);
+    CheckVniMatch(match);
   }
 
   void CheckNoAction() const { EXPECT_FALSE(table_entry.has_action()); }
@@ -62,7 +62,7 @@ class VxlanDecapModEntryTest : public BaseTableTest {
     EXPECT_EQ(table_entry.table_id(), helper.table_id());
   }
 
-  void CheckVniValue(const ::p4::v1::FieldMatch& match) const {
+  void CheckVniMatch(const ::p4::v1::FieldMatch& match) const {
     constexpr int VNI_SIZE = 3;
 
     ASSERT_TRUE(match.has_exact());

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_entry_test.cc
@@ -11,73 +11,100 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 40763773U;
+constexpr uint32_t ACTION_ID = 20733968U;
+
+enum {
+  SRC_PORT_PARAM_ID = 3,
+  DST_PORT_PARAM_ID = 4,
+  VNI_PARAM_ID = 5,
+};
+
+class VxlanEncapV4TableEntryTest : public Ipv4TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+
+    auto table_action = table_entry.action();
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+  #if defined(ES2K_TARGET)
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+  #endif
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // PrepareVxlanEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, vxlan_encap_v4_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 40763773U;
-  constexpr uint32_t ACTION_ID = 20733968U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 3,
-    DST_PORT_PARAM_ID = 4,
-    VNI_PARAM_ID = 5,
-  };
-
+TEST_F(VxlanEncapV4TableEntryTest, remove_entry) {
   // Arrange
   InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, insert_entry);
+  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
   ASSERT_EQ(table_entry.table_id(), TABLE_ID);
-  ASSERT_TRUE(table_entry.has_action());
+  CheckNoAction();
+}
 
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  ASSERT_EQ(action.action_id(), ACTION_ID);
+TEST_F(VxlanEncapV4TableEntryTest, insert_entry) {
+  // Arrange
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-#if defined(ES2K_TARGET)
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-#endif
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_entry_test.cc
@@ -50,7 +50,7 @@ class VxlanEncapV4TableEntryTest : public Ipv4TunnelTest {
 
     absl::optional<uint16_t> src_port;
     absl::optional<uint16_t> dst_port;
-    absl::optional<uint16_t> vni;
+    absl::optional<uint32_t> vni;
 
     for (int i = 0; i < num_params; ++i) {
       auto param = params[i];
@@ -79,7 +79,7 @@ class VxlanEncapV4TableEntryTest : public Ipv4TunnelTest {
     EXPECT_EQ(dst_port.value(), DST_PORT);
 
     ASSERT_TRUE(vni.has_value());
-    EXPECT_EQ(vni.value(), VNI);
+    EXPECT_EQ(vni.value(), tunnel_info.vni);
   }
 
   void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_vlan_pop_test.cc
@@ -50,7 +50,7 @@ class VxlanEncapV4VlanPopTest : public Ipv4TunnelTest {
 
     absl::optional<uint16_t> src_port;
     absl::optional<uint16_t> dst_port;
-    absl::optional<uint16_t> vni;
+    absl::optional<uint32_t> vni;
 
     for (int i = 0; i < num_params; ++i) {
       auto param = params[i];
@@ -77,7 +77,7 @@ class VxlanEncapV4VlanPopTest : public Ipv4TunnelTest {
     EXPECT_EQ(dst_port.value(), DST_PORT);
 
     ASSERT_TRUE(vni.has_value());
-    EXPECT_EQ(vni.value(), VNI);
+    EXPECT_EQ(vni.value(), tunnel_info.vni);
   }
 
   void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_vlan_pop_test.cc
@@ -11,72 +11,100 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 39675860U;
+constexpr uint32_t ACTION_ID = 26114242U;
+
+enum {
+  SRC_PORT_PARAM_ID = 3,
+  DST_PORT_PARAM_ID = 4,
+  VNI_PARAM_ID = 5,
+};
+
+class VxlanEncapV4VlanPopTest : public Ipv4TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    auto table_action = table_entry.action();
+
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // PrepareVxlanEncapAndVlanPopTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv4TunnelTest, vxlan_encap_v4_vlan_pop_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 39675860U;
-  constexpr uint32_t ACTION_ID = 26114242U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 3,
-    DST_PORT_PARAM_ID = 4,
-    VNI_PARAM_ID = 5,
-  };
-
+TEST_F(VxlanEncapV4VlanPopTest, remove_entry) {
   // Arrange
   InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
   PrepareVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                        insert_entry);
+                                        REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
   ASSERT_EQ(table_entry.table_id(), TABLE_ID);
-  ASSERT_TRUE(table_entry.has_action());
+  CheckNoAction();
+}
 
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  ASSERT_EQ(action.action_id(), ACTION_ID);
+TEST_F(VxlanEncapV4VlanPopTest, insert_entry) {
+  // Arrange
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareVxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                        INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
@@ -49,7 +49,7 @@ class EncapV6TableEntryTest : public Ipv6TunnelTest {
 
     absl::optional<uint16_t> src_port;
     absl::optional<uint16_t> dst_port;
-    absl::optional<uint16_t> vni;
+    absl::optional<uint32_t> vni;
 
     for (int i = 0; i < num_params; ++i) {
       auto param = params[i];
@@ -76,7 +76,7 @@ class EncapV6TableEntryTest : public Ipv6TunnelTest {
     EXPECT_EQ(dst_port.value(), DST_PORT);
 
     ASSERT_TRUE(vni.has_value());
-    EXPECT_EQ(vni.value(), VNI);
+    EXPECT_EQ(vni.value(), tunnel_info.vni);
   }
 
   void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
@@ -11,72 +11,99 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 46225003U;
+constexpr uint32_t ACTION_ID = 30345128U;
+
+enum {
+  SRC_PORT_PARAM_ID = 7,
+  DST_PORT_PARAM_ID = 8,
+  VNI_PARAM_ID = 9,
+};
+
+class EncapV6TableEntryTest : public Ipv6TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    auto table_action = table_entry.action();
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // PrepareV6VxlanEncapTableEntry
 //----------------------------------------------------------------------
 
-TEST_F(Ipv6TunnelTest, vxlan_encap_v6_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 46225003U;
-  constexpr uint32_t ACTION_ID = 30345128U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 7,
-    DST_PORT_PARAM_ID = 8,
-    VNI_PARAM_ID = 9,
-  };
-
+TEST_F(EncapV6TableEntryTest, remove_entry) {
   // Arrange
   InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
   PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                insert_entry);
+                                REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
   ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckNoAction();
+}
 
-  ASSERT_TRUE(table_entry.has_action());
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  ASSERT_EQ(action.action_id(), ACTION_ID);
+TEST_F(EncapV6TableEntryTest, insert_entry) {
+  // Arrange
+  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareV6VxlanEncapTableEntry(&table_entry, tunnel_info, p4info,
+                                INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_entry_test.cc
@@ -1,6 +1,12 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+// Unit test for PrepareV6VxlanEncapTableEntry().
+
+// TODO(derek):
+// - Replace hard-coded IDs with p4info lookups.
+// - Check all action params.
+
 #include <stdint.h>
 
 #include "absl/types/optional.h"
@@ -16,6 +22,10 @@ constexpr bool REMOVE_ENTRY = false;
 
 constexpr uint32_t TABLE_ID = 46225003U;
 constexpr uint32_t ACTION_ID = 30345128U;
+
+enum {
+  MF_MOD_BLOB_PTR = 1,
+};
 
 enum {
   SRC_PORT_PARAM_ID = 7,
@@ -69,9 +79,30 @@ class EncapV6TableEntryTest : public Ipv6TunnelTest {
     EXPECT_EQ(vni.value(), VNI);
   }
 
-  void CheckNoAction() const {
-    ASSERT_FALSE(table_entry.has_action());
+  void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }
+
+  void CheckMatches() const {
+    ASSERT_EQ(table_entry.match_size(), 1);
+
+    auto& match = table_entry.match()[0];
+    ASSERT_EQ(match.field_id(), MF_MOD_BLOB_PTR);
+
+    CheckVniMatch(match);
   }
+
+  void CheckVniMatch(const ::p4::v1::FieldMatch& match) const {
+    constexpr int VNI_SIZE = 3;
+
+    ASSERT_TRUE(match.has_exact());
+    const auto& match_value = match.exact().value();
+
+    ASSERT_EQ(match_value.size(), VNI_SIZE);
+
+    uint32_t vni_value = DecodeVniValue(match_value);
+    EXPECT_EQ(vni_value, tunnel_info.vni);
+  }
+
+  void CheckTableEntry() const { ASSERT_EQ(table_entry.table_id(), TABLE_ID); }
 };
 
 //----------------------------------------------------------------------
@@ -88,7 +119,8 @@ TEST_F(EncapV6TableEntryTest, remove_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
+  CheckMatches();
   CheckNoAction();
 }
 
@@ -102,7 +134,7 @@ TEST_F(EncapV6TableEntryTest, insert_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
   CheckAction();
 }
 

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
@@ -49,7 +49,7 @@ class VxlanEncapV6VlanPopTest : public Ipv6TunnelTest {
 
     absl::optional<uint16_t> src_port;
     absl::optional<uint16_t> dst_port;
-    absl::optional<uint16_t> vni;
+    absl::optional<uint32_t> vni;
 
     for (int i = 0; i < num_params; ++i) {
       auto param = params[i];
@@ -76,7 +76,7 @@ class VxlanEncapV6VlanPopTest : public Ipv6TunnelTest {
     EXPECT_EQ(dst_port.value(), DST_PORT);
 
     ASSERT_TRUE(vni.has_value());
-    EXPECT_EQ(vni.value(), VNI);
+    EXPECT_EQ(vni.value(), tunnel_info.vni);
   }
 
   void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
@@ -1,6 +1,12 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+// Unit test for PrepareV6VxlanEncapAndVlanPopTableEntry().
+
+// TODO(derek):
+// - Replace hard-coded IDs with p4info lookups.
+// - Check all action params.
+
 #include <stdint.h>
 
 #include "absl/types/optional.h"
@@ -16,6 +22,10 @@ constexpr bool REMOVE_ENTRY = false;
 
 constexpr uint32_t TABLE_ID = 34318005U;
 constexpr uint32_t ACTION_ID = 28284062U;
+
+enum {
+  MF_MOD_BLOB_PTR = 1,
+};
 
 enum {
   SRC_PORT_PARAM_ID = 7,
@@ -69,9 +79,30 @@ class VxlanEncapV6VlanPopTest : public Ipv6TunnelTest {
     EXPECT_EQ(vni.value(), VNI);
   }
 
-  void CheckNoAction() const {
-    ASSERT_FALSE(table_entry.has_action());
+  void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }
+
+  void CheckMatches() const {
+    ASSERT_EQ(table_entry.match_size(), 1);
+
+    auto& match = table_entry.match()[0];
+    ASSERT_EQ(match.field_id(), MF_MOD_BLOB_PTR);
+
+    CheckVniMatch(match);
   }
+
+  void CheckVniMatch(const ::p4::v1::FieldMatch& match) const {
+    constexpr int VNI_SIZE = 3;
+
+    ASSERT_TRUE(match.has_exact());
+    const auto& match_value = match.exact().value();
+
+    ASSERT_EQ(match_value.size(), VNI_SIZE);
+
+    uint32_t vni_value = DecodeVniValue(match_value);
+    EXPECT_EQ(vni_value, tunnel_info.vni);
+  }
+
+  void CheckTableEntry() const { ASSERT_EQ(table_entry.table_id(), TABLE_ID); }
 };
 
 //----------------------------------------------------------------------
@@ -88,7 +119,8 @@ TEST_F(VxlanEncapV6VlanPopTest, remove_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
+  CheckMatches();
   CheckNoAction();
 }
 
@@ -102,7 +134,7 @@ TEST_F(VxlanEncapV6VlanPopTest, insert_entry) {
   DumpTableEntry(table_entry);
 
   // Assert
-  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckTableEntry();
   CheckAction();
 }
 

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_vlan_pop_test.cc
@@ -11,73 +11,99 @@
 
 namespace ovsp4rt {
 
+constexpr bool INSERT_ENTRY = true;
+constexpr bool REMOVE_ENTRY = false;
+
+constexpr uint32_t TABLE_ID = 34318005U;
+constexpr uint32_t ACTION_ID = 28284062U;
+
+enum {
+  SRC_PORT_PARAM_ID = 7,
+  DST_PORT_PARAM_ID = 8,
+  VNI_PARAM_ID = 9,
+};
+
+class VxlanEncapV6VlanPopTest : public Ipv6TunnelTest {
+ protected:
+  struct tunnel_info tunnel_info = {0};
+  p4::v1::TableEntry table_entry;
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    auto table_action = table_entry.action();
+    auto action = table_action.action();
+    ASSERT_EQ(action.action_id(), ACTION_ID);
+
+    auto params = action.params();
+    int num_params = action.params_size();
+
+    absl::optional<uint16_t> src_port;
+    absl::optional<uint16_t> dst_port;
+    absl::optional<uint16_t> vni;
+
+    for (int i = 0; i < num_params; ++i) {
+      auto param = params[i];
+      int param_id = param.param_id();
+      auto param_value = param.value();
+
+      if (param_id == SRC_PORT_PARAM_ID) {
+        src_port = DecodePortValue(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        dst_port = DecodePortValue(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        vni = DecodeVniValue(param_value);
+      }
+    }
+
+    ASSERT_TRUE(src_port.has_value());
+
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+
+    ASSERT_TRUE(dst_port.has_value());
+    EXPECT_EQ(dst_port.value(), DST_PORT);
+
+    ASSERT_TRUE(vni.has_value());
+    EXPECT_EQ(vni.value(), VNI);
+  }
+
+  void CheckNoAction() const {
+    ASSERT_FALSE(table_entry.has_action());
+  }
+};
+
 //----------------------------------------------------------------------
 // PrepareV6VxlanEncapAndVlanPopTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(Ipv6TunnelTest, vxlan_encap_v6_vlan_pop_params_are_correct) {
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
-  constexpr bool insert_entry = true;
-
-  constexpr uint32_t TABLE_ID = 34318005U;
-  constexpr uint32_t ACTION_ID = 28284062U;
-
-  enum {
-    SRC_PORT_PARAM_ID = 7,
-    DST_PORT_PARAM_ID = 8,
-    VNI_PARAM_ID = 9,
-  };
-
+TEST_F(VxlanEncapV6VlanPopTest, remove_entry) {
   // Arrange
   InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
   PrepareV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
-                                          insert_entry);
+                                          REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
   EXPECT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckNoAction();
+}
 
-  ASSERT_TRUE(table_entry.has_action());
-  auto table_action = table_entry.action();
-  auto action = table_action.action();
-  EXPECT_EQ(action.action_id(), ACTION_ID);
+TEST_F(VxlanEncapV6VlanPopTest, insert_entry) {
+  // Arrange
+  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
-  auto params = action.params();
-  int num_params = action.params_size();
+  // Act
+  PrepareV6VxlanEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                          INSERT_ENTRY);
+  DumpTableEntry(table_entry);
 
-  absl::optional<uint16_t> src_port;
-  absl::optional<uint16_t> dst_port;
-  absl::optional<uint16_t> vni;
-
-  for (int i = 0; i < num_params; ++i) {
-    auto param = params[i];
-    int param_id = param.param_id();
-    auto param_value = param.value();
-
-    if (param_id == SRC_PORT_PARAM_ID) {
-      src_port = DecodePortValue(param_value);
-    } else if (param_id == DST_PORT_PARAM_ID) {
-      dst_port = DecodePortValue(param_value);
-    } else if (param_id == VNI_PARAM_ID) {
-      vni = DecodeVniValue(param_value);
-    }
-  }
-
-  ASSERT_TRUE(src_port.has_value());
-
-  // To work around a bug in the Linux Networking P4 program, we
-  // ignore the src_port value specified by the caller and instead
-  // set the src_port param to (dst_port * 2).
-  EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-  ASSERT_TRUE(dst_port.has_value());
-  EXPECT_EQ(dst_port.value(), DST_PORT);
-
-  ASSERT_TRUE(vni.has_value());
-  EXPECT_EQ(vni.value(), VNI);
+  // Assert
+  ASSERT_EQ(table_entry.table_id(), TABLE_ID);
+  CheckAction();
 }
 
 }  // namespace ovsp4rt


### PR DESCRIPTION
- Changed variables and function return values from uint16_t to
  uint32_t.

- Modified tests to compare decoded value to `tunnel_info.vni`
  in all cases. This ensures that they validate against the actual
  input value, not the nominal default.

- Also removed extraneous copy of rx_tunnel_v4_table_test.cc
  from the sidecar directory.

This CL is based on PRs https://github.com/ipdk-io/networking-recipe/pull/612 and https://github.com/ipdk-io/networking-recipe/pull/613. Because these PRs have not yet been merged, you will see them if you select the **Files changed** tab.

To view the changes specific to this commit, see https://github.com/ipdk-io/networking-recipe/pull/614/commits/066a670feddfa12c3d2722c91a50c87749783051.