### PR TITLE
[ovsp4rt] Add 20-bit VNI (tunnel_id) test case

### DIFF
--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_geneve_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_geneve_entry_test.cc
@@ -258,4 +258,24 @@ TEST_F(FdbTxGeneveEntryTest, insert_v6_untagged_entry) {
   CheckAction();
 }
 
+#ifdef WIDE_VNI_VALUES
+
+TEST_F(FdbTxGeneveEntryTest, insert_v6_untagged_entry_20_bit_vni) {
+  // Arrange
+  InitLearnInfo(OVS_TUNNEL_GENEVE);
+  InitV6NativeUntagged(POP_VLAN_SET_GENEVE_UNDERLAY_V6);
+  learn_info.tnl_info.vni = 0xFACED;
+
+  // Act
+  PrepareFdbTableEntryforV4GeneveTunnel(&table_entry, learn_info, p4info,
+                                        INSERT_ENTRY, detail);
+
+  // Assert
+  CheckTableEntry();
+  CheckMatches();
+  CheckAction();
+}
+
+#endif  //WIDE_VNI_VALUES
+
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/tests/es2k/fdb_tx_geneve_entry_test.cc
+++ b/ovs-p4rt/sidecar/tests/es2k/fdb_tx_geneve_entry_test.cc
@@ -276,6 +276,6 @@ TEST_F(FdbTxGeneveEntryTest, insert_v6_untagged_entry_20_bit_vni) {
   CheckAction();
 }
 
-#endif  //WIDE_VNI_VALUES
+#endif  // WIDE_VNI_VALUES
 
 }  // namespace ovsp4rt


### PR DESCRIPTION
The maximum with of VNI when it is used as a tunnel_id is 20 bits.
- Added a happy-path test for a 20-bit value.
- Added an unhappy-path test for a 24-bit value.