### PR TITLE
[ovsp4rt] Implement Context object

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -22,6 +22,8 @@ endif()
 add_library(ovs_sidecar_o OBJECT
     ${OVSP4RT_INCLUDE_DIR}/ovsp4rt/ovs-p4rt.h
     ovsp4rt.cc
+    ovsp4rt_context.cc
+    ovsp4rt_context.h
     ovsp4rt_private.h
 )
 

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -566,7 +566,7 @@ void PrepareL2ToTunnelV6(p4::v1::TableEntry* table_entry,
   }
 }
 
-absl::Status ConfigFdbSmacTableEntry(ovsp4rt::OvsP4rtSession* session,
+absl::Status ConfigFdbSmacTableEntry(Context& context,
                                      const struct mac_learning_info& learn_info,
                                      const ::p4::config::v1::P4Info& p4info,
                                      bool insert_entry) {
@@ -574,16 +574,12 @@ absl::Status ConfigFdbSmacTableEntry(ovsp4rt::OvsP4rtSession* session,
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
   PrepareFdbSmacTableEntry(table_entry, learn_info, p4info, insert_entry,
                            detail);
 
-  auto status = ovsp4rt::SendWriteRequest(session, write_request);
+  auto status = context.sendWriteRequest(write_request);
   if (!status.ok()) {
     LogFailureWithMacAddr(insert_entry, detail.getLogTableName(),
                           learn_info.mac_addr);
@@ -592,18 +588,13 @@ absl::Status ConfigFdbSmacTableEntry(ovsp4rt::OvsP4rtSession* session,
 }
 
 absl::Status ConfigL2TunnelTableEntry(
-    ovsp4rt::OvsP4rtSession* session,
-    const struct mac_learning_info& learn_info,
+    Context& context, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
   if (learn_info.tnl_info.local_ip.family == AF_INET6 &&
       learn_info.tnl_info.remote_ip.family == AF_INET6) {
@@ -612,7 +603,7 @@ absl::Status ConfigL2TunnelTableEntry(
     PrepareL2ToTunnelV4(table_entry, learn_info, p4info, insert_entry, detail);
   }
 
-  auto status = ovsp4rt::SendWriteRequest(session, write_request);
+  auto status = context.sendWriteRequest(write_request);
   if (!status.ok()) {
     LogFailureWithMacAddr(insert_entry, detail.getLogTableName(),
                           learn_info.mac_addr);
@@ -623,23 +614,18 @@ absl::Status ConfigL2TunnelTableEntry(
 #endif  // ES2K_TARGET
 
 absl::Status ConfigFdbTxVlanTableEntry(
-    ovsp4rt::OvsP4rtSession* session,
-    const struct mac_learning_info& learn_info,
+    Context& context, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
   PrepareFdbTxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
                              detail);
 
-  auto status = ovsp4rt::SendWriteRequest(session, write_request);
+  auto status = context.sendWriteRequest(write_request);
   if (!status.ok()) {
     LogFailureWithMacAddr(insert_entry, detail.getLogTableName(),
                           learn_info.mac_addr);
@@ -648,23 +634,18 @@ absl::Status ConfigFdbTxVlanTableEntry(
 }
 
 absl::Status ConfigFdbRxVlanTableEntry(
-    ovsp4rt::OvsP4rtSession* session,
-    const struct mac_learning_info& learn_info,
+    Context& context, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
   PrepareFdbRxVlanTableEntry(table_entry, learn_info, p4info, insert_entry,
                              detail);
 
-  auto status = ovsp4rt::SendWriteRequest(session, write_request);
+  auto status = context.sendWriteRequest(write_request);
   if (!status.ok()) {
     LogFailureWithMacAddr(insert_entry, detail.getLogTableName(),
                           learn_info.mac_addr);
@@ -673,18 +654,13 @@ absl::Status ConfigFdbRxVlanTableEntry(
 }
 
 absl::Status ConfigFdbTunnelTableEntry(
-    ovsp4rt::OvsP4rtSession* session,
-    const struct mac_learning_info& learn_info,
+    Context& context, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
 #if defined(DPDK_TARGET)
   PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info,
@@ -708,7 +684,7 @@ absl::Status ConfigFdbTunnelTableEntry(
 #error "ASSERT: Unknown TARGET type!"
 #endif
 
-  auto status = ovsp4rt::SendWriteRequest(session, write_request);
+  auto status = context.sendWriteRequest(write_request);
   if (!status.ok()) {
     LogFailureWithMacAddr(insert_entry, detail.getLogTableName(),
                           learn_info.mac_addr);
@@ -1530,18 +1506,14 @@ void PrepareV6TunnelTermTableEntry(p4::v1::TableEntry* table_entry,
 }
 #endif  // ES2K_TARGET
 
-absl::Status ConfigEncapTableEntry(ovsp4rt::OvsP4rtSession* session,
+absl::Status ConfigEncapTableEntry(Context& context,
                                    const struct tunnel_info& tunnel_info,
                                    const ::p4::config::v1::P4Info& p4info,
                                    bool insert_entry) {
-  p4::v1::WriteRequest write_request;
+  ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
 #if defined(DPDK_TARGET)
   PrepareEncapTableEntry(table_entry, tunnel_info, p4info, insert_entry);
@@ -1568,7 +1540,7 @@ absl::Status ConfigEncapTableEntry(ovsp4rt::OvsP4rtSession* session,
 #error "ASSERT: Unknown TARGET type!"
 #endif
 
-  return ovsp4rt::SendWriteRequest(session, write_request);
+  return context.sendWriteRequest(write_request);
 }
 
 #if defined(ES2K_TARGET)
@@ -1726,18 +1698,14 @@ void PrepareDecapModAndVlanPushTableEntry(
   }
 }
 
-absl::Status ConfigDecapTableEntry(ovsp4rt::OvsP4rtSession* session,
+absl::Status ConfigDecapTableEntry(Context& context,
                                    const struct tunnel_info& tunnel_info,
                                    const ::p4::config::v1::P4Info& p4info,
                                    bool insert_entry) {
-  p4::v1::WriteRequest write_request;
+  ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
   if (tunnel_info.vlan_info.port_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED) {
     PrepareDecapModTableEntry(table_entry, tunnel_info, p4info, insert_entry);
@@ -1746,7 +1714,7 @@ absl::Status ConfigDecapTableEntry(ovsp4rt::OvsP4rtSession* session,
                                          insert_entry);
   }
 
-  return ovsp4rt::SendWriteRequest(session, write_request);
+  return context.sendWriteRequest(write_request);
 }
 
 void PrepareVlanPushTableEntry(p4::v1::TableEntry* table_entry,
@@ -1808,53 +1776,43 @@ void PrepareVlanPopTableEntry(p4::v1::TableEntry* table_entry,
   }
 }
 
-absl::Status ConfigVlanPushTableEntry(ovsp4rt::OvsP4rtSession* session,
-                                      const uint16_t vlan_id,
+absl::Status ConfigVlanPushTableEntry(Context& context, const uint16_t vlan_id,
                                       const ::p4::config::v1::P4Info& p4info,
                                       bool insert_entry) {
-  p4::v1::WriteRequest write_request;
+  ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
   PrepareVlanPushTableEntry(table_entry, vlan_id, p4info, insert_entry);
 
-  return ovsp4rt::SendWriteRequest(session, write_request);
+  return context.sendWriteRequest(write_request);
 }
 
 absl::StatusOr<::p4::v1::ReadResponse> GetVlanPushTableEntry(
-    ovsp4rt::OvsP4rtSession* session, const uint16_t vlan_id,
+    Context& context, const uint16_t vlan_id,
     const ::p4::config::v1::P4Info& p4info) {
   ::p4::v1::ReadRequest read_request;
   ::p4::v1::TableEntry* table_entry;
 
-  table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
+  table_entry = context.initReadRequest(&read_request);
 
   PrepareVlanPushTableEntry(table_entry, vlan_id, p4info, false);
 
-  return ovsp4rt::SendReadRequest(session, read_request);
+  return context.sendReadRequest(read_request);
 }
 
-absl::Status ConfigVlanPopTableEntry(ovsp4rt::OvsP4rtSession* session,
-                                     const uint16_t vlan_id,
+absl::Status ConfigVlanPopTableEntry(Context& context, const uint16_t vlan_id,
                                      const ::p4::config::v1::P4Info& p4info,
                                      bool insert_entry) {
-  p4::v1::WriteRequest write_request;
+  ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
   PrepareVlanPopTableEntry(table_entry, vlan_id, p4info, insert_entry);
 
-  return ovsp4rt::SendWriteRequest(session, write_request);
+  return context.sendWriteRequest(write_request);
 }
 
 void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
@@ -1898,7 +1856,7 @@ void PrepareSrcPortTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                  struct ip_mac_map_info& ip_info,
+                                  const struct ip_mac_map_info& ip_info,
                                   const ::p4::config::v1::P4Info& p4info,
                                   bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_SRC_IP_MAC_MAP_TABLE;
@@ -1947,7 +1905,7 @@ void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
 }
 
 void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                  struct ip_mac_map_info& ip_info,
+                                  const struct ip_mac_map_info& ip_info,
                                   const ::p4::config::v1::P4Info& p4info,
                                   bool insert_entry, DiagDetail& detail) {
   detail.table_id = LOG_DST_IP_MAC_MAP_TABLE;
@@ -2017,46 +1975,43 @@ void PrepareTxAccVsiTableEntry(p4::v1::TableEntry* table_entry, uint32_t sp,
 }
 
 absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV4TableEntry(
-    ovsp4rt::OvsP4rtSession* session,
-    const struct mac_learning_info& learn_info,
+    Context& context, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info) {
   ::p4::v1::ReadRequest read_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
+  table_entry = context.initReadRequest(&read_request);
 
   PrepareL2ToTunnelV4(table_entry, learn_info, p4info, false, detail);
 
   // This function does not log failed requests.
-  return ovsp4rt::SendReadRequest(session, read_request);
+  return context.sendReadRequest(read_request);
 }
 
 absl::StatusOr<::p4::v1::ReadResponse> GetL2ToTunnelV6TableEntry(
-    ovsp4rt::OvsP4rtSession* session,
-    const struct mac_learning_info& learn_info,
+    Context& context, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info) {
   ::p4::v1::ReadRequest read_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
+  table_entry = context.initReadRequest(&read_request);
 
   PrepareL2ToTunnelV6(table_entry, learn_info, p4info, false, detail);
 
   // This function does not log failed requests.
-  return ovsp4rt::SendReadRequest(session, read_request);
+  return context.sendReadRequest(read_request);
 }
 
 absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
-    ovsp4rt::OvsP4rtSession* session,
-    const struct mac_learning_info& learn_info,
+    Context& context, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool adding = false) {
   ::p4::v1::ReadRequest read_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
+  table_entry = context.initReadRequest(&read_request);
 
 #if defined(DPDK_TARGET)
   PrepareFdbTableEntryforV4VxlanTunnel(table_entry, learn_info, p4info, false,
@@ -2075,7 +2030,7 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
 #error "ASSERT: Unknown TARGET type!"
 #endif
 
-  auto status = ovsp4rt::SendReadRequest(session, read_request);
+  auto status = context.sendReadRequest(read_request);
   if (status.ok() && adding) {
     ovsp4rt_log_error("Error adding to %s: entry already exists",
                       detail.getLogTableName());
@@ -2084,18 +2039,17 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbTunnelTableEntry(
 }
 
 absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
-    ovsp4rt::OvsP4rtSession* session,
-    const struct mac_learning_info& learn_info,
+    Context& context, const struct mac_learning_info& learn_info,
     const ::p4::config::v1::P4Info& p4info, bool adding = false) {
   ::p4::v1::ReadRequest read_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
+  table_entry = context.initReadRequest(&read_request);
 
   PrepareFdbTxVlanTableEntry(table_entry, learn_info, p4info, false, detail);
 
-  auto status = ovsp4rt::SendReadRequest(session, read_request);
+  auto status = context.sendReadRequest(read_request);
   if (status.ok() && adding) {
     ovsp4rt_log_error("Error adding to %: entry already exists",
                       detail.getLogTableName());
@@ -2104,75 +2058,66 @@ absl::StatusOr<::p4::v1::ReadResponse> GetFdbVlanTableEntry(
 }
 
 absl::StatusOr<::p4::v1::ReadResponse> GetVmSrcTableEntry(
-    ovsp4rt::OvsP4rtSession* session, struct ip_mac_map_info ip_info,
+    Context& context, struct ip_mac_map_info ip_info,
     const ::p4::config::v1::P4Info& p4info) {
   ::p4::v1::ReadRequest read_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
+  table_entry = context.initReadRequest(&read_request);
 
   PrepareSrcIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
 
   // This function does not log failed requests.
-  return ovsp4rt::SendReadRequest(session, read_request);
+  return context.sendReadRequest(read_request);
 }
 
 absl::StatusOr<::p4::v1::ReadResponse> GetVmDstTableEntry(
-    ovsp4rt::OvsP4rtSession* session, struct ip_mac_map_info ip_info,
+    Context& context, const struct ip_mac_map_info& ip_info,
     const ::p4::config::v1::P4Info& p4info) {
   ::p4::v1::ReadRequest read_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
+  table_entry = context.initReadRequest(&read_request);
 
   PrepareDstIpMacMapTableEntry(table_entry, ip_info, p4info, false, detail);
 
-  return ovsp4rt::SendReadRequest(session, read_request);
+  return context.sendReadRequest(read_request);
 }
 
 absl::StatusOr<::p4::v1::ReadResponse> GetTxAccVsiTableEntry(
-    ovsp4rt::OvsP4rtSession* session, uint32_t sp,
-    const ::p4::config::v1::P4Info& p4info) {
+    Context& context, uint32_t sp, const ::p4::config::v1::P4Info& p4info) {
   ::p4::v1::ReadRequest read_request;
   ::p4::v1::TableEntry* table_entry;
 
-  table_entry = ovsp4rt::SetupTableEntryToRead(session, &read_request);
+  table_entry = context.initReadRequest(&read_request);
 
   PrepareTxAccVsiTableEntry(table_entry, sp, p4info);
 
-  return ovsp4rt::SendReadRequest(session, read_request);
+  return context.sendReadRequest(read_request);
 }
 
 absl::Status ConfigureVsiSrcPortTableEntry(
-    ovsp4rt::OvsP4rtSession* session, const struct src_port_info& sp,
+    Context& context, const struct src_port_info& sp,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
-  p4::v1::WriteRequest write_request;
+  ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
   PrepareSrcPortTableEntry(table_entry, sp, p4info, insert_entry);
 
-  return ovsp4rt::SendWriteRequest(session, write_request);
+  return context.sendWriteRequest(write_request);
 }
 
 absl::Status ConfigRxTunnelSrcPortTableEntry(
-    ovsp4rt::OvsP4rtSession* session, const struct tunnel_info& tunnel_info,
+    Context& context, const struct tunnel_info& tunnel_info,
     const ::p4::config::v1::P4Info& p4info, bool insert_entry) {
-  p4::v1::WriteRequest write_request;
+  ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
   if (tunnel_info.local_ip.family == AF_INET &&
       tunnel_info.remote_ip.family == AF_INET) {
@@ -2182,23 +2127,19 @@ absl::Status ConfigRxTunnelSrcPortTableEntry(
     PrepareV6RxTunnelTableEntry(table_entry, tunnel_info, p4info, insert_entry);
   }
 
-  return ovsp4rt::SendWriteRequest(session, write_request);
+  return context.sendWriteRequest(write_request);
 }
 
 #endif  // ES2K_TARGET
 
-absl::Status ConfigTunnelTermTableEntry(ovsp4rt::OvsP4rtSession* session,
+absl::Status ConfigTunnelTermTableEntry(Context& context,
                                         const struct tunnel_info& tunnel_info,
                                         const ::p4::config::v1::P4Info& p4info,
                                         bool insert_entry) {
-  p4::v1::WriteRequest write_request;
+  ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 #if defined(DPDK_TARGET)
   PrepareTunnelTermTableEntry(table_entry, tunnel_info, p4info, insert_entry);
 
@@ -2215,53 +2156,45 @@ absl::Status ConfigTunnelTermTableEntry(ovsp4rt::OvsP4rtSession* session,
 #error "ASSERT: Unknown TARGET type!"
 #endif
 
-  return ovsp4rt::SendWriteRequest(session, write_request);
+  return context.sendWriteRequest(write_request);
 }
 
 #if defined(ES2K_TARGET)
 
-absl::Status ConfigDstIpMacMapTableEntry(ovsp4rt::OvsP4rtSession* session,
-                                         struct ip_mac_map_info& ip_info,
+absl::Status ConfigDstIpMacMapTableEntry(Context& context,
+                                         const struct ip_mac_map_info& ip_info,
                                          const ::p4::config::v1::P4Info& p4info,
                                          bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
   PrepareDstIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
                                detail);
 
-  auto status = ovsp4rt::SendWriteRequest(session, write_request);
+  auto status = context.sendWriteRequest(write_request);
   if (!status.ok()) {
     LogFailure(insert_entry, detail.getLogTableName());
   }
   return status;
 }
 
-absl::Status ConfigSrcIpMacMapTableEntry(ovsp4rt::OvsP4rtSession* session,
-                                         struct ip_mac_map_info& ip_info,
+absl::Status ConfigSrcIpMacMapTableEntry(Context& context,
+                                         const struct ip_mac_map_info& ip_info,
                                          const ::p4::config::v1::P4Info& p4info,
                                          bool insert_entry) {
   ::p4::v1::WriteRequest write_request;
   ::p4::v1::TableEntry* table_entry;
   DiagDetail detail;
 
-  if (insert_entry) {
-    table_entry = ovsp4rt::SetupTableEntryToInsert(session, &write_request);
-  } else {
-    table_entry = ovsp4rt::SetupTableEntryToDelete(session, &write_request);
-  }
+  table_entry = context.initWriteRequest(&write_request, insert_entry);
 
   PrepareSrcIpMacMapTableEntry(table_entry, ip_info, p4info, insert_entry,
                                detail);
 
-  auto status = ovsp4rt::SendWriteRequest(session, write_request);
+  auto status = context.sendWriteRequest(write_request);
   if (!status.ok()) {
     LogFailure(insert_entry, detail.getLogTableName());
   }
@@ -2315,7 +2248,7 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
 
   if (!insert_entry) {
     auto status_or_read_response =
-        GetL2ToTunnelV4TableEntry(context.session(), learn_info, p4info);
+        GetL2ToTunnelV4TableEntry(context, learn_info, p4info);
     if (status_or_read_response.ok()) {
       learn_info.is_tunnel = true;
     }
@@ -2325,7 +2258,7 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
      */
     if (!learn_info.is_tunnel) {
       status_or_read_response =
-          GetL2ToTunnelV6TableEntry(context.session(), learn_info, p4info);
+          GetL2ToTunnelV6TableEntry(context, learn_info, p4info);
       if (status_or_read_response.ok()) {
         learn_info.is_tunnel = true;
         learn_info.tnl_info.local_ip.family = AF_INET6;
@@ -2337,41 +2270,40 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
   if (learn_info.is_tunnel) {
     if (insert_entry) {
       auto status_or_read_response =
-          GetFdbTunnelTableEntry(context.session(), learn_info, p4info, true);
+          GetFdbTunnelTableEntry(context, learn_info, p4info, true);
       if (status_or_read_response.ok()) {
         return;
       }
     }
 
-    status = ConfigFdbTunnelTableEntry(context.session(), learn_info, p4info,
-                                       insert_entry);
+    status =
+        ConfigFdbTunnelTableEntry(context, learn_info, p4info, insert_entry);
     if (!status.ok()) {
     }
 
-    status = ConfigL2TunnelTableEntry(context.session(), learn_info, p4info,
-                                      insert_entry);
+    status =
+        ConfigL2TunnelTableEntry(context, learn_info, p4info, insert_entry);
     if (!status.ok()) {
     }
 
-    status = ConfigFdbSmacTableEntry(context.session(), learn_info, p4info,
-                                     insert_entry);
+    status = ConfigFdbSmacTableEntry(context, learn_info, p4info, insert_entry);
     if (!status.ok()) {
     }
   } else {
     if (insert_entry) {
       auto status_or_read_response =
-          GetFdbVlanTableEntry(context.session(), learn_info, p4info, true);
+          GetFdbVlanTableEntry(context, learn_info, p4info, true);
       if (status_or_read_response.ok()) {
         return;
       }
 
-      status = ConfigFdbRxVlanTableEntry(context.session(), learn_info, p4info,
-                                         insert_entry);
+      status =
+          ConfigFdbRxVlanTableEntry(context, learn_info, p4info, insert_entry);
       if (!status.ok()) {
       }
 
       status_or_read_response =
-          GetTxAccVsiTableEntry(context.session(), learn_info.src_port, p4info);
+          GetTxAccVsiTableEntry(context, learn_info.src_port, p4info);
       if (!status_or_read_response.ok()) {
         return;
       }
@@ -2406,13 +2338,12 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
       learn_info.src_port = host_sp;
     }
 
-    status = ConfigFdbTxVlanTableEntry(context.session(), learn_info, p4info,
-                                       insert_entry);
+    status =
+        ConfigFdbTxVlanTableEntry(context, learn_info, p4info, insert_entry);
     if (!status.ok()) {
     }
 
-    status = ConfigFdbSmacTableEntry(context.session(), learn_info, p4info,
-                                     insert_entry);
+    status = ConfigFdbSmacTableEntry(context, learn_info, p4info, insert_entry);
     if (!status.ok()) {
     }
   }
@@ -2438,8 +2369,8 @@ void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
   status = context.getPipelineConfig(&p4info);
   if (!status.ok()) return;
 
-  status = ConfigRxTunnelSrcPortTableEntry(context.session(), tunnel_info,
-                                           p4info, insert_entry);
+  status = ConfigRxTunnelSrcPortTableEntry(context, tunnel_info, p4info,
+                                           insert_entry);
   if (!status.ok()) return;
 }
 
@@ -2496,7 +2427,7 @@ void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
   if (!status.ok()) return;
 
   auto status_or_read_response =
-      GetTxAccVsiTableEntry(context.session(), vsi_sp.src_port, p4info);
+      GetTxAccVsiTableEntry(context, vsi_sp.src_port, p4info);
   if (!status_or_read_response.ok()) return;
 
   ::p4::v1::ReadResponse read_response =
@@ -2528,8 +2459,7 @@ void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
 
   vsi_sp.src_port = host_sp;
 
-  status = ConfigureVsiSrcPortTableEntry(context.session(), vsi_sp, p4info,
-                                         insert_entry);
+  status = ConfigureVsiSrcPortTableEntry(context, vsi_sp, p4info, insert_entry);
   if (!status.ok()) return;
 }
 
@@ -2552,12 +2482,10 @@ void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
   status = context.getPipelineConfig(&p4info);
   if (!status.ok()) return;
 
-  status = ConfigVlanPushTableEntry(context.session(), vlan_id, p4info,
-                                    insert_entry);
+  status = ConfigVlanPushTableEntry(context, vlan_id, p4info, insert_entry);
   if (!status.ok()) return;
 
-  status =
-      ConfigVlanPopTableEntry(context.session(), vlan_id, p4info, insert_entry);
+  status = ConfigVlanPopTableEntry(context, vlan_id, p4info, insert_entry);
   if (!status.ok()) return;
 }
 
@@ -2583,15 +2511,15 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
   if (!status.ok()) return;
 
   if (learn_info.is_tunnel) {
-    status = ConfigFdbTunnelTableEntry(context.session(), learn_info, p4info,
-                                       insert_entry);
+    status =
+        ConfigFdbTunnelTableEntry(context, learn_info, p4info, insert_entry);
   } else if (learn_info.is_vlan) {
-    status = ConfigFdbTxVlanTableEntry(context.session(), learn_info, p4info,
-                                       insert_entry);
+    status =
+        ConfigFdbTxVlanTableEntry(context, learn_info, p4info, insert_entry);
     if (!status.ok()) return;
 
-    status = ConfigFdbRxVlanTableEntry(context.session(), learn_info, p4info,
-                                       insert_entry);
+    status =
+        ConfigFdbRxVlanTableEntry(context, learn_info, p4info, insert_entry);
     if (!status.ok()) return;
   }
 }
@@ -2640,18 +2568,16 @@ void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
   status = context.getPipelineConfig(&p4info);
   if (!status.ok()) return;
 
-  status = ConfigEncapTableEntry(context.session(), tunnel_info, p4info,
-                                 insert_entry);
+  status = ConfigEncapTableEntry(context, tunnel_info, p4info, insert_entry);
   if (!status.ok()) return;
 
 #if defined(ES2K_TARGET)
-  status = ConfigDecapTableEntry(context.session(), tunnel_info, p4info,
-                                 insert_entry);
+  status = ConfigDecapTableEntry(context, tunnel_info, p4info, insert_entry);
   if (!status.ok()) return;
 #endif
 
-  status = ConfigTunnelTermTableEntry(context.session(), tunnel_info, p4info,
-                                      insert_entry);
+  status =
+      ConfigTunnelTermTableEntry(context, tunnel_info, p4info, insert_entry);
   if (!status.ok()) return;
 }
 
@@ -2676,32 +2602,30 @@ void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
   if (!status.ok()) return;
 
   if (insert_entry) {
-    auto status_or_read_response =
-        GetVmSrcTableEntry(context.session(), ip_info, p4info);
+    auto status_or_read_response = GetVmSrcTableEntry(context, ip_info, p4info);
     if (status_or_read_response.ok()) {
       goto try_dstip;
     }
   }
 
   if (ValidIpAddr(ip_info.src_ip_addr.ip.v4addr.s_addr)) {
-    status = ConfigSrcIpMacMapTableEntry(context.session(), ip_info, p4info,
-                                         insert_entry);
+    status =
+        ConfigSrcIpMacMapTableEntry(context, ip_info, p4info, insert_entry);
     if (!status.ok()) {
     }
   }
 
 try_dstip:
   if (insert_entry) {
-    auto status_or_read_response =
-        GetVmDstTableEntry(context.session(), ip_info, p4info);
+    auto status_or_read_response = GetVmDstTableEntry(context, ip_info, p4info);
     if (status_or_read_response.ok()) {
       return;
     }
   }
 
   if (ValidIpAddr(ip_info.src_ip_addr.ip.v4addr.s_addr)) {
-    status = ConfigDstIpMacMapTableEntry(context.session(), ip_info, p4info,
-                                         insert_entry);
+    status =
+        ConfigDstIpMacMapTableEntry(context, ip_info, p4info, insert_entry);
     if (!status.ok()) {
     }
   }

--- a/ovs-p4rt/sidecar/ovsp4rt_context.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_context.cc
@@ -1,0 +1,67 @@
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ovsp4rt_context.h"
+
+#include "absl/flags/flag.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "session/ovsp4rt_credentials.h"
+#include "session/ovsp4rt_session.h"
+
+#define DEFAULT_OVS_P4RT_ROLE_NAME "ovs-p4rt"
+
+ABSL_FLAG(uint64_t, device_id, 1, "P4Runtime device ID.");
+
+ABSL_FLAG(std::string, role_name, DEFAULT_OVS_P4RT_ROLE_NAME,
+          "P4 config role name.");
+
+namespace ovsp4rt {
+
+absl::Status Context::connect(const char* grpc_addr) {
+  // Start a new client session.
+  auto result = ovsp4rt::OvsP4rtSession::Create(
+      grpc_addr, GenerateClientCredentials(), absl::GetFlag(FLAGS_device_id),
+      absl::GetFlag(FLAGS_role_name));
+  if (!result.ok()) {
+    return result.status();
+  }
+
+  // Unwrap the session from the StatusOr object.
+  session_ = std::move(result).value();
+  return absl::OkStatus();
+}
+
+absl::Status Context::getPipelineConfig(::p4::config::v1::P4Info* p4info) {
+  return GetForwardingPipelineConfig(session_.get(), p4info);
+}
+
+::p4::v1::TableEntry* Context::initReadRequest(::p4::v1::ReadRequest* request) {
+  return SetupTableEntryToRead(session_.get(), request);
+}
+
+absl::StatusOr<::p4::v1::ReadResponse> Context::sendReadRequest(
+    const p4::v1::ReadRequest& request) {
+  return SendReadRequest(session_.get(), request);
+}
+
+::p4::v1::TableEntry* Context::initInsertRequest(
+    ::p4::v1::WriteRequest* request) {
+  return SetupTableEntryToInsert(session_.get(), request);
+}
+
+::p4::v1::TableEntry* Context::initModifyRequest(
+    ::p4::v1::WriteRequest* request) {
+  return SetupTableEntryToModify(session_.get(), request);
+}
+
+::p4::v1::TableEntry* Context::initDeleteRequest(
+    ::p4::v1::WriteRequest* request) {
+  return SetupTableEntryToDelete(session_.get(), request);
+}
+
+absl::Status Context::sendWriteRequest(const p4::v1::WriteRequest& request) {
+  return SendWriteRequest(session_.get(), request);
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/ovsp4rt_context.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_context.h
@@ -8,14 +8,10 @@
 
 #include <string>
 
-//#include "absl/flags/declare.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "session/ovsp4rt_session.h"
-
-//ABSL_DECLARE_FLAG(uint64_t, device_id);
-//ABSL_DECLARE_FLAG(std::string, role_name);
 
 namespace ovsp4rt {
 

--- a/ovs-p4rt/sidecar/ovsp4rt_context.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_context.h
@@ -1,0 +1,61 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_CONTEXT_H_
+#define OVSP4RT_CONTEXT_H_
+
+#include <stdint.h>
+
+#include <string>
+
+//#include "absl/flags/declare.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "session/ovsp4rt_session.h"
+
+//ABSL_DECLARE_FLAG(uint64_t, device_id);
+//ABSL_DECLARE_FLAG(std::string, role_name);
+
+namespace ovsp4rt {
+
+class Context {
+ public:
+  Context() {}
+
+  absl::Status connect(const char* grpc_addr);
+
+  OvsP4rtSession* session() const { return session_.get(); }
+
+  absl::Status getPipelineConfig(::p4::config::v1::P4Info* p4info);
+
+  // Read requests
+  ::p4::v1::TableEntry* initReadRequest(::p4::v1::ReadRequest* request);
+
+  absl::StatusOr<p4::v1::ReadResponse> sendReadRequest(
+      const p4::v1::ReadRequest& request);
+
+  // Write requests
+  ::p4::v1::TableEntry* initInsertRequest(::p4::v1::WriteRequest* request);
+  ::p4::v1::TableEntry* initModifyRequest(::p4::v1::WriteRequest* request);
+  ::p4::v1::TableEntry* initDeleteRequest(::p4::v1::WriteRequest* request);
+
+  ::p4::v1::TableEntry* initWriteRequest(::p4::v1::WriteRequest* request,
+                                         bool insert_entry) {
+    if (insert_entry) {
+      return initInsertRequest(request);
+    } else {
+      return initDeleteRequest(request);
+    }
+  }
+
+  absl::Status sendWriteRequest(const p4::v1::WriteRequest& request);
+
+ private:
+  // P4Runtime session.
+  std::unique_ptr<ovsp4rt::OvsP4rtSession> session_;
+};
+
+}  // namespace ovsp4rt
+
+#endif  // OVSP4RT_CONTEXT_H_

--- a/ovs-p4rt/sidecar/ovsp4rt_private.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_private.h
@@ -36,7 +36,7 @@ void PrepareVxlanEncapTableEntry(p4::v1::TableEntry* table_entry,
 #if defined(ES2K_TARGET)
 
 void PrepareDstIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                  struct ip_mac_map_info& ip_info,
+                                  const struct ip_mac_map_info& ip_info,
                                   const ::p4::config::v1::P4Info& p4info,
                                   bool insert_entry, DiagDetail& detail);
 
@@ -66,7 +66,7 @@ void PrepareFdbTxVlanTableEntry(p4::v1::TableEntry* table_entry,
                                 bool insert_entry, DiagDetail& detail);
 
 void PrepareSrcIpMacMapTableEntry(p4::v1::TableEntry* table_entry,
-                                  struct ip_mac_map_info& ip_info,
+                                  const struct ip_mac_map_info& ip_info,
                                   const ::p4::config::v1::P4Info& p4info,
                                   bool insert_entry, DiagDetail& detail);
 


### PR DESCRIPTION
- Implemented the `Context` class, to provide an abstract interface to the P4Runtime server.

- Modified ovsp4rt.cc to use the `Context` object instead of the `OvsP4rtSession` object.

In addition to simplifying the code, the `Context` object should allow us to mock out the P4Runtime server for unit testing.