### PR TITLE
[ovsp4rt] Rename tests for consistency

### DIFF
--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -145,8 +145,8 @@ define_ovsp4rt_test(fdb_tx_geneve_entry_test)
 define_ovsp4rt_test(fdb_tx_vlan_entry_test)
 define_ovsp4rt_test(fdb_tx_vxlan_entry_test)
 
-define_ipv4_tunnel_test(geneve_encap_v4_table_entry_test)
-define_ipv6_tunnel_test(geneve_encap_v6_table_entry_test)
+define_ipv4_tunnel_test(geneve_encap_v4_table_test)
+define_ipv6_tunnel_test(geneve_encap_v6_table_test)
 define_ipv4_tunnel_test(geneve_encap_v4_vlan_pop_test)
 
 define_ovsp4rt_test(l2_to_v4_tunnel_test)
@@ -162,8 +162,8 @@ define_ovsp4rt_test(vlan_pop_table_test)
 
 define_ovsp4rt_test(vxlan_decap_mod_entry_test)
 
-define_ipv4_tunnel_test(vxlan_encap_v4_table_entry_test)
-define_ipv6_tunnel_test(vxlan_encap_v6_table_entry_test)
+define_ipv4_tunnel_test(vxlan_encap_v4_table_test)
+define_ipv6_tunnel_test(vxlan_encap_v6_table_test)
 define_ipv4_tunnel_test(vxlan_encap_v4_vlan_pop_test)
 define_ipv6_tunnel_test(vxlan_encap_v6_vlan_pop_test)
 

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_table_test.cc
@@ -33,7 +33,7 @@ enum {
   VNI_PARAM_ID = 5,
 };
 
