### PR TITLE
Fix cmake warning in FindDpdkDriver module

### DIFF
--- a/cmake/FindDpdkDriver.cmake
+++ b/cmake/FindDpdkDriver.cmake
@@ -147,7 +147,6 @@ _set_sde_pkg_config_path()
 #-----------------------------------------------------------------------
 # Use pkg-config to find DPDK module
 #-----------------------------------------------------------------------
-include(FindPkgConfig)
 pkg_check_modules(DpdkDriver REQUIRED libdpdk)
 
 #-----------------------------------------------------------------------


### PR DESCRIPTION
Addresses the following warning:
```text
CMake Warning (dev) at /usr/local/share/cmake-3.30/Modules/FindPackageHandleStandardArgs.cmake:441 (message):
  The package name passed to `find_package_handle_standard_args` (PkgConfig)
  does not match the name of the calling package (DpdkDriver).  This can lead
  to problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /usr/local/share/cmake-3.30/Modules/FindPkgConfig.cmake:114 (find_package_handle_standard_args)
  cmake/FindDpdkDriver.cmake:150 (include)
  CMakeLists.txt:183 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```