### PR TITLE
[ovsp4rt] Update unit tests for wide VNIs

### DIFF
--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
@@ -48,7 +48,7 @@ class GeneveEncapV4VlanPopTest : public Ipv4TunnelTest {
 
     absl::optional<uint16_t> src_port;
     absl::optional<uint16_t> dst_port;
-    absl::optional<uint16_t> vni;
+    absl::optional<uint32_t> vni;
 
     for (int i = 0; i < num_params; ++i) {
       auto param = params[i];

--- a/ovs-p4rt/sidecar/testing/tunnel_term_v4_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/tunnel_term_v4_table_test.cc
@@ -295,4 +295,23 @@ TEST_F(TunnelTermV4TableTest, geneve_insert_tagged_entry) {
   CheckAction();
 }
 
+#ifdef WIDE_VNI_VALUES
+
+TEST_F(TunnelTermV4TableTest, geneve_insert_untagged_entry_with_20_bit_vni) {
+  // Arrange
+  InitTunnelInfo();
+  InitGeneveUntagged();
+  tunnel_info.vni = 0x95054;
+
+  // Act
+  PrepareTunnelTermTableEntry(&table_entry, tunnel_info, p4info, INSERT_ENTRY);
+
+  // Assert
+  CheckTableEntry();
+  CheckMatches();
+  CheckAction();
+}
+
+#endif  // WIDE_VNI_VALUES
+
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/testing/vxlan_decap_mod_table_test.cc
+++ b/ovs-p4rt/sidecar/testing/vxlan_decap_mod_table_test.cc
@@ -121,4 +121,40 @@ TEST_F(VxlanDecapModTableTest, insert_entry) {
   CheckAction();
 }
 
+#ifdef WIDE_VNI_VALUES
+
+TEST_F(VxlanDecapModTableTest, insert_entry_with_20_bit_vni) {
+  // Arrange
+  InitTunnelInfo();
+  InitAction();
+  tunnel_info.vni = 0x87124;  // 20-bit value
+
+  // Act
+  PrepareVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                 INSERT_ENTRY);
+
+  // Assert
+  CheckTableEntry();
+  CheckMatches();
+  CheckAction();
+}
+
+TEST_F(VxlanDecapModTableTest, insert_entry_with_24_bit_vni) {
+  // Arrange
+  InitTunnelInfo();
+  InitAction();
+  tunnel_info.vni = 0x871244;  // 24-bit value
+
+  // Act
+  PrepareVxlanDecapModTableEntry(&table_entry, tunnel_info, p4info,
+                                 INSERT_ENTRY);
+
+  // Assert
+  CheckTableEntry();
+  CheckMatches();
+  CheckAction();
+}
+
+#endif  // WIDE_VNI_VALUES
+
 }  // namespace ovsp4rt


### PR DESCRIPTION
- Widened a temporary variable from 16 to 32 bits.
- Added a couple of 24-bit VNI test cases.

Extracted from PR https://github.com/ipdk-io/networking-recipe/pull/616 so the test updates can be merged separately.

> [!NOTE]
> These are safe changes. They augment what they unit tests support. They have no effect on encodings or the public API.