### PR TITLE
[ovsp4rt] Update geneve_encap_v4_vlan_pop_test

### DIFF
--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -180,7 +180,7 @@ define_ovsp4rt_test(geneve_decap_mod_table_test)
 
 define_tunnel_test(geneve_encap_v4_table_test)
 define_ipv6_tunnel_test(geneve_encap_v6_table_test)
-define_ipv4_tunnel_test(geneve_encap_v4_vlan_pop_test)
+define_tunnel_test(geneve_encap_v4_vlan_pop_test)
 define_tunnel_test(geneve_encap_v6_vlan_pop_test)
 
 define_ovsp4rt_test(src_ip_mac_map_table_test)

--- a/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
+++ b/ovs-p4rt/sidecar/testing/geneve_encap_v4_vlan_pop_test.cc
@@ -3,87 +3,138 @@
 
 // Unit test for PrepareGeneveEncapAndVlanPopTableEntry().
 
-// TODO(derek): Replace hard-coded IDs with p4info lookups.
-// TODO(derek): Check all action params.
+#define DUMP_JSON
 
 #include <stdint.h>
 
 #include "absl/types/optional.h"
 #include "gtest/gtest.h"
+#include "ip_tunnel_test.h"
 #include "ovsp4rt/ovs-p4rt.h"
 #include "ovsp4rt_private.h"
-#include "testing/ipv4_tunnel_test.h"
 
 namespace ovsp4rt {
 
-constexpr bool INSERT_ENTRY = true;
-constexpr bool REMOVE_ENTRY = false;
-
-constexpr uint32_t TABLE_ID = 47977422U;
-constexpr uint32_t ACTION_ID = 26665268U;
-
-enum {
-  MF_MOD_BLOB_PTR = 1,
-};
-
-enum {
-  SRC_PORT_PARAM_ID = 3,
-  DST_PORT_PARAM_ID = 4,
-  VNI_PARAM_ID = 5,
-};
-
-class GeneveEncapV4VlanPopTest : public Ipv4TunnelTest {
+class GeneveEncapV4VlanPopTest : public IpTunnelTest {
  protected:
-  struct tunnel_info tunnel_info = {0};
-  p4::v1::TableEntry table_entry;
+  GeneveEncapV4VlanPopTest() {}
+
+  void SetUp() { SelectTable("geneve_encap_vlan_pop_mod_table"); }
+
+  void InitAction() { SelectAction("geneve_encap_vlan_pop"); }
+
+  //----------------------------
+  // CheckAction()
+  //----------------------------
 
   void CheckAction() const {
     ASSERT_TRUE(table_entry.has_action());
-    auto table_action = table_entry.action();
-    auto action = table_action.action();
-    ASSERT_EQ(action.action_id(), ACTION_ID);
+    const auto& table_action = table_entry.action();
 
-    auto params = action.params();
-    int num_params = action.params_size();
+    const auto& action = table_action.action();
+    ASSERT_EQ(action.action_id(), ActionId());
 
-    absl::optional<uint16_t> src_port;
-    absl::optional<uint16_t> dst_port;
-    absl::optional<uint32_t> vni;
+    // Get param IDs.
+    const int SRC_ADDR_PARAM_ID = GetParamId("src_addr");
+    EXPECT_NE(SRC_ADDR_PARAM_ID, -1);
 
-    for (int i = 0; i < num_params; ++i) {
-      auto param = params[i];
+    const int DST_ADDR_PARAM_ID = GetParamId("dst_addr");
+    EXPECT_NE(DST_ADDR_PARAM_ID, -1);
+
+    const int SRC_PORT_PARAM_ID = GetParamId("src_port");
+    EXPECT_NE(SRC_PORT_PARAM_ID, -1);
+
+    const int DST_PORT_PARAM_ID = GetParamId("dst_port");
+    EXPECT_NE(DST_PORT_PARAM_ID, -1);
+
+    const int VNI_PARAM_ID = GetParamId("vni");
+    EXPECT_NE(VNI_PARAM_ID, -1);
+
+    // Process action parameters.
+    const auto& params = action.params();
+
+    for (const auto& param : params) {
+      const auto& param_value = param.value();
       int param_id = param.param_id();
-      auto param_value = param.value();
 
-      if (param_id == SRC_PORT_PARAM_ID) {
-        src_port = DecodePortValue(param_value);
+      if (param_id == SRC_ADDR_PARAM_ID) {
+        CheckSrcAddrParam(param_value);
+      } else if (param_id == DST_ADDR_PARAM_ID) {
+        CheckDstAddrParam(param_value);
+      } else if (param_id == SRC_PORT_PARAM_ID) {
+        CheckSrcPortParam(param_value);
       } else if (param_id == DST_PORT_PARAM_ID) {
-        dst_port = DecodePortValue(param_value);
+        CheckDstPortParam(param_value);
       } else if (param_id == VNI_PARAM_ID) {
-        vni = DecodeVniValue(param_value);
+        CheckVniParam(param_value);
+      } else {
+        FAIL() << "Unexpected param_id (" << param_id << ")";
       }
     }
+  }
 
-    ASSERT_TRUE(src_port.has_value());
+  void CheckSrcAddrParam(const std::string& value) const {
+    constexpr int SRC_ADDR_SIZE = 4;
+    ASSERT_EQ(value.size(), SRC_ADDR_SIZE);
 
+    auto word_value = ntohl(DecodeWordValue(value));
+    ASSERT_EQ(word_value, tunnel_info.local_ip.ip.v4addr.s_addr);
+  }
+
+  void CheckDstAddrParam(const std::string& value) const {
+    constexpr int DST_ADDR_SIZE = 4;
+    ASSERT_EQ(value.size(), DST_ADDR_SIZE);
+
+    auto word_value = ntohl(DecodeWordValue(value));
+    ASSERT_EQ(word_value, tunnel_info.remote_ip.ip.v4addr.s_addr);
+  }
+
+  void CheckSrcPortParam(const std::string& value) const {
+    constexpr int PORT_PARAM_SIZE = 2;
+    EXPECT_EQ(value.size(), PORT_PARAM_SIZE);
+
+    auto src_port_param = DecodePortValue(value);
     // To work around a bug in the Linux Networking P4 program, we
     // ignore the src_port value specified by the caller and instead
     // set the src_port param to (dst_port * 2).
-    EXPECT_EQ(src_port.value(), DST_PORT * 2);  // SRC_PORT
-
-    ASSERT_TRUE(dst_port.has_value());
-    EXPECT_EQ(dst_port.value(), DST_PORT);
-
-    ASSERT_TRUE(vni.has_value());
-    EXPECT_EQ(vni.value(), tunnel_info.vni);
+    auto expected = tunnel_info.dst_port * 2;
+    EXPECT_EQ(src_port_param, expected);
   }
+
+  void CheckDstPortParam(const std::string& value) const {
+    constexpr int PORT_PARAM_SIZE = 2;
+    EXPECT_EQ(value.size(), PORT_PARAM_SIZE);
+
+    auto dst_port_param = DecodePortValue(value);
+    EXPECT_EQ(dst_port_param, tunnel_info.dst_port);
+  }
+
+  void CheckVniParam(const std::string& value) const {
+    constexpr int VNI_PARAM_SIZE = 3;
+    EXPECT_EQ(value.size(), VNI_PARAM_SIZE);
+
+    auto vni_param = DecodeVniValue(value);
+    EXPECT_EQ(vni_param, tunnel_info.vni);
+  }
+
+  //----------------------------
+  // CheckNoAction()
+  //----------------------------
 
   void CheckNoAction() const { ASSERT_FALSE(table_entry.has_action()); }
 
+  //----------------------------
+  // CheckMatches()
+  //----------------------------
+
   void CheckMatches() const {
     ASSERT_EQ(table_entry.match_size(), 1);
+    const auto& match = table_entry.match()[0];
 
-    auto& match = table_entry.match()[0];
+    constexpr char MOD_BLOB_PTR[] = "vmeta.common.mod_blob_ptr";
+    const int MF_MOD_BLOB_PTR = GetMatchFieldId(MOD_BLOB_PTR);
+    ASSERT_NE(MF_MOD_BLOB_PTR, -1);
+
     ASSERT_EQ(match.field_id(), MF_MOD_BLOB_PTR);
 
     CheckVniMatch(match);
@@ -101,21 +152,25 @@ class GeneveEncapV4VlanPopTest : public Ipv4TunnelTest {
     EXPECT_EQ(vni_value, tunnel_info.vni);
   }
 
-  void CheckTableEntry() const { ASSERT_EQ(table_entry.table_id(), TABLE_ID); }
+  //----------------------------
+  // CheckTableEntry()
+  //----------------------------
+
+  void CheckTableEntry() const { ASSERT_EQ(table_entry.table_id(), TableId()); }
 };
 
 //----------------------------------------------------------------------
-// PrepareGeneveEncapTableEntry()
+// Test cases
 //----------------------------------------------------------------------
 
 TEST_F(GeneveEncapV4VlanPopTest, remove_entry) {
   // Arrange
-  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
+  InitV4TunnelInfo(OVS_TUNNEL_GENEVE);
 
   // Act
   PrepareGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
                                          REMOVE_ENTRY);
-  DumpTableEntry(table_entry);
+  DumpTableEntry();
 
   // Assert
   CheckTableEntry();
@@ -125,12 +180,13 @@ TEST_F(GeneveEncapV4VlanPopTest, remove_entry) {
 
 TEST_F(GeneveEncapV4VlanPopTest, insert_entry) {
   // Arrange
-  InitV4TunnelInfo(tunnel_info, OVS_TUNNEL_GENEVE);
+  InitV4TunnelInfo(OVS_TUNNEL_GENEVE);
+  InitAction();
 
   // Act
   PrepareGeneveEncapAndVlanPopTableEntry(&table_entry, tunnel_info, p4info,
                                          INSERT_ENTRY);
-  DumpTableEntry(table_entry);
+  DumpTableEntry();
 
   // Assert
   CheckTableEntry();


### PR DESCRIPTION
- Updated to use IpTunnelTest base class.

- Replaced hard-coded IDs with p4info lookups.

- Added checks for "src_addr" and "dst_addr" params.

This test is now complete.