### PR TITLE
[ovsp4rt] Implement HaveEntry predicates (DRAFT)

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache 2.0
 #
 
-option(BUILD_CLIENT  "Build ovs-p4rt with Client class" OFF)
-option(BUILD_JOURNAL "Build ovs-p4rt with Journal class" OFF)
+option(BUILD_CLIENT  "Build ovs-p4rt with Client class" ON)
+option(BUILD_JOURNAL "Build ovs-p4rt with Journal class" ON)
 option(BUILD_SPIES   "Build ovs-p4rt spies library" OFF)
 
 mark_as_advanced(BUILD_CLIENT)

--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache 2.0
 #
 
-option(BUILD_CLIENT  "Build ovs-p4rt with Client class" ON)
-option(BUILD_JOURNAL "Build ovs-p4rt with Journal class" ON)
+option(BUILD_CLIENT  "Build ovs-p4rt with Client class" OFF)
+option(BUILD_JOURNAL "Build ovs-p4rt with Journal class" OFF)
 option(BUILD_SPIES   "Build ovs-p4rt spies library" OFF)
 
 mark_as_advanced(BUILD_CLIENT)


### PR DESCRIPTION
- Implemented `HaveEntry` predicates as wrappers around the `GetEntry`
  functions. Modified the code to use the predicates when the purpose
  of the read request is to test for the existence of an entry.

  This change is ES2K-specific.

Extracted from PR #674 and based on PR #727. See https://github.com/ipdk-io/networking-recipe/pull/728/commits/175a9f461de27617522469c7286bb405f0763fdc to view the incremental changes.