### PR TITLE
Add missing header for va_args

### DIFF
--- a/clients/p4rt_perf_test/p4rt_perf_util.cc
+++ b/clients/p4rt_perf_test/p4rt_perf_util.cc
@@ -1,6 +1,7 @@
 // Copyright 2023-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdarg.h>
 #include "p4rt_perf_util.h"
 
 std::string EncodeByteValue(int arg_count...) {


### PR DESCRIPTION
Adding the missing header to ptf_test_util file.

This was not picked up with older dependencies/libraries once upgraded, compilation fails without this header inclusion.