### PR TITLE
[ovsp4rt] Implement geneve_encap_v6_vlan_pop_test

### DIFF
--- a/ovs-p4rt/sidecar/ovsp4rt_private.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_private.h
@@ -89,6 +89,10 @@ void PrepareGeneveEncapAndVlanPopTableEntry(
     p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry);
 
+void PrepareV6GeneveEncapAndVlanPopTableEntry(
+    p4::v1::TableEntry* table_entry, const struct tunnel_info& tunnel_info,
+    const ::p4::config::v1::P4Info& p4info, bool insert_entry);
+
 void PrepareGeneveEncapTableEntry(p4::v1::TableEntry* table_entry,
                                   const struct tunnel_info& tunnel_info,
                                   const ::p4::config::v1::P4Info& p4info,

--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -181,6 +181,7 @@ define_ovsp4rt_test(geneve_decap_mod_table_test)
 define_ipv4_tunnel_test(geneve_encap_v4_table_test)
 define_ipv6_tunnel_test(geneve_encap_v6_table_test)
 define_ipv4_tunnel_test(geneve_encap_v4_vlan_pop_test)
+define_tunnel_test(geneve_encap_v6_vlan_pop_test)
 
 define_ovsp4rt_test(src_ip_mac_map_table_test)
 define_ovsp4rt_test(dst_ip_mac_map_table_test)

--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -113,11 +113,42 @@ macro(define_ipv6_tunnel_test TARGET)
   set_test_properties(${TARGET})
 
   target_link_libraries(${TARGET} PUBLIC
-    ipv4_test_utils
+    ipv6_test_utils
   )
 
   list(APPEND UNIT_TEST_NAMES ${TARGET})
 endmacro(define_ipv6_tunnel_test)
+
+#-----------------------------------------------------------------------
+# tunnel_test_utils
+#-----------------------------------------------------------------------
+add_library(tunnel_test_utils STATIC
+  base_table_test.h
+  base_tunnel_test.h
+  p4info_text.h
+  test_main.cc
+)
+
+target_link_libraries(tunnel_test_utils PUBLIC
+  absl::flags_parse
+)
+
+#-----------------------------------------------------------------------
+# define_tunnel_test()
+#-----------------------------------------------------------------------
+macro(define_tunnel_test TARGET)
+  add_executable(${TARGET}
+    ${TARGET}.cc
+  )
+
+  set_test_properties(${TARGET})
+
+  target_link_libraries(${TARGET} PUBLIC
+    tunnel_test_utils
+  )
+
+  list(APPEND UNIT_TEST_NAMES ${TARGET})
+endmacro(define_tunnel_test)
 
 #-----------------------------------------------------------------------
 # encode_host_port_value_test (DPDK, ES2K)

--- a/ovs-p4rt/sidecar/testing/base_tunnel_test.h
+++ b/ovs-p4rt/sidecar/testing/base_tunnel_test.h
@@ -1,0 +1,82 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef BASE_TUNNEL_TEST_H_
+#define BASE_TUNNEL_TEST_H_
+
+#include <arpa/inet.h>
+
+#include "base_table_test.h"
+#include "gtest/gtest.h"
+#include "ovsp4rt/ovs-p4rt.h"
+
+namespace ovsp4rt {
+
+class BaseTunnelTest : public BaseTableTest {
+ protected:
+  BaseTunnelTest() {}
+
+  void InitV4TunnelInfo(uint8_t tunnel_type) {
+    constexpr char IPV4_SRC_ADDR[] = "10.20.30.40";
+    constexpr char IPV4_DST_ADDR[] = "192.168.17.5";
+    constexpr int IPV4_PREFIX_LEN = 24;
+
+    constexpr uint16_t SRC_PORT = 0x1066;
+    constexpr uint16_t DST_PORT = 0x4224;
+    constexpr uint16_t VNI = 0x1776;
+
+    EXPECT_EQ(inet_pton(AF_INET, IPV4_SRC_ADDR,
+                        &tunnel_info.local_ip.ip.v4addr.s_addr),
+              1)
+        << "Error converting " << IPV4_SRC_ADDR;
+    tunnel_info.local_ip.prefix_len = IPV4_PREFIX_LEN;
+    tunnel_info.local_ip.family = AF_INET;
+
+    EXPECT_EQ(inet_pton(AF_INET, IPV4_DST_ADDR,
+                        &tunnel_info.remote_ip.ip.v4addr.s_addr),
+              1)
+        << "Error converting " << IPV4_DST_ADDR;
+    tunnel_info.remote_ip.prefix_len = IPV4_PREFIX_LEN;
+    tunnel_info.remote_ip.family = AF_INET;
+
+    tunnel_info.src_port = SRC_PORT;
+    tunnel_info.dst_port = DST_PORT;
+    tunnel_info.vni = VNI;
+    tunnel_info.tunnel_type = tunnel_type;
+  };
+
+  void InitV6TunnelInfo(uint8_t tunnel_type) {
+    constexpr char IPV6_SRC_ADDR[] = "fe80::215:5dff:fefa";
+    constexpr char IPV6_DST_ADDR[] = "fe80::215:192.168.17.5";
+    constexpr int IPV6_PREFIX_LEN = 64;
+
+    constexpr uint16_t SRC_PORT = 0x1984;
+    constexpr uint16_t DST_PORT = 0x4224;
+    constexpr uint16_t VNI = 0x1066;
+
+    EXPECT_EQ(inet_pton(AF_INET6, IPV6_SRC_ADDR,
+                        &tunnel_info.local_ip.ip.v6addr.__in6_u.__u6_addr32),
+              1)
+        << "Error converting " << IPV6_SRC_ADDR;
+    tunnel_info.local_ip.prefix_len = IPV6_PREFIX_LEN;
+    tunnel_info.local_ip.family = AF_INET6;
+
+    EXPECT_EQ(inet_pton(AF_INET6, IPV6_DST_ADDR,
+                        &tunnel_info.remote_ip.ip.v6addr.__in6_u.__u6_addr32),
+              1)
+        << "Error converting " << IPV6_DST_ADDR;
+    tunnel_info.remote_ip.prefix_len = IPV6_PREFIX_LEN;
+    tunnel_info.remote_ip.family = AF_INET6;
+
+    tunnel_info.src_port = SRC_PORT;
+    tunnel_info.dst_port = DST_PORT;
+    tunnel_info.vni = VNI;
+    tunnel_info.tunnel_type = tunnel_type;
+  };
+
+  struct tunnel_info tunnel_info = {0};
+};
+
+}  // namespace ovsp4rt
+
+#endif  // BASE_TUNNEL_TEST_H_

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v6_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v6_vlan_pop_test.cc
@@ -1,0 +1,215 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit test for PrepareV6GeneveEncapAndVlanPopTableEntry().
+
+#include <stdint.h>
+
+#include <iostream>
+#include <string>
+
+#include "base_tunnel_test.h"
+#include "gtest/gtest.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "ovsp4rt_private.h"
+
+namespace ovsp4rt {
+
+class GeneveEncapV6VlanPopTest : public BaseTunnelTest {
+ protected:
+  GeneveEncapV6VlanPopTest() {}
+
+  void SetUp() { SelectTable("geneve_encap_v6_vlan_pop_mod_table"); }
+
+  void InitAction() { SelectAction("geneve_encap_v6_vlan_pop"); }
+
+  //----------------------------
+  // CheckAction()
+  //----------------------------
+
+  void CheckAction() const {
+    ASSERT_TRUE(table_entry.has_action());
+    const auto& table_action = table_entry.action();
+
+    const auto& action = table_action.action();
+    EXPECT_EQ(action.action_id(), ActionId());
+
+    // Get param IDs.
+    const int SRC_ADDR_PARAM_ID = GetParamId("src_addr");
+    EXPECT_NE(SRC_ADDR_PARAM_ID, -1);
+
+    const int DST_ADDR_PARAM_ID = GetParamId("dst_addr");
+    EXPECT_NE(DST_ADDR_PARAM_ID, -1);
+
+    const int SRC_PORT_PARAM_ID = GetParamId("src_port");
+    EXPECT_NE(SRC_PORT_PARAM_ID, -1);
+
+    const int DST_PORT_PARAM_ID = GetParamId("dst_port");
+    EXPECT_NE(DST_PORT_PARAM_ID, -1);
+
+    const int VNI_PARAM_ID = GetParamId("vni");
+    EXPECT_NE(VNI_PARAM_ID, -1);
+
+    // Process action parameters.
+    const auto& params = action.params();
+
+    for (const auto& param : params) {
+      const auto& param_value = param.value();
+      int param_id = param.param_id();
+
+      if (param_id == SRC_ADDR_PARAM_ID) {
+        CheckSrcAddrParam(param_value);
+      } else if (param_id == DST_ADDR_PARAM_ID) {
+        CheckDstAddrParam(param_value);
+      } else if (param_id == SRC_PORT_PARAM_ID) {
+        CheckSrcPortParam(param_value);
+      } else if (param_id == DST_PORT_PARAM_ID) {
+        CheckDstPortParam(param_value);
+      } else if (param_id == VNI_PARAM_ID) {
+        CheckVniParam(param_value);
+      } else {
+        FAIL() << "Unexpected param_id (" << param_id << ")";
+      }
+    }
+  }
+  void CheckSrcAddrParam(const std::string& value) const {
+    // TODO(derek): implement CheckSrcAddrParam().
+  }
+
+  void CheckDstAddrParam(const std::string& value) const {
+    // TODO(derek): implement CheckDstAddrParam().
+  }
+
+  void CheckSrcPortParam(const std::string& value) const {
+    constexpr int PORT_PARAM_SIZE = 2;
+    EXPECT_EQ(value.size(), PORT_PARAM_SIZE);
+
+    auto src_port_param = DecodePortValue(value);
+    // To work around a bug in the Linux Networking P4 program, we
+    // ignore the src_port value specified by the caller and instead
+    // set the src_port param to (dst_port * 2).
+    auto expected = tunnel_info.dst_port * 2;
+    EXPECT_EQ(src_port_param, expected);
+  }
+
+  void CheckDstPortParam(const std::string& value) const {
+    constexpr int PORT_PARAM_SIZE = 2;
+    EXPECT_EQ(value.size(), PORT_PARAM_SIZE);
+
+    auto dst_port_param = DecodePortValue(value);
+    EXPECT_EQ(dst_port_param, tunnel_info.dst_port);
+  }
+
+  void CheckVniParam(const std::string& value) const {
+    constexpr int VNI_PARAM_SIZE = 3;
+    EXPECT_EQ(value.size(), VNI_PARAM_SIZE);
+
+    auto vni_param = DecodeVniValue(value);
+    EXPECT_EQ(vni_param, tunnel_info.vni);
+  }
+
+  //----------------------------
+  // CheckNoAction()
+  //----------------------------
+
+  void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }
+
+  //----------------------------
+  // CheckMatches()
+  //----------------------------
+
+  void CheckMatches() const {
+    ASSERT_EQ(table_entry.match_size(), 1);
+    const auto& match = table_entry.match()[0];
+
+    constexpr char MOD_BLOB_PTR[] = "vmeta.common.mod_blob_ptr";
+    const int MF_MOD_BLOB_PTR = GetMatchFieldId(MOD_BLOB_PTR);
+    ASSERT_NE(MF_MOD_BLOB_PTR, -1);
+
+    ASSERT_EQ(match.field_id(), MF_MOD_BLOB_PTR);
+
+    CheckVniMatch(match);
+  }
+
+  void CheckVniMatch(const ::p4::v1::FieldMatch& match) const {
+    constexpr int VNI_SIZE = 3;
+
+    ASSERT_TRUE(match.has_exact());
+    const auto& match_value = match.exact().value();
+
+    ASSERT_EQ(match_value.size(), VNI_SIZE);
+
+    uint32_t vni_value = DecodeVniValue(match_value);
+    EXPECT_EQ(vni_value, tunnel_info.vni);
+  }
+
+  //----------------------------
+  // CheckTableEntry()
+  //----------------------------
+
+  void CheckTableEntry() const {
+    ASSERT_TRUE(HasTable());
+    EXPECT_EQ(table_entry.table_id(), TableId());
+  }
+
+  //----------------------------
+  // Protected member data
+  //----------------------------
+
+  struct tunnel_info tunnel_info = {0};
+};
+
+//----------------------------------------------------------------------
+// Test cases
+//----------------------------------------------------------------------
+
+TEST_F(GeneveEncapV6VlanPopTest, remove_entry) {
+  // Arrange
+  InitV6TunnelInfo(OVS_TUNNEL_GENEVE);
+
+  // Act
+  PrepareV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                           REMOVE_ENTRY);
+
+  // Assert
+  CheckTableEntry();
+  CheckMatches();
+  CheckNoAction();
+}
+
+TEST_F(GeneveEncapV6VlanPopTest, insert_entry) {
+  // Arrange
+  InitV6TunnelInfo(OVS_TUNNEL_GENEVE);
+  InitAction();
+
+  // Act
+  PrepareV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                           INSERT_ENTRY);
+
+  // Assert
+  CheckTableEntry();
+  CheckAction();
+}
+
+#ifdef WIDE_VNI_VALUE
+
+TEST_F(GeneveEncapV6VlanPopTest, insert_entry_with_24_bit_vni) {
+  // Arrange
+  InitV4TunnelInfo(OVS_TUNNEL_GENEVE);
+  tunnel_info.vni = 0x95054;
+  InitAction();
+
+  // Act
+  PrepareV6GeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
+                                           INSERT_ENTRY);
+  DumpTableEntry();
+
+  // Assert
+  CheckTableEntry();
+  CheckMatches();
+  CheckAction();
+}
+
+#endif  // WIDE_VNI_VALUE
+
+}  // namespace ovsp4rt


### PR DESCRIPTION
- Unit test for PrepareV6GeneveEncapAndVlanPopTableEntry().

Based on PR https://github.com/ipdk-io/networking-recipe/pull/633.