-class GeneveEncapV4TableEntryTest : public Ipv4TunnelTest {
+class GeneveEncapV4TableTest : public Ipv4TunnelTest {
  protected:
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
@@ -109,7 +109,7 @@ class GeneveEncapV4TableEntryTest : public Ipv4TunnelTest {
 // Test PrepareGeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(GeneveEncapV4TableEntryTest, remove_entry) {
+TEST_F(GeneveEncapV4TableTest, remove_entry) {
   // Arrange
   InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
@@ -123,7 +123,7 @@ TEST_F(GeneveEncapV4TableEntryTest, remove_entry) {
   CheckNoAction();
 }
 
-TEST_F(GeneveEncapV4TableEntryTest, insert_entry) {
+TEST_F(GeneveEncapV4TableTest, insert_entry) {
   // Arrange
   InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v6_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareVxlanEncapTableEntry().
+// Unit test for PrepareV6GeneveEncapTableEntry().
 
 // TODO(derek):
 // - Replace hard-coded IDs with p4info lookups.
@@ -13,34 +13,33 @@
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
-#include "testing/ipv4_tunnel_test.h"
+#include "testing/ipv6_tunnel_test.h"
 
 namespace ovsp4rt {
 
 constexpr bool INSERT_ENTRY = true;
 constexpr bool REMOVE_ENTRY = false;
 
-constexpr uint32_t TABLE_ID = 40763773U;
-constexpr uint32_t ACTION_ID = 20733968U;
+constexpr uint32_t TABLE_ID = 42283616U;
+constexpr uint32_t ACTION_ID = 29610186U;
 
 enum {
   MF_MOD_BLOB_PTR = 1,
 };
 
 enum {
-  SRC_PORT_PARAM_ID = 3,
-  DST_PORT_PARAM_ID = 4,
-  VNI_PARAM_ID = 5,
+  SRC_PORT_PARAM_ID = 7,
+  DST_PORT_PARAM_ID = 8,
+  VNI_PARAM_ID = 9,
 };
 
-class VxlanEncapV4TableEntryTest : public Ipv4TunnelTest {
+class GeneveEncapV6TableTest : public Ipv6TunnelTest {
  protected:
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
 
   void CheckAction() const {
     ASSERT_TRUE(table_entry.has_action());
-
     auto table_action = table_entry.action();
     auto action = table_action.action();
     ASSERT_EQ(action.action_id(), ACTION_ID);
@@ -66,14 +65,12 @@ class VxlanEncapV4TableEntryTest : public Ipv4TunnelTest {
       }
     }
 
-#if defined(ES2K_TARGET)
     ASSERT_TRUE(src_port.has_value());
 
     // To work around a bug in the Linux Networking P4 program, we
     // ignore the src_port value specified by the caller and instead
     // set the src_port param to (dst_port * 2).
     EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-#endif
 
     ASSERT_TRUE(dst_port.has_value());
     EXPECT_EQ(dst_port.value(), DST_PORT);
@@ -109,15 +106,16 @@ class VxlanEncapV4TableEntryTest : public Ipv4TunnelTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareVxlanEncapTableEntry()
+// PrepareV6GeneveEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(VxlanEncapV4TableEntryTest, remove_entry) {
+TEST_F(GeneveEncapV6TableTest, remove_entry) {
   // Arrange
-  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
+  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
+  PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
+                                 REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
@@ -126,12 +124,13 @@ TEST_F(VxlanEncapV4TableEntryTest, remove_entry) {
   CheckNoAction();
 }
 
-TEST_F(VxlanEncapV4TableEntryTest, insert_entry) {
+TEST_F(GeneveEncapV6TableTest, insert_entry) {
   // Arrange
-  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
+  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
 
   // Act
-  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+  PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
+                                 INSERT_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v4_table_test.cc
@@ -1,7 +1,7 @@
 // Copyright 2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Unit test for PrepareV6GeneveEncapTableEntry().
+// Unit test for PrepareVxlanEncapTableEntry().
 
 // TODO(derek):
 // - Replace hard-coded IDs with p4info lookups.
@@ -13,33 +13,34 @@
 #include "gtest/gtest.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
-#include "testing/ipv6_tunnel_test.h"
+#include "testing/ipv4_tunnel_test.h"
 
 namespace ovsp4rt {
 
 constexpr bool INSERT_ENTRY = true;
 constexpr bool REMOVE_ENTRY = false;
 
-constexpr uint32_t TABLE_ID = 42283616U;
-constexpr uint32_t ACTION_ID = 29610186U;
+constexpr uint32_t TABLE_ID = 40763773U;
+constexpr uint32_t ACTION_ID = 20733968U;
 
 enum {
   MF_MOD_BLOB_PTR = 1,
 };
 
 enum {
-  SRC_PORT_PARAM_ID = 7,
-  DST_PORT_PARAM_ID = 8,
-  VNI_PARAM_ID = 9,
+  SRC_PORT_PARAM_ID = 3,
+  DST_PORT_PARAM_ID = 4,
+  VNI_PARAM_ID = 5,
 };
 
-class GeneveEncapV6TableEntryTest : public Ipv6TunnelTest {
+class VxlanEncapV4TableTest : public Ipv4TunnelTest {
  protected:
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
 
   void CheckAction() const {
     ASSERT_TRUE(table_entry.has_action());
+
     auto table_action = table_entry.action();
     auto action = table_action.action();
     ASSERT_EQ(action.action_id(), ACTION_ID);
@@ -65,12 +66,14 @@ class GeneveEncapV6TableEntryTest : public Ipv6TunnelTest {
       }
     }
 
+#if defined(ES2K_TARGET)
     ASSERT_TRUE(src_port.has_value());
 
     // To work around a bug in the Linux Networking P4 program, we
     // ignore the src_port value specified by the caller and instead
     // set the src_port param to (dst_port * 2).
     EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
+#endif
 
     ASSERT_TRUE(dst_port.has_value());
     EXPECT_EQ(dst_port.value(), DST_PORT);
@@ -106,16 +109,15 @@ class GeneveEncapV6TableEntryTest : public Ipv6TunnelTest {
 };
 
 //----------------------------------------------------------------------
-// PrepareV6GeneveEncapTableEntry()
+// PrepareVxlanEncapTableEntry()
 //----------------------------------------------------------------------
 
-TEST_F(GeneveEncapV6TableEntryTest, remove_entry) {
+TEST_F(VxlanEncapV4TableTest, remove_entry) {
   // Arrange
-  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                 REMOVE_ENTRY);
+  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, REMOVE_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert
@@ -124,13 +126,12 @@ TEST_F(GeneveEncapV6TableEntryTest, remove_entry) {
   CheckNoAction();
 }
 
-TEST_F(GeneveEncapV6TableEntryTest, insert_entry) {
+TEST_F(VxlanEncapV4TableTest, insert_entry) {
   // Arrange
-  InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
+  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
   // Act
-  PrepareV6GeneveEncapTableEntry(&table_entry, tunnel_info, p4info,
-                                 INSERT_ENTRY);
+  PrepareVxlanEncapTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
   DumpTableEntry(table_entry);
 
   // Assert

--- a/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_encap_v6_table_test.cc
@@ -33,7 +33,7 @@ enum {
   VNI_PARAM_ID = 9,
 };
 
-class EncapV6TableEntryTest : public Ipv6TunnelTest {
+class VxlanEncapV6TableTest : public Ipv6TunnelTest {
  protected:
   struct tunnel_info tunnel_info = {0};
   p4::v1::TableEntry table_entry;
@@ -109,7 +109,7 @@ class EncapV6TableEntryTest : public Ipv6TunnelTest {
 // PrepareV6VxlanEncapTableEntry
 //----------------------------------------------------------------------
 
-TEST_F(EncapV6TableEntryTest, remove_entry) {
+TEST_F(VxlanEncapV6TableTest, remove_entry) {
   // Arrange
   InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 
@@ -124,7 +124,7 @@ TEST_F(EncapV6TableEntryTest, remove_entry) {
   CheckNoAction();
 }
 
-TEST_F(EncapV6TableEntryTest, insert_entry) {
+TEST_F(VxlanEncapV6TableTest, insert_entry) {
   // Arrange
   InitV6TunnelInfo(tunnel_info, OVS_TUNNEL_VXLAN);
 


### PR DESCRIPTION
- Renamed four tests to be consistent with current conventions. Shortened "_table_entry_test" suffix to "_table_test".