### PR TITLE
[ovsp4rt] Implement Client class (DRAFT)

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache 2.0
 #
 
-option(BUILD_CLIENT  "Build ovs-p4rt with Client class" OFF)
-option(BUILD_JOURNAL "Build ovs-p4rt with Journal class" OFF)
+option(BUILD_CLIENT  "Build ovs-p4rt with Client class" ON)
+option(BUILD_JOURNAL "Build ovs-p4rt with Journal class" ON)
 option(BUILD_SPIES   "Build ovs-p4rt spies library" OFF)
 
 mark_as_advanced(BUILD_CLIENT)

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -2483,7 +2483,7 @@ void ConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
 // ConfigFdbEntry (DPDK)
 //----------------------------------------------------------------------
 void ConfigFdbEntry(ClientInterface& client,
-                    const struct mac_learning_info& learn_info,
+                    struct mac_learning_info learn_info,
                     bool insert_entry, const char* grpc_addr) {
   absl::Status status;
 

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -2483,8 +2483,8 @@ void ConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
 // ConfigFdbEntry (DPDK)
 //----------------------------------------------------------------------
 void ConfigFdbEntry(ClientInterface& client,
-                    struct mac_learning_info learn_info,
-                    bool insert_entry, const char* grpc_addr) {
+                    struct mac_learning_info learn_info, bool insert_entry,
+                    const char* grpc_addr) {
   absl::Status status;
 
   // Start a new client session.

--- a/ovs-p4rt/sidecar/ovsp4rt.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt.cc
@@ -2231,7 +2231,7 @@ void ConfigFdbEntry(ClientInterface& client,
    */
   if (!insert_entry) {
     auto status_or_read_response =
-        GetL2ToTunnelV4TableEntry(session.get(), learn_info, p4info);
+        GetL2ToTunnelV4TableEntry(client, learn_info, p4info);
     if (status_or_read_response.ok()) {
       learn_info.is_tunnel = true;
     }
@@ -2241,7 +2241,7 @@ void ConfigFdbEntry(ClientInterface& client,
      */
     if (!learn_info.is_tunnel) {
       status_or_read_response =
-          GetL2ToTunnelV6TableEntry(session.get(), learn_info, p4info);
+          GetL2ToTunnelV6TableEntry(client, learn_info, p4info);
       if (status_or_read_response.ok()) {
         learn_info.is_tunnel = true;
         learn_info.tnl_info.local_ip.family = AF_INET6;
@@ -2253,7 +2253,7 @@ void ConfigFdbEntry(ClientInterface& client,
   if (learn_info.is_tunnel) {
     if (insert_entry) {
       auto status_or_read_response =
-          GetFdbTunnelTableEntry(session.get(), learn_info, p4info, true);
+          GetFdbTunnelTableEntry(client, learn_info, p4info, true);
       if (status_or_read_response.ok()) {
         // Return if entry already exists.
         return;
@@ -2278,7 +2278,7 @@ void ConfigFdbEntry(ClientInterface& client,
   } else {
     if (insert_entry) {
       auto status_or_read_response =
-          GetFdbVlanTableEntry(session.get(), learn_info, p4info, true);
+          GetFdbVlanTableEntry(client, learn_info, p4info, true);
       if (status_or_read_response.ok()) {
         // Return if entry already exists.
         return;
@@ -2562,8 +2562,7 @@ void ConfigIpMacMapEntry(ClientInterface& client,
   if (!status.ok()) return;
 
   if (insert_entry) {
-    auto status_or_read_response =
-        GetVmSrcTableEntry(session.get(), ip_info, p4info);
+    auto status_or_read_response = GetVmSrcTableEntry(client, ip_info, p4info);
     if (status_or_read_response.ok()) {
       goto try_dstip;
     }
@@ -2578,8 +2577,7 @@ void ConfigIpMacMapEntry(ClientInterface& client,
 
 try_dstip:
   if (insert_entry) {
-    auto status_or_read_response =
-        GetVmDstTableEntry(session.get(), ip_info, p4info);
+    auto status_or_read_response = GetVmDstTableEntry(client, ip_info, p4info);
     if (status_or_read_response.ok()) {
       return;
     }

--- a/ovs-p4rt/sidecar/ovsp4rt_internal_api.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_internal_api.h
@@ -13,7 +13,7 @@
 namespace ovsp4rt {
 
 extern void ConfigFdbEntry(ClientInterface& client,
-                           const struct mac_learning_info& learn_info,
+                           struct mac_learning_info learn_info,
                            bool insert_entry, const char* grpc_addr);
 
 extern void ConfigTunnelEntry(ClientInterface& client,

--- a/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
@@ -83,7 +83,7 @@ void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
   using namespace ovsp4rt;
 
   JournalClient client;
-  client.journal().recordInput(_func__, ip_info, insert_entry);
+  client.journal().recordInput(__func__, ip_info, insert_entry);
 
   ConfigIpMacMapEntry(client, ip_info, insert_entry, grpc_addr);
 }
@@ -137,7 +137,7 @@ void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
   using namespace ovsp4rt;
 
   JournalClient client;
-  client.journal().recordInput(__func__, tnl_sp, insert_entry);
+  client.journal().recordInput(__func__, vlan_id, insert_entry);
 
   ConfigVlanEntry(client, vlan_id, insert_entry, grpc_addr);
 }


### PR DESCRIPTION
**Superseded by PR #732**

This is a project to improve the testability of ovsp4rt. See issue https://github.com/ipdk-io/networking-recipe/issues/701 for details.

- Modified ovsp4rt.cc to use a `Client` object instead of an `OvsP4rtSession` object to communicate with the P4Runtime server.

- Made each public C API function a wrapper around a C++ function that accepts a `Client` object as a parameter. This allows a test to replace the object with a test double (e.g. a mock).

- Moved the C API functions to another file (`ovsp4rt_standard_api.cc` or `ovsp4rt_journal_api.cc`), separating the user interface from the implementation.

> [!NOTE]
> - The `BUILD_CLIENT` cmake option is enabled by default in this branch. CI can't compile the modified version of `ovsp4rt.cc` without it.
> - The `BUILD_JOURNAL` cmake option is also enabled by default, so the CI workflow compiles that as well.
>
> This PR supersedes PR https://github.com/ipdk-io/networking-recipe/pull/674.