### PR TITLE
Define list of values for P4OVS_MODE variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,9 @@ endif()
 # OVS build mode #
 ##################
 
+set_property(CACHE P4OVS_MODE PROPERTY STRINGS
+    "NONE;P4OVS;OVSP4RT;STUBS")
+
 set(P4OVS_MODE "p4ovs" CACHE STRING "P4OVS build mode")
 string(TOLOWER "${P4OVS_MODE}" P4OVS_MODE)
 


### PR DESCRIPTION
- Set the STRINGS property on the P4OVS_MODE variable to a list of supported values. The user may choose from this list in `ccmake` or the cmake GUI.