### PR TITLE
Workflow build check name change

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,9 +38,9 @@ env:
 
 jobs:
 #---------------------------------------------------------------------
-# es2k_build_and_test
+# es2k_build_check
 #---------------------------------------------------------------------
-  es2k_build_and_test:
+  es2k_build_check:
     runs-on: [self-hosted, es2k-runner]
     steps:
       - name: List available runners


### PR DESCRIPTION
The workflow is to check build only and unit tests arent performed (atleast not yet). So, changing name from `es2k_build_and_test` to `es2k_build_check`