### PR TITLE
[ovsp4rt] Separate C API functions from rest of code

### DIFF
--- a/ovs-p4rt/sidecar/ovsp4rt_internal_api.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_internal_api.h
@@ -1,0 +1,48 @@
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Defines the interface to the C++ functions that implement
+// the ovsp4rt C API.
+
+#ifndef OVSP4RT_INTERNAL_API_H_
+#define OVSP4RT_INTERNAL_API_H_
+
+#include "client/ovsp4rt_client_interface.h"
+#include "ovsp4rt/ovs-p4rt.h"
+
+namespace ovsp4rt {
+
+extern void ConfigFdbEntry(ClientInterface& client,
+                           const struct mac_learning_info& learn_info,
+                           bool insert_entry, const char* grpc_addr);
+
+extern void ConfigTunnelEntry(ClientInterface& client,
+                              const struct tunnel_info& tunnel_info,
+                              bool insert_entry, const char* grpc_addr);
+
+#if defined(ES2K_TARGET)
+
+extern void ConfigIpMacMapEntry(ClientInterface& client,
+                                const struct ip_mac_map_info& ip_info,
+                                bool insert_entry, const char* grpc_addr);
+
+extern void ConfigRxTunnelSrcEntry(ClientInterface& client,
+                                   const struct tunnel_info& tunnel_info,
+                                   bool insert_entry, const char* grpc_addr);
+
+extern void ConfigSrcPortEntry(ClientInterface& client,
+                               struct src_port_info vsi_sp, bool insert_entry,
+                               const char* grpc_addr);
+
+extern void ConfigTunnelSrcPortEntry(ClientInterface& client,
+                                     const struct src_port_info& tnl_sp,
+                                     bool insert_entry, const char* grpc_addr);
+
+extern void ConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
+                            bool insert_entry, const char* grpc_addr);
+
+#endif  // ES2K_TARGET
+
+}  // namespace ovsp4rt
+
+#endif  // OVSP4RT_INTERNAL_API_H_

--- a/ovs-p4rt/sidecar/ovsp4rt_standard_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_standard_api.cc
@@ -1,0 +1,138 @@
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Standard implementation of the ovsp4rt C API.
+
+#include "client/ovsp4rt_client.h"
+#include "ovsp4rt/ovs-p4rt.h"
+#include "ovsp4rt_internal_api.h"
+
+//----------------------------------------------------------------------
+// ovsp4rt_config_fdb_entry (DPDK, ES2K)
+//----------------------------------------------------------------------
+void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
+                              bool insert_entry, const char* grpc_addr) {
+  using namespace ovsp4rt;
+
+  Client client;
+
+  ConfigFdbEntry(client, learn_info, insert_entry, grpc_addr);
+}
+
+//----------------------------------------------------------------------
+// ovsp4rt_config_tunnel_entry (DPDK, ES2K)
+//----------------------------------------------------------------------
+void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
+                                 bool insert_entry, const char* grpc_addr) {
+  using namespace ovsp4rt;
+
+  Client client;
+
+  ConfigTunnelEntry(client, tunnel_info, insert_entry, grpc_addr);
+}
+
+//----------------------------------------------------------------------
+// ovsp4rt_str_to_tunnel_type (DPDK, ES2K)
+//
+// It is unclear whether this function belongs here or in a separate
+// file.
+//----------------------------------------------------------------------
+enum ovs_tunnel_type ovsp4rt_str_to_tunnel_type(const char* tnl_type) {
+  if (tnl_type) {
+    if (strcmp(tnl_type, "vxlan") == 0) {
+      return OVS_TUNNEL_VXLAN;
+    } else if (strcmp(tnl_type, "geneve") == 0) {
+      return OVS_TUNNEL_GENEVE;
+    }
+  }
+  return OVS_TUNNEL_UNKNOWN;
+}
+
+#if defined(DPDK_TARGET)
+
+//----------------------------------------------------------------------
+// Unimplemented functions (DPDK)
+//----------------------------------------------------------------------
+void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
+                                        bool insert_entry,
+                                        const char* grpc_addr) {}
+
+void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
+                               const char* grpc_addr) {}
+
+void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
+                                          bool insert_entry,
+                                          const char* grpc_addr) {}
+
+void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
+                                   bool insert_entry, const char* grpc_addr) {}
+
+void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
+                                     bool insert_entry, const char* grpc_addr) {
+}
+
+#elif defined(ES2K_TARGET)
+
+//----------------------------------------------------------------------
+// ovsp4rt_config_ip_mac_map_entry (ES2K)
+//----------------------------------------------------------------------
+void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
+                                     bool insert_entry, const char* grpc_addr) {
+  using namespace ovsp4rt;
+
+  Client client;
+
+  ConfigIpMacMapEntry(client, ip_info, insert_entry, grpc_addr);
+}
+
+//----------------------------------------------------------------------
+// ovsp4rt_config_rx_tunnel_src_entry (ES2K)
+//----------------------------------------------------------------------
+void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
+                                        bool insert_entry,
+                                        const char* grpc_addr) {
+  using namespace ovsp4rt;
+
+  Client client;
+
+  ConfigRxTunnelSrcEntry(client, tunnel_info, insert_entry, grpc_addr);
+}
+
+//----------------------------------------------------------------------
+// ovsp4rt_config_src_port_entry (ES2K)
+//----------------------------------------------------------------------
+void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
+                                   bool insert_entry, const char* grpc_addr) {
+  using namespace ovsp4rt;
+
+  Client client;
+
+  ConfigSrcPortEntry(client, vsi_sp, insert_entry, grpc_addr);
+}
+
+//----------------------------------------------------------------------
+// ovsp4rt_config_tunnel_src_port_entry (ES2K)
+//----------------------------------------------------------------------
+void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
+                                          bool insert_entry,
+                                          const char* grpc_addr) {
+  using namespace ovsp4rt;
+
+  Client client;
+
+  ConfigTunnelSrcPortEntry(client, tnl_sp, insert_entry, grpc_addr);
+}
+
+//----------------------------------------------------------------------
+// ovsp4rt_config_vlan_entry (ES2K)
+//----------------------------------------------------------------------
+void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
+                               const char* grpc_addr) {
+  using namespace ovsp4rt;
+
+  Client client;
+
+  ConfigVlanEntry(client, vlan_id, insert_entry, grpc_addr);
+}
+
+#endif  // ES2K_TARGET


### PR DESCRIPTION
- Moved the C API wrapper functions to a separate source file. This makes it possible to substitute a different implementation of the API, for testing.

Extracted from PR #674. Works with an updated version of ovsp4rt.cc that has not been committed. Currently excluded from the build.