### PR TITLE
Pin workflow scripts to Ubuntu-22.04

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -24,7 +24,7 @@ jobs:
   # 1-markdownlint
   #---------------------------------------------------------------------
   markdownlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:
@@ -51,7 +51,7 @@ jobs:
   # 2-rstdoc8
   #---------------------------------------------------------------------
   rstdoc8:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:
@@ -80,7 +80,7 @@ jobs:
   # 3-rstcheck
   #---------------------------------------------------------------------
   rstcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:
@@ -110,7 +110,7 @@ jobs:
   #---------------------------------------------------------------------
   py_bandit_check:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone networking-recipe
         uses: actions/checkout@v4
@@ -127,7 +127,7 @@ jobs:
   # 5-clang_format_check
   #---------------------------------------------------------------------
   clang_format_check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:
@@ -154,7 +154,7 @@ jobs:
   # 6-shellcheck
   #---------------------------------------------------------------------
   shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,7 +40,7 @@ jobs:
   # dpdk_build_and_test
   #---------------------------------------------------------------------
   dpdk_build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
 
     steps:
@@ -90,7 +90,7 @@ jobs:
   # build_p4runtime_protos
   #---------------------------------------------------------------------
   build_p4runtime_protos:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
- Changed `ubuntu-latest` to `ubuntu-22.04` in the workflows, in preparation for GitHub bumping ubuntu-latest to 24.04.

This change is in response to the following warning from GitHub Actions:
```text
ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636
```