### PR TITLE
[ovsp4rt] Implement journaling client

### DIFF
--- a/ovs-p4rt/sidecar/client/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/client/CMakeLists.txt
@@ -13,7 +13,16 @@ add_library(ovsp4rt_client_o OBJECT
   ovsp4rt_client_interface.h
 )
 
+if(BUILD_JOURNAL)
+  # The journaling client is a subclass of the standard client.
+  target_sources(ovsp4rt_client_o PRIVATE
+    ovsp4rt_journal_client.cc
+    ovsp4rt_journal_client.h
+  )
+endif()
+
 target_include_directories(ovsp4rt_client_o PUBLIC
+  ${OVSP4RT_INCLUDE_DIR}
   ${SIDECAR_SOURCE_DIR}
   ${STRATUM_SOURCE_DIR}
 )

--- a/ovs-p4rt/sidecar/client/ovsp4rt_journal_client.cc
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_journal_client.cc
@@ -5,26 +5,22 @@
 
 namespace ovsp4rt {
 
+// TODO(derek): func_name parameter?
 absl::StatusOr<::p4::v1::ReadResponse> JournalClient::sendReadRequest(
     const p4::v1::ReadRequest& request) {
-#if 0
-  _journal.recordReadRequest(request);
+  journal_.recordReadRequest(request);
   auto response = Client::sendReadRequest(request);
-  _journal.recordReadResponse(response);
-#else
-  return Client::sendReadRequest(request);
-#endif
+  journal_.recordReadResponse(response);
+  return response;
 }
 
+// TODO(derek): func_name parameter?
 absl::Status JournalClient::sendWriteRequest(
     const p4::v1::WriteRequest& request) {
-#if 0
-  _journal.recordWriteRequest(request);
-  auto response = Client::sendWriteRequest(request);
-  _journal.recordWriteResponse(response);
-#else
-  return Client::sendWriteRequest(request);
-#endif
+  journal_.recordWriteRequest(request);
+  auto status = Client::sendWriteRequest(request);
+  journal_.recordWriteStatus(status);
+  return status;
 }
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/client/ovsp4rt_journal_client.cc
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_journal_client.cc
@@ -1,0 +1,30 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ovsp4rt_journal_client.h"
+
+namespace ovsp4rt {
+
+absl::StatusOr<::p4::v1::ReadResponse> JournalClient::sendReadRequest(
+    const p4::v1::ReadRequest& request) {
+#if 0
+  _journal.recordReadRequest(request);
+  auto response = Client::sendReadRequest(request);
+  _journal.recordReadResponse(response);
+#else
+  return Client::sendReadRequest(request);
+#endif
+}
+
+absl::Status JournalClient::sendWriteRequest(
+    const p4::v1::WriteRequest& request) {
+#if 0
+  _journal.recordWriteRequest(request);
+  auto response = Client::sendWriteRequest(request);
+  _journal.recordWriteResponse(response);
+#else
+  return Client::sendWriteRequest(request);
+#endif
+}
+
+}  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/client/ovsp4rt_journal_client.h
+++ b/ovs-p4rt/sidecar/client/ovsp4rt_journal_client.h
@@ -1,0 +1,37 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OVSP4RT_JOURNAL_CLIENT_H_
+#define OVSP4RT_JOURNAL_CLIENT_H_
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "client/ovsp4rt_client.h"
+#include "journal/ovsp4rt_journal.h"
+#include "p4/v1/p4runtime.pb.h"
+
+namespace ovsp4rt {
+
+class JournalClient : public Client {
+ public:
+  JournalClient() {}
+  virtual ~JournalClient() = default;
+
+  // Sends a Read Table Entry request to the P4Runtime server.
+  absl::StatusOr<p4::v1::ReadResponse> sendReadRequest(
+      const p4::v1::ReadRequest& request) override;
+
+  // Sends a Write Table Entry request to the P4Runtime server.
+  absl::Status sendWriteRequest(const p4::v1::WriteRequest& request) override;
+
+  // Returns a reference to the Journal object.
+  Journal& journal() { return journal_; }
+
+ private:
+  // Journal object.
+  Journal journal_;
+};
+
+}  // namespace ovsp4rt
+
+#endif  // OVSP4RT_JOURNAL_CLIENT_H_

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_journal.cc
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_journal.cc
@@ -38,7 +38,21 @@ void Journal::recordInput(const char* func_name, uint16_t vlan_id,
   input_ = EncodeVlanId(func_name, vlan_id, insert_entry);
 }
 
-// ::p4::v1::WriteRequest
-void recordOutput(const char* func, ::p4::v1::WriteRequest& request) {}
+void Journal::recordReadRequest(const ::p4::v1::ReadRequest& request) {
+  // TODO(derek): to be implemented. Add func_name parameter?
+}
+
+void Journal::recordReadResponse(
+    const absl::StatusOr<::p4::v1::ReadResponse>& response) {
+  // TODO(derek): to be implemented. Add func_name parameter?
+}
+
+void Journal::recordWriteRequest(const ::p4::v1::WriteRequest& request) {
+  // TODO(derek): to be implemented. Add func_name parameter?
+}
+
+void Journal::recordWriteStatus(const absl::Status& status) {
+  // TODO(derek): to be implemented. Add func_name parameter?
+}
 
 }  // namespace ovsp4rt

--- a/ovs-p4rt/sidecar/journal/ovsp4rt_journal.h
+++ b/ovs-p4rt/sidecar/journal/ovsp4rt_journal.h
@@ -15,7 +15,7 @@
 
 namespace ovsp4rt {
 
-// Captures the inputs and outputs to an API function.
+// Records the inputs and outputs of an API function.
 class Journal {
  public:
   ~Journal() { saveEntry(); }
@@ -34,7 +34,14 @@ class Journal {
 
   void recordInput(const char* func_name, uint16_t vlan_id, bool insert_entry);
 
-  void recordOutput(const char* func, ::p4::v1::WriteRequest& request) {}
+  void recordReadRequest(const ::p4::v1::ReadRequest& request);
+
+  void recordReadResponse(
+      const absl::StatusOr<::p4::v1::ReadResponse>& response);
+
+  void recordWriteRequest(const ::p4::v1::WriteRequest& request);
+
+  void recordWriteStatus(const absl::Status& status);
 
   void saveEntry() {}
 


### PR DESCRIPTION
- Created `JournalClient`, a subclass of `Client` that is instrumented to record interactions between OVS and the P4Runtime server.

> [!NOTE]
> Extracted from PR #674. Currently excluded from the build.