### PR TITLE
[ovsp4rt] Rename internal API functions

### DIFF
--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -1,6 +1,19 @@
 // Copyright 2022-2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+// Revision of ovsp4rt.cc to improve testability.
+// *** UNDER CONSTRUCTION ***
+//
+// - Replaced the OvsP4rtSession object with a Client object,
+//   which provides an abstract interface to the P4Runtime
+//   server.
+//
+// - Split each ovsp4rt API into an internal C++ function
+//   that implements the core logic of the API, and a
+//   C wrapper function.
+//
+// - Moved the C wrapper functions to a separate file.
+
 #include <arpa/inet.h>
 
 #include <string>

--- a/ovs-p4rt/sidecar/newovsp4rt.cc
+++ b/ovs-p4rt/sidecar/newovsp4rt.cc
@@ -2205,14 +2205,14 @@ absl::Status ConfigSrcIpMacMapTableEntry(ClientInterface& client,
 //----------------------------------------------------------------------
 
 //----------------------------------------------------------------------
-// ConfigFdbEntry (ES2K)
+// DoConfigFdbEntry (ES2K)
 //
 // learn_info is passed by value because this function may make local
 // modifications to it.
 //----------------------------------------------------------------------
-void ConfigFdbEntry(ClientInterface& client,
-                    struct mac_learning_info learn_info, bool insert_entry,
-                    const char* grpc_addr) {
+void DoConfigFdbEntry(ClientInterface& client,
+                      struct mac_learning_info learn_info, bool insert_entry,
+                      const char* grpc_addr) {
   absl::Status status;
 
   // Start a new client session.
@@ -2345,11 +2345,11 @@ void ConfigFdbEntry(ClientInterface& client,
 }
 
 //----------------------------------------------------------------------
-// ConfigRxTunnelSrcEntry (ES2K)
+// DoConfigRxTunnelSrcEntry (ES2K)
 //----------------------------------------------------------------------
-void ConfigRxTunnelSrcEntry(ClientInterface& client,
-                            const struct tunnel_info& tunnel_info,
-                            bool insert_entry, const char* grpc_addr) {
+void DoConfigRxTunnelSrcEntry(ClientInterface& client,
+                              const struct tunnel_info& tunnel_info,
+                              bool insert_entry, const char* grpc_addr) {
   absl::Status status;
 
   // Start a new client session.
@@ -2367,11 +2367,11 @@ void ConfigRxTunnelSrcEntry(ClientInterface& client,
 }
 
 //----------------------------------------------------------------------
-// ConfigTunnelSrcPortEntry (ES2K)
+// DoConfigTunnelSrcPortEntry (ES2K)
 //----------------------------------------------------------------------
-void ConfigTunnelSrcPortEntry(ClientInterface& client,
-                              const struct src_port_info& tnl_sp,
-                              bool insert_entry, const char* grpc_addr) {
+void DoConfigTunnelSrcPortEntry(ClientInterface& client,
+                                const struct src_port_info& tnl_sp,
+                                bool insert_entry, const char* grpc_addr) {
   absl::Status status;
 
   // Start a new client session.
@@ -2395,13 +2395,13 @@ void ConfigTunnelSrcPortEntry(ClientInterface& client,
 }
 
 //----------------------------------------------------------------------
-// ConfigSrcPortEntry (ES2K)
+// DoConfigSrcPortEntry (ES2K)
 //
 // vsi_sp is passed by value because this function makes local
 // modifications to it.
 //----------------------------------------------------------------------
-void ConfigSrcPortEntry(ClientInterface& client, struct src_port_info vsi_sp,
-                        bool insert_entry, const char* grpc_addr) {
+void DoConfigSrcPortEntry(ClientInterface& client, struct src_port_info vsi_sp,
+                          bool insert_entry, const char* grpc_addr) {
   absl::Status status;
 
   // Start a new client session.
@@ -2455,10 +2455,10 @@ void ConfigSrcPortEntry(ClientInterface& client, struct src_port_info vsi_sp,
 }
 
 //----------------------------------------------------------------------
-// ConfigVlanEntry (ES2K)
+// DoConfigVlanEntry (ES2K)
 //----------------------------------------------------------------------
-void ConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
-                     bool insert_entry, const char* grpc_addr) {
+void DoConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
+                       bool insert_entry, const char* grpc_addr) {
   absl::Status status;
 
   // Start a new client session.
@@ -2480,11 +2480,11 @@ void ConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
 #elif defined(DPDK_TARGET)
 
 //----------------------------------------------------------------------
-// ConfigFdbEntry (DPDK)
+// DoConfigFdbEntry (DPDK)
 //----------------------------------------------------------------------
-void ConfigFdbEntry(ClientInterface& client,
-                    struct mac_learning_info learn_info, bool insert_entry,
-                    const char* grpc_addr) {
+void DoConfigFdbEntry(ClientInterface& client,
+                      struct mac_learning_info learn_info, bool insert_entry,
+                      const char* grpc_addr) {
   absl::Status status;
 
   // Start a new client session.
@@ -2513,11 +2513,11 @@ void ConfigFdbEntry(ClientInterface& client,
 #endif  // DPDK_TARGET
 
 //----------------------------------------------------------------------
-// ConfigTunnelEntry (common)
+// DoConfigTunnelEntry (common)
 //----------------------------------------------------------------------
-void ConfigTunnelEntry(ClientInterface& client,
-                       const struct tunnel_info& tunnel_info, bool insert_entry,
-                       const char* grpc_addr) {
+void DoConfigTunnelEntry(ClientInterface& client,
+                         const struct tunnel_info& tunnel_info,
+                         bool insert_entry, const char* grpc_addr) {
   absl::Status status;
 
   // Start a new client session.
@@ -2545,11 +2545,11 @@ void ConfigTunnelEntry(ClientInterface& client,
 #if defined(ES2K_TARGET)
 
 //----------------------------------------------------------------------
-// ConfigIpMacMapEntry (ES2K)
+// DoConfigIpMacMapEntry (ES2K)
 //----------------------------------------------------------------------
-void ConfigIpMacMapEntry(ClientInterface& client,
-                         const struct ip_mac_map_info& ip_info,
-                         bool insert_entry, const char* grpc_addr) {
+void DoConfigIpMacMapEntry(ClientInterface& client,
+                           const struct ip_mac_map_info& ip_info,
+                           bool insert_entry, const char* grpc_addr) {
   absl::Status status;
 
   // Start a new client session.

--- a/ovs-p4rt/sidecar/ovsp4rt_internal_api.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_internal_api.h
@@ -12,34 +12,35 @@
 
 namespace ovsp4rt {
 
-extern void ConfigFdbEntry(ClientInterface& client,
-                           struct mac_learning_info learn_info,
-                           bool insert_entry, const char* grpc_addr);
+extern void DoConfigFdbEntry(ClientInterface& client,
+                             struct mac_learning_info learn_info,
+                             bool insert_entry, const char* grpc_addr);
 
-extern void ConfigTunnelEntry(ClientInterface& client,
-                              const struct tunnel_info& tunnel_info,
-                              bool insert_entry, const char* grpc_addr);
+extern void DoConfigTunnelEntry(ClientInterface& client,
+                                const struct tunnel_info& tunnel_info,
+                                bool insert_entry, const char* grpc_addr);
 
 #if defined(ES2K_TARGET)
 
-extern void ConfigIpMacMapEntry(ClientInterface& client,
-                                const struct ip_mac_map_info& ip_info,
-                                bool insert_entry, const char* grpc_addr);
+extern void DoConfigIpMacMapEntry(ClientInterface& client,
+                                  const struct ip_mac_map_info& ip_info,
+                                  bool insert_entry, const char* grpc_addr);
 
-extern void ConfigRxTunnelSrcEntry(ClientInterface& client,
-                                   const struct tunnel_info& tunnel_info,
-                                   bool insert_entry, const char* grpc_addr);
-
-extern void ConfigSrcPortEntry(ClientInterface& client,
-                               struct src_port_info vsi_sp, bool insert_entry,
-                               const char* grpc_addr);
-
-extern void ConfigTunnelSrcPortEntry(ClientInterface& client,
-                                     const struct src_port_info& tnl_sp,
+extern void DoConfigRxTunnelSrcEntry(ClientInterface& client,
+                                     const struct tunnel_info& tunnel_info,
                                      bool insert_entry, const char* grpc_addr);
 
-extern void ConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
-                            bool insert_entry, const char* grpc_addr);
+extern void DoConfigSrcPortEntry(ClientInterface& client,
+                                 struct src_port_info vsi_sp, bool insert_entry,
+                                 const char* grpc_addr);
+
+extern void DoConfigTunnelSrcPortEntry(ClientInterface& client,
+                                       const struct src_port_info& tnl_sp,
+                                       bool insert_entry,
+                                       const char* grpc_addr);
+
+extern void DoConfigVlanEntry(ClientInterface& client, uint16_t vlan_id,
+                              bool insert_entry, const char* grpc_addr);
 
 #endif  // ES2K_TARGET
 

--- a/ovs-p4rt/sidecar/ovsp4rt_internal_api.h
+++ b/ovs-p4rt/sidecar/ovsp4rt_internal_api.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Defines the interface to the C++ functions that implement
-// the ovsp4rt C API.
+// the core logic of the ovsp4rt C API.
 
 #ifndef OVSP4RT_INTERNAL_API_H_
 #define OVSP4RT_INTERNAL_API_H_

--- a/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Journaling implementation of the ovsp4rt C API.
+// *** UNDER CONSTRUCTION ***
 
 #include "client/ovsp4rt_journal_client.h"
 #include "ovsp4rt/ovs-p4rt.h"

--- a/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
@@ -17,7 +17,7 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
   JournalClient client;
   client.journal().recordInput(__func__, learn_info, insert_entry);
 
-  ConfigFdbEntry(client, learn_info, insert_entry, grpc_addr);
+  DoConfigFdbEntry(client, learn_info, insert_entry, grpc_addr);
 }
 
 //----------------------------------------------------------------------
@@ -30,7 +30,7 @@ void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
   JournalClient client;
   client.journal().recordInput(__func__, tunnel_info, insert_entry);
 
-  ConfigTunnelEntry(client, tunnel_info, insert_entry, grpc_addr);
+  DoConfigTunnelEntry(client, tunnel_info, insert_entry, grpc_addr);
 }
 
 //----------------------------------------------------------------------
@@ -85,7 +85,7 @@ void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
   JournalClient client;
   client.journal().recordInput(__func__, ip_info, insert_entry);
 
-  ConfigIpMacMapEntry(client, ip_info, insert_entry, grpc_addr);
+  DoConfigIpMacMapEntry(client, ip_info, insert_entry, grpc_addr);
 }
 
 //----------------------------------------------------------------------
@@ -99,7 +99,7 @@ void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
   JournalClient client;
   client.journal().recordInput(__func__, tunnel_info, insert_entry);
 
-  ConfigRxTunnelSrcEntry(client, tunnel_info, insert_entry, grpc_addr);
+  DoConfigRxTunnelSrcEntry(client, tunnel_info, insert_entry, grpc_addr);
 }
 
 //----------------------------------------------------------------------
@@ -112,7 +112,7 @@ void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
   JournalClient client;
   client.journal().recordInput(__func__, vsi_sp, insert_entry);
 
-  ConfigSrcPortEntry(client, vsi_sp, insert_entry, grpc_addr);
+  DoConfigSrcPortEntry(client, vsi_sp, insert_entry, grpc_addr);
 }
 
 //----------------------------------------------------------------------
@@ -126,7 +126,7 @@ void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
   JournalClient client;
   client.journal().recordInput(__func__, tnl_sp, insert_entry);
 
-  ConfigTunnelSrcPortEntry(client, tnl_sp, insert_entry, grpc_addr);
+  DoConfigTunnelSrcPortEntry(client, tnl_sp, insert_entry, grpc_addr);
 }
 
 //----------------------------------------------------------------------
@@ -139,7 +139,7 @@ void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
   JournalClient client;
   client.journal().recordInput(__func__, vlan_id, insert_entry);
 
-  ConfigVlanEntry(client, vlan_id, insert_entry, grpc_addr);
+  DoConfigVlanEntry(client, vlan_id, insert_entry, grpc_addr);
 }
 
 #endif  // ES2K_TARGET

--- a/ovs-p4rt/sidecar/ovsp4rt_standard_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_standard_api.cc
@@ -1,7 +1,8 @@
-// Copyright 2022-2024 Intel Corporation
+// Copyright 2022-2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // Standard implementation of the ovsp4rt C API.
+// *** UNDER CONSTRUCTION ***
 
 #include "client/ovsp4rt_client.h"
 #include "ovsp4rt/ovs-p4rt.h"

--- a/ovs-p4rt/sidecar/ovsp4rt_standard_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_standard_api.cc
@@ -16,7 +16,7 @@ void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
 
   Client client;
 
-  ConfigFdbEntry(client, learn_info, insert_entry, grpc_addr);
+  DoConfigFdbEntry(client, learn_info, insert_entry, grpc_addr);
 }
 
 //----------------------------------------------------------------------
@@ -28,7 +28,7 @@ void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
 
   Client client;
 
-  ConfigTunnelEntry(client, tunnel_info, insert_entry, grpc_addr);
+  DoConfigTunnelEntry(client, tunnel_info, insert_entry, grpc_addr);
 }
 
 //----------------------------------------------------------------------
@@ -82,7 +82,7 @@ void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info ip_info,
 
   Client client;
 
-  ConfigIpMacMapEntry(client, ip_info, insert_entry, grpc_addr);
+  DoConfigIpMacMapEntry(client, ip_info, insert_entry, grpc_addr);
 }
 
 //----------------------------------------------------------------------
@@ -95,7 +95,7 @@ void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
 
   Client client;
 
-  ConfigRxTunnelSrcEntry(client, tunnel_info, insert_entry, grpc_addr);
+  DoConfigRxTunnelSrcEntry(client, tunnel_info, insert_entry, grpc_addr);
 }
 
 //----------------------------------------------------------------------
@@ -107,7 +107,7 @@ void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
 
   Client client;
 
-  ConfigSrcPortEntry(client, vsi_sp, insert_entry, grpc_addr);
+  DoConfigSrcPortEntry(client, vsi_sp, insert_entry, grpc_addr);
 }
 
 //----------------------------------------------------------------------
@@ -120,7 +120,7 @@ void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
 
   Client client;
 
-  ConfigTunnelSrcPortEntry(client, tnl_sp, insert_entry, grpc_addr);
+  DoConfigTunnelSrcPortEntry(client, tnl_sp, insert_entry, grpc_addr);
 }
 
 //----------------------------------------------------------------------
@@ -132,7 +132,7 @@ void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
 
   Client client;
 
-  ConfigVlanEntry(client, vlan_id, insert_entry, grpc_addr);
+  DoConfigVlanEntry(client, vlan_id, insert_entry, grpc_addr);
 }
 
 #endif  // ES2K_TARGET


### PR DESCRIPTION
- Renamed the functions in the internal C++ API from ConfigEntry to DoConfigEntry, to keep them from being confused with ConfigTableEntry functions.

The conventions are:

- A PrepareTableEntry function populates the fields of a TableEntry.

- A ConfigTableEntry function initializes a WriteRequest, prepares the TableEntry, and sends the request to the P4Runtime server.

- A GetTableEntry function initializes a ReadRequest, prepares the TableEntry, sends the request to the P4Runtime server, and returns the response.

- A DoConfigEntry function implements the core logic of an ovsp4rt_table_entry C API. It may make one or more ConfigTableEntry or GetTableEntry calls.