### PR TITLE
[ovsp4rt] Add methods to core test classes

### DIFF
--- a/ovs-p4rt/sidecar/testing/base_table_test.h
+++ b/ovs-p4rt/sidecar/testing/base_table_test.h
@@ -1,6 +1,10 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+// #define DUMP_JSON before including this header file to
+// enable the --dump_json command-line flag and the body
+// of the DumpTableEntry() method.
+
 #ifndef BASE_TABLE_TEST_H_
 #define BASE_TABLE_TEST_H_
 
@@ -33,8 +37,8 @@ using google::protobuf::util::MessageToJsonString;
 #endif
 using stratum::ParseProtoFromString;
 
-constexpr uint32_t VNI_VALUE_MASK = 0x0000ffffU;
-constexpr uint32_t TUNNEL_ID_MASK = 0x00ffffffU;
+constexpr uint32_t VNI_VALUE_MASK = 0x00ffffffU;  // bit<24>
+constexpr uint32_t TUNNEL_ID_MASK = 0x000fffffU;  // bit<20>
 
 constexpr bool INSERT_ENTRY = true;
 constexpr bool REMOVE_ENTRY = false;
@@ -57,6 +61,36 @@ class BaseTableTest : public ::testing::Test {
       std::exit(EXIT_FAILURE);
     }
   }
+
+  //----------------------------
+  // P4Info lookup methods
+  //----------------------------
+
+  inline int GetActionId(const std::string& action_name) const {
+    return helper.GetActionId(action_name);
+  }
+
+  inline int GetMatchFieldId(const std::string& mf_name) const {
+    return helper.GetMatchFieldId(mf_name);
+  }
+
+  inline int GetParamId(const std::string& param_name) const {
+    return helper.GetParamId(param_name);
+  }
+
+  inline void SelectAction(const std::string& action_name) {
+    helper.SelectAction(action_name);
+  }
+
+  inline void SelectTable(const std::string& table_name) {
+    helper.SelectTable(table_name);
+  }
+
+  inline int ActionId() const { return helper.action_id(); }
+
+  inline bool HasTable() const { return helper.has_table(); }
+
+  inline int TableId() const { return helper.table_id(); }
 
   //----------------------------
   // Utility methods

--- a/ovs-p4rt/sidecar/testing/p4info_helper.h
+++ b/ovs-p4rt/sidecar/testing/p4info_helper.h
@@ -21,6 +21,17 @@ class P4InfoHelper {
         table_id_(-1),
         action_id_(-1) {}
 
+  int GetActionId(const std::string& action_name) const {
+    for (const auto& action : p4info_.actions()) {
+      const auto& pre = action.preamble();
+      if (pre.name() == action_name || pre.alias() == action_name) {
+        return pre.id();
+      }
+    }
+    std::cerr << "Action '" << action_name << "' not found!\n";
+    return -1;
+  }
+
   int GetMatchFieldId(const std::string& mf_name) const {
     for (const auto& mf : table_->match_fields()) {
       if (mf.name() == mf_name) {


### PR DESCRIPTION
- Added GetActionId() method to P4InfoHelper class, for use by older tests.

- Provided methods to encapsulate access to the P4InfoHelper object.

> [!NOTE]
> Most of the following PRs are based on this PR.