### PR TITLE
[ovsp4rt] Remove session() method from Client class

### DIFF
--- a/ovs-p4rt/sidecar/client/ovsp4rt_client.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_client.h
@@ -24,9 +24,6 @@ class Client : public ClientInterface {
   // Connects to the P4Runtime server.
   virtual absl::Status connect(const char* grpc_addr);
 
-  // Returns a pointer to the ovsp4rt session object.
-  virtual OvsP4rtSession* session() const { return session_.get(); }
-
   // Gets the pipeline configuration from the P4Runtime server.
   virtual absl::Status getPipelineConfig(::p4::config::v1::P4Info* p4info);
 

--- a/ovs-p4rt/sidecar/client/ovsp4rt_client_interface.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_client_interface.h
@@ -7,7 +7,6 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "p4/v1/p4runtime.pb.h"
-#include "session/ovsp4rt_session.h"
 
 namespace ovsp4rt {
 
@@ -17,9 +16,6 @@ class ClientInterface {
 
   // Connects to the P4Runtime server.
   virtual absl::Status connect(const char* grpc_addr) = 0;
-
-  // Returns a pointer to the ovsp4rt session object.
-  virtual OvsP4rtSession* session() const = 0;
 
   // Gets the pipeline configuration from the P4Runtime server.
   virtual absl::Status getPipelineConfig(::p4::config::v1::P4Info* p4info) = 0;

--- a/ovs-p4rt/sidecar/client/ovsp4rt_client_mock.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_client_mock.h
@@ -13,8 +13,6 @@ class ClientMock : public ClientInterface {
  public:
   MOCK_METHOD(absl::Status, connect, (const char*));
 
-  MOCK_METHOD(OvsP4rtSession*, session, (), (const));
-
   MOCK_METHOD(absl::Status, getPipelineConfig, (::p4::config::v1::P4Info*));
 
   MOCK_METHOD(::p4::v1::TableEntry*, initReadRequest, (::p4::v1::ReadRequest*));


### PR DESCRIPTION
The purpose of the `Client` class is to replace the discrete logic that interacts with the P4Runtime server with an object that implements an abstract interface. It should not expose the session object to the user.