### PR TITLE
[ovsp4rt] Update vxlan_encap_v4_table_test

### DIFF
--- a/ovs-p4rt/sidecar/testing/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/testing/CMakeLists.txt
@@ -205,7 +205,7 @@ define_ovsp4rt_test(vlan_push_mod_table_test)
 define_ovsp4rt_test(vxlan_decap_mod_table_test)
 define_ovsp4rt_test(vxlan_decap_mod_vlan_push_test)
 
-define_ipv4_tunnel_test(vxlan_encap_v4_table_test)
+define_tunnel_test(vxlan_encap_v4_table_test)
 define_ipv6_tunnel_test(vxlan_encap_v6_table_test)
 define_ipv4_tunnel_test(vxlan_encap_v4_vlan_pop_test)
 define_ipv6_tunnel_test(vxlan_encap_v6_vlan_pop_test)


### PR DESCRIPTION
- Updated to use IpTunnelTest base class.

- Replaced hard-coded IDs with p4info lookups.

- Added checks for "src_addr" and "dst_addr" params.

This test is now complete.