### PR TITLE
Fix problem setting property on P4OVS_MODE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,11 +85,11 @@ endif()
 # OVS build mode #
 ##################
 
-set_property(CACHE P4OVS_MODE PROPERTY STRINGS
-    "NONE;P4OVS;OVSP4RT;STUBS")
-
 set(P4OVS_MODE "p4ovs" CACHE STRING "P4OVS build mode")
 string(TOLOWER "${P4OVS_MODE}" P4OVS_MODE)
+
+set_property(CACHE P4OVS_MODE PROPERTY STRINGS
+    "NONE;P4OVS;OVSP4RT;STUBS")
 
 if(NOT WITH_OVSP4RT OR P4OVS_MODE STREQUAL "none")
     unset(WITH_OVSP4RT)


### PR DESCRIPTION
- Moved the set_property() for the STRINGS property on P4OVS_MODE after its definition. This fixes a CMake configuration error that cropped up in the Tofino build.