### PR TITLE
[ovsp4rt] JSON encoder updates

### DIFF
--- a/ovs-p4rt/sidecar/journal/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/journal/CMakeLists.txt
@@ -47,8 +47,8 @@ target_include_directories(encode_addr_test PUBLIC
 )
 
 target_link_libraries(encode_addr_test PUBLIC
-  GTest::gtest
   absl::flags_parse
+  GTest::gtest
 )
 
 add_test(NAME encode_addr_test COMMAND encode_addr_test)

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_encode.cc
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_encode.cc
@@ -11,8 +11,13 @@
 #include "ovsp4rt/ovs-p4rt.h"
 
 namespace {
+
 constexpr uint32_t LEARN_INFO_SCHEMA = 1;
 constexpr uint32_t PORT_INFO_SCHEMA = 1;
+constexpr uint32_t TUNNEL_INFO_SCHEMA = 1;
+constexpr uint32_t VLAN_ID_SCHEMA = 1;
+constexpr uint32_t IP_MAC_MAP_INFO_SCHEMA = 1;
+
 }  // namespace
 
 namespace ovsp4rt {
@@ -110,9 +115,26 @@ void VlanInfoToJson(nlohmann::json& json, const struct vlan_info& info) {
 // Return JSON representation of API input.
 //----------------------------------------------------------------------
 
+// ovsp4rt_config_ip_mac_map_entry()
+nlohmann::json EncodeIpMacMapInfo(const char* func_name,
+                                  const struct ip_mac_map_info& info,
+                                  bool insert_entry) {
+  nlohmann::json json;
+
+  json["func_name"] = func_name;
+  json["schema"] = IP_MAC_MAP_INFO_SCHEMA;
+  json["struct_name"] = "ip_mac_map_info";
+
+  auto& params = json["params"];
+  IpMacMapInfoToJson(params["ip_mac_map_info"], info);
+  params["insert_entry"] = insert_entry;
+
+  return json;
+}
+
 // ovsp4rt_config_fdb_entry()
 nlohmann::json EncodeMacLearningInfo(const char* func_name,
-                                     const struct mac_learning_info& learn_info,
+                                     const struct mac_learning_info& info,
                                      bool insert_entry) {
   nlohmann::json json;
 
@@ -121,16 +143,17 @@ nlohmann::json EncodeMacLearningInfo(const char* func_name,
   json["struct_name"] = "mac_learning_info";
 
   auto& params = json["params"];
-  MacLearningInfoToJson(params["learn_info"], learn_info);
+  MacLearningInfoToJson(params["learn_info"], info);
   params["insert_entry"] = insert_entry;
 
   return json;
 }
 
+// ovsp4rt_config_rx_tunnel_src_entry()
 // ovsp4rt_config_src_port_entry()
 // ovsp4rt_config_tunnel_src_port_entry()
 nlohmann::json EncodeSrcPortInfo(const char* func_name,
-                                 const struct src_port_info& sp_info,
+                                 const struct src_port_info& info,
                                  bool insert_entry) {
   nlohmann::json json;
 
@@ -139,7 +162,40 @@ nlohmann::json EncodeSrcPortInfo(const char* func_name,
   json["struct_name"] = "src_port_info";
 
   auto& params = json["params"];
-  SrcPortInfoToJson(params["port_info"], sp_info);
+  SrcPortInfoToJson(params["port_info"], info);
+  params["insert_entry"] = insert_entry;
+
+  return json;
+}
+
+// ovsp4rt_config_rx_tunnel_src_entry()
+// ovsp4rt_config_tunnel_entry()
+nlohmann::json EncodeTunnelInfo(const char* func_name,
+                                const struct tunnel_info& info,
+                                bool insert_entry) {
+  nlohmann::json json;
+
+  json["func_name"] = func_name;
+  json["schema"] = TUNNEL_INFO_SCHEMA;
+  json["struct_name"] = "tunnel_info";
+
+  auto& params = json["params"];
+  TunnelInfoToJson(json["tunnel_info"], info);
+  params["insert_entry"] = insert_entry;
+
+  return json;
+}
+
+// ovsp4rt_config_rx_tunnel_src_entry()
+nlohmann::json EncodeVlanId(const char* func_name, uint16_t vlan_id,
+                            bool insert_entry) {
+  nlohmann::json json;
+
+  json["func_name"] = func_name;
+  json["schema"] = VLAN_ID_SCHEMA;
+
+  auto& params = json["params"];
+  params["vlan_id"] = vlan_id;
   params["insert_entry"] = insert_entry;
 
   return json;

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_encode.h
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_encode.h
@@ -48,13 +48,24 @@ extern void VlanInfoToJson(nlohmann::json& json, const struct vlan_info& info);
 // Return JSON representation of API inputs.
 //----------------------------------------------------------------------
 
+extern nlohmann::json EncodeIpMacMapInfo(const char* func_name,
+                                         const struct ip_mac_map_info& info,
+                                         bool insert_entry);
+
 extern nlohmann::json EncodeMacLearningInfo(
-    const char* func_name, const struct mac_learning_info& learn_info,
+    const char* func_name, const struct mac_learning_info& info,
     bool insert_entry);
 
 extern nlohmann::json EncodeSrcPortInfo(const char* func_name,
-                                        const struct src_port_info& sp_info,
+                                        const struct src_port_info& info,
                                         bool insert_entry);
+
+extern nlohmann::json EncodeTunnelInfo(const char* func_name,
+                                       const struct tunnel_info& info,
+                                       bool insert_entry);
+
+extern nlohmann::json EncodeVlanId(const char* func_name, uint16_t vlan_id,
+                                   bool insert_entry);
 
 }  // namespace ovsp4rt
 

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_journal.cc
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_journal.cc
@@ -21,11 +21,15 @@ void Journal::recordInput(const char* func_name,
 
 // ip_mac_map_info
 void Journal::recordInput(const char* func_name, const ip_mac_map_info& info,
-                          bool insert_entry) {}
+                          bool insert_entry) {
+  input_ = EncodeIpMacMapInfo(func_name, info, insert_entry);
+}
 
 // tunnel_info
 void Journal::recordInput(const char* func_name, const tunnel_info& info,
-                          bool insert_entry) {}
+                          bool insert_entry) {
+  input_ = EncodeTunnelInfo(func_name, info, insert_entry);
+}
 
 // src_port_info
 void Journal::recordInput(const char* func_name, const src_port_info info,
@@ -35,7 +39,9 @@ void Journal::recordInput(const char* func_name, const src_port_info info,
 
 // vlan_id
 void Journal::recordInput(const char* func_name, uint16_t vlan_id,
-                          bool insert_entry) {}
+                          bool insert_entry) {
+  input_ = EncodeVlanId(func_name, vlan_id, insert_entry);
+}
 
 // ::p4::v1::WriteRequest
 void recordOutput(const char* func, ::p4::v1::WriteRequest& request) {}

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_journal.h
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_journal.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include <nlohmann/json.hpp>
+#include <vector>
 
 #include "ovsp4rt/ovs-p4rt.h"
 #include "p4/v1/p4runtime.pb.h"
@@ -17,6 +18,8 @@ namespace ovsp4rt {
 // Captures the inputs and outputs to an API function.
 class Journal {
  public:
+  ~Journal() { saveEntry(); }
+
   void recordInput(const char* func_name, const struct mac_learning_info& info,
                    bool insert_entry);
 
@@ -37,7 +40,7 @@ class Journal {
 
  private:
   nlohmann::json input_;
-  nlohmann::json output_;
+  std::vector<nlohmann::json> output_;
 };
 
 }  // namespace ovsp4rt


### PR DESCRIPTION
- Implemented JSON encoders for the ip_mac_map_info, tunnel_info, and vlan_id inputs.

These changes were extracted from PRs https://github.com/ipdk-io/networking-recipe/pull/573 and https://github.com/ipdk-io/networking-recipe/pull/534, which this PR replaces.

These changes are benign as far as the rest of ovsp4rt is concerned. They are disabled by default.

The encoders are part of a background effort to make ovsp4rt more testable.