### PR TITLE
[ovsp4rt] Extract ovsp4rt_str_to_tunnel_type()

### DIFF
--- a/ovs-p4rt/sidecar/CMakeLists.txt
+++ b/ovs-p4rt/sidecar/CMakeLists.txt
@@ -35,10 +35,12 @@ if(BUILD_CLIENT)
     target_sources(ovs_sidecar_o PRIVATE
       ovsp4rt_internal_api.h
       ovsp4rt_journal_api.cc
+      ovsp4rt_simple_api.cc
     )
   else()
     target_sources(ovs_sidecar_o PRIVATE
       ovsp4rt_internal_api.h
+      ovsp4rt_simple_api.cc
       ovsp4rt_standard_api.cc
     )
   endif()

--- a/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_journal_api.cc
@@ -33,23 +33,6 @@ void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
   ConfigTunnelEntry(client, tunnel_info, insert_entry, grpc_addr);
 }
 
-//----------------------------------------------------------------------
-// ovsp4rt_str_to_tunnel_type (DPDK, ES2K)
-//
-// It is unclear whether this function belongs here or in a separate
-// file.
-//----------------------------------------------------------------------
-enum ovs_tunnel_type ovsp4rt_str_to_tunnel_type(const char* tnl_type) {
-  if (tnl_type) {
-    if (strcmp(tnl_type, "vxlan") == 0) {
-      return OVS_TUNNEL_VXLAN;
-    } else if (strcmp(tnl_type, "geneve") == 0) {
-      return OVS_TUNNEL_GENEVE;
-    }
-  }
-  return OVS_TUNNEL_UNKNOWN;
-}
-
 #if defined(DPDK_TARGET)
 
 //----------------------------------------------------------------------

--- a/ovs-p4rt/sidecar/ovsp4rt_simple_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_simple_api.cc
@@ -1,0 +1,22 @@
+// Copyright 2022-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// ovsprt C API functions that do not have a C++ implementation.
+
+#include <string.h>
+
+#include "ovsp4rt/ovs-p4rt.h"
+
+//----------------------------------------------------------------------
+// ovsp4rt_str_to_tunnel_type (common)
+//----------------------------------------------------------------------
+enum ovs_tunnel_type ovsp4rt_str_to_tunnel_type(const char* tnl_type) {
+  if (tnl_type) {
+    if (strcmp(tnl_type, "vxlan") == 0) {
+      return OVS_TUNNEL_VXLAN;
+    } else if (strcmp(tnl_type, "geneve") == 0) {
+      return OVS_TUNNEL_GENEVE;
+    }
+  }
+  return OVS_TUNNEL_UNKNOWN;
+}

--- a/ovs-p4rt/sidecar/ovsp4rt_standard_api.cc
+++ b/ovs-p4rt/sidecar/ovsp4rt_standard_api.cc
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Intel Corporation
+// Copyright 2022-2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // Standard implementation of the ovsp4rt C API.
@@ -29,23 +29,6 @@ void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
   Client client;
 
   ConfigTunnelEntry(client, tunnel_info, insert_entry, grpc_addr);
-}
-
-//----------------------------------------------------------------------
-// ovsp4rt_str_to_tunnel_type (DPDK, ES2K)
-//
-// It is unclear whether this function belongs here or in a separate
-// file.
-//----------------------------------------------------------------------
-enum ovs_tunnel_type ovsp4rt_str_to_tunnel_type(const char* tnl_type) {
-  if (tnl_type) {
-    if (strcmp(tnl_type, "vxlan") == 0) {
-      return OVS_TUNNEL_VXLAN;
-    } else if (strcmp(tnl_type, "geneve") == 0) {
-      return OVS_TUNNEL_GENEVE;
-    }
-  }
-  return OVS_TUNNEL_UNKNOWN;
 }
 
 #if defined(DPDK_TARGET)


### PR DESCRIPTION
- Moved ovsp4rt_str_to_tunnel_type() to a separate source file for C api functions that are not wrappers.

This change only applies when BUILD_CLIENT is enabled.