### PR TITLE
Update CMakePresets.json file

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,9 +14,10 @@
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": true,
                 "CMAKE_INSTALL_PREFIX": {
                     "type": "PATH",
-                    "value": "install"
+                    "value": "${sourceDir}/install"
                 },
                 "SET_RPATH": true
             }


### PR DESCRIPTION
- Enabled CMAKE_EXPORT_COMPILE_COMMANDS. This option instructs CMake to generate a `compile_commands.json` file in the build directory, for use by other tools (such as `clang-tidy`)

- Expanded CMAKE_INSTALL_PREFIX to an absolute path, which is what happens when you set `CMAKE_INSTALL_PREFIX` on the CMake command line